### PR TITLE
feat(onboarding): sqlite-backed host readiness catalog

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -125,7 +125,7 @@ src/crosshook-native/              # Primary source root
 **Location**: `~/.local/share/crosshook/metadata.db`
 **Mode**: WAL (write-ahead logging)
 **Permissions**: `0600` (owner read/write only)
-**Current schema version**: 13
+**Current schema version**: 21
 **Access**: `MetadataStore::try_new()` in `crosshook-core`
 **Migrations**: `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`
 
@@ -151,6 +151,9 @@ src/crosshook-native/              # Primary source root
 | `trainer_hash_cache` | v13 | SHA-256 hash per trainer per profile |
 | `offline_readiness_snapshots` | v13 | Offline readiness state snapshots |
 | `community_tap_offline_state` | v13 | Per-tap offline availability state |
+| `host_readiness_catalog` | v21 | Persisted host-tool readiness catalog (from TOML merge) |
+| `readiness_nag_dismissals` | v21 | TTL dismissals for per-tool readiness nags (global) |
+| `host_readiness_snapshots` | v21 | Last cached generalized host readiness snapshot (single row) |
 
 ### Persistence design classification
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
 
       - name: Cache Cargo registry and build artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,7 +141,7 @@ src/crosshook-native/              # Primary source root
 **Location**: `~/.local/share/crosshook/metadata.db`
 **Mode**: WAL (write-ahead logging)
 **Permissions**: `0600` (owner read/write only)
-**Current schema version**: 13
+**Current schema version**: 21
 **Access**: `MetadataStore::try_new()` in `crosshook-core`
 **Migrations**: `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`
 
@@ -167,6 +167,9 @@ src/crosshook-native/              # Primary source root
 | `trainer_hash_cache`             |     v13      | SHA-256 hash per trainer per profile                                   |
 | `offline_readiness_snapshots`    |     v13      | Offline readiness state snapshots                                      |
 | `community_tap_offline_state`    |     v13      | Per-tap offline availability state                                     |
+| `host_readiness_catalog`         |     v21      | Persisted host-tool readiness catalog (from TOML merge)                |
+| `readiness_nag_dismissals`       |     v21      | TTL dismissals for per-tool readiness nags (global)                    |
+| `host_readiness_snapshots`       |     v21      | Last cached generalized host readiness snapshot (single row)           |
 
 ### Persistence design classification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,15 @@ For storage changes, plans must also:
 - Explicitly classify each datum as TOML settings, SQLite metadata, or runtime-only state.
 - Include a persistence/usability section that addresses migration/backward compatibility, offline expectations, degraded/failure fallback, and what users can view or edit.
 
+## SQLite Metadata DB (summary)
+
+Operational metadata lives in **`~/.local/share/crosshook/metadata.db`** (WAL, `0600`). Migrations: `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`.
+
+- **Current schema version**: **21**
+- **Tables added in v21**: `host_readiness_catalog`, `readiness_nag_dismissals`, `host_readiness_snapshots`
+
+Full table inventory, persistence classification, and `external_cache_entries` payload limits: [`AGENTS.md`](AGENTS.md) § _SQLite Metadata DB_.
+
 ## Labels (use only these families)
 
 - `type:` bug, feature, docs, refactor, compatibility, build, migration

--- a/docs/prps/plans/completed/umu-migration-phase-4-auto-default.plan.md
+++ b/docs/prps/plans/completed/umu-migration-phase-4-auto-default.plan.md
@@ -434,7 +434,6 @@ Each task lists its BATCH, ACTION, IMPLEMENT sketch, MIRROR reference, GOTCHA, a
 - **BATCH**: B2
 - **ACTION**: In `src/crosshook-native/crates/crosshook-core/src/export/launcher.rs` tests module, update the 6 `exec "$PROTON" run` assertions at lines 888, 1010, 1148, 1169, 1185, 1306 to assert BOTH branches (umu success + Proton fallback) of the new probe, and add a standalone probe-shape test mirroring `network_isolation_enabled_generates_runtime_probe_and_exec`.
 - **IMPLEMENT**:
-
   1. For each of the 6 call sites, keep the existing `exec "$PROTON" run …` fallback assertion AND add a sibling umu-branch assertion using the same prefix chain. Example at line 888:
 
      ```rust

--- a/docs/prps/reviews/fixes/pr-277-fixes.md
+++ b/docs/prps/reviews/fixes/pr-277-fixes.md
@@ -1,0 +1,48 @@
+# Fix Report: pr-277-review
+
+**Source**: `docs/prps/reviews/pr-277-review.md`
+**Applied**: 2026-04-16T14:31:49-04:00
+**Mode**: Parallel (2 batches, max width 2)
+**Severity threshold**: LOW
+
+## Summary
+
+- **Total findings in source**: 4
+- **Already processed before this run**:
+  - Fixed: 1
+  - Failed: 0
+- **Eligible this run**: 3
+- **Applied this run**:
+  - Fixed: 3
+  - Failed: 0
+- **Skipped this run**:
+  - Below severity threshold: 0
+  - No suggested fix: 0
+  - Missing file: 0
+
+## Fixes Applied
+
+| ID   | Severity | File                                                       | Line | Status | Notes                                                                                                             |
+| ---- | -------- | ---------------------------------------------------------- | ---- | ------ | ----------------------------------------------------------------------------------------------------------------- |
+| F002 | MEDIUM   | src/crosshook-native/src-tauri/src/commands/onboarding.rs  | 121  | Fixed  | `dismiss_readiness_nag` now errors when the SQLite metadata store is unavailable, keeping frontend state honest.  |
+| F003 | MEDIUM   | src/crosshook-native/src/components/ReadinessChecklist.tsx | 193  | Fixed  | Docs-only and alternatives-only guidance now still expands, while blank commands no longer render a copy action.  |
+| F004 | LOW      | src/crosshook-native/src/lib/mocks/handlers/onboarding.ts  | 166  | Fixed  | Browser mocks now remember dismissed readiness tool IDs and strip matching guidance on subsequent readiness runs. |
+
+## Files Changed
+
+- `src/crosshook-native/src-tauri/src/commands/onboarding.rs` (Fixed F002 with regression coverage)
+- `src/crosshook-native/src/components/ReadinessChecklist.tsx` (Fixed F003)
+- `src/crosshook-native/src/lib/mocks/store.ts` (Added per-tool dismissal tracking for browser mocks)
+- `src/crosshook-native/src/lib/mocks/handlers/onboarding.ts` (Fixed F004)
+
+## Validation Results
+
+| Check      | Result |
+| ---------- | ------ |
+| Type check | Pass   |
+| Tests      | Pass   |
+
+## Next Steps
+
+- Re-run `$code-review 277` to verify the remaining review surface; all findings in the current artifact are now marked `Fixed`.
+- Run `$git-workflow` to commit the review-fix changes when satisfied.

--- a/docs/prps/reviews/pr-277-review.md
+++ b/docs/prps/reviews/pr-277-review.md
@@ -1,0 +1,83 @@
+# PR Review #277 — feat(onboarding): sqlite-backed host readiness catalog
+
+**Reviewed**: 2026-04-16T14:15:41-04:00
+**Mode**: PR
+**Author**: yandy-r
+**Branch**: feat/flatpak-host-rediness -> main
+**Decision**: REQUEST CHANGES
+
+## Summary
+
+The readiness catalog and SQLite-backed onboarding work are directionally good, and the validation stack passes on the PR head. The blocking issue is that the new distro-aware guidance path can emit blank install commands for SteamOS and gaming-immutable hosts, and there are two additional persistence/UX gaps around dismissal handling and browser-mode parity.
+
+## Findings
+
+### CRITICAL
+
+- None.
+
+### HIGH
+
+- **[F001]** `src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs:141` — `build_umu_install_advice()` accepts catalog rows whose `command` is empty, and the new default catalog does that for `SteamOS` and `GamingImmutable`. When `umu-run` is actually missing on those hosts, onboarding emits `umu_install_guidance.install_command = ""` and the review UI renders a blank `Copy command` action instead of actionable install guidance.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Ignore empty-command catalog rows in `build_umu_install_advice()` and fall back to a usable docs-only or `Unknown` guidance path before constructing `UmuInstallGuidance`.
+
+### MEDIUM
+
+- **[F002]** `src/crosshook-native/src-tauri/src/commands/onboarding.rs:121` — `dismiss_readiness_nag()` returns `Ok(())` when `MetadataStore` is unavailable, but there is no fallback persistence path for host-tool dismissals. In the supported SQLite-disabled mode, the UI clears the reminder locally and then the reminder reappears on the next readiness run because nothing was actually saved.
+  - **Status**: Fixed
+  - **Category**: Completeness
+  - **Suggested fix**: Either persist a degraded fallback dismissal state in `settings.toml`, or return an error so the frontend does not pretend the dismissal succeeded.
+
+- **[F003]** `src/crosshook-native/src/components/ReadinessChecklist.tsx:193` — the new host-tool guidance UI only exposes `Install help` when `install_guidance.command` is non-empty. Several catalog rows intentionally rely on `alternatives` and `docs_url` with an empty command for SteamOS and immutable hosts, so those missing-tool states currently render with no expandable help, docs link, or dismiss action at all.
+  - **Status**: Fixed
+  - **Category**: Completeness
+  - **Suggested fix**: Treat non-empty `alternatives` or `docs_url` as sufficient to show the guidance block, and only hide the `Copy command` button when the command itself is empty.
+
+### LOW
+
+- **[F004]** `src/crosshook-native/src/lib/mocks/handlers/onboarding.ts:166` — the new `dismiss_readiness_nag` browser-dev mock is a no-op, so rerunning generalized readiness resurrects dismissed host-tool reminders immediately. That makes browser-only UI verification diverge from the real backend for the new feature.
+  - **Status**: Fixed
+  - **Category**: Completeness
+  - **Suggested fix**: Track dismissed tool IDs in the mock store and clear matching `install_guidance` entries in `buildMockReadinessResult()` before returning.
+
+## Validation Results
+
+| Check      | Result |
+| ---------- | ------ |
+| Type check | Pass   |
+| Lint       | Pass   |
+| Tests      | Pass   |
+| Build      | Pass   |
+
+## Files Reviewed
+
+- `.cursorrules` (Modified)
+- `AGENTS.md` (Modified)
+- `CLAUDE.md` (Modified)
+- `docs/prps/plans/completed/umu-migration-phase-4-auto-default.plan.md` (Modified)
+- `src/crosshook-native/assets/default_host_readiness_catalog.toml` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/readiness_catalog_store.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/readiness_dismissal_store.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/readiness_snapshot_store.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/onboarding/catalog.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/onboarding/mod.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/settings/mod.rs` (Modified)
+- `src/crosshook-native/src-tauri/src/commands/onboarding.rs` (Modified)
+- `src/crosshook-native/src-tauri/src/lib.rs` (Modified)
+- `src/crosshook-native/src/components/LaunchPanel.tsx` (Modified)
+- `src/crosshook-native/src/components/OnboardingWizard.tsx` (Modified)
+- `src/crosshook-native/src/components/PinnedProfilesStrip.tsx` (Modified)
+- `src/crosshook-native/src/components/ReadinessChecklist.tsx` (Modified)
+- `src/crosshook-native/src/components/profile-sections/RuntimeSection.tsx` (Modified)
+- `src/crosshook-native/src/components/wizard/WizardReviewSummary.tsx` (Modified)
+- `src/crosshook-native/src/hooks/useOnboarding.ts` (Modified)
+- `src/crosshook-native/src/lib/mocks/handlers/onboarding.ts` (Modified)
+- `src/crosshook-native/src/lib/mocks/wrapHandler.ts` (Modified)
+- `src/crosshook-native/src/styles/preview.css` (Modified)
+- `src/crosshook-native/src/types/onboarding.ts` (Modified)
+- `src/crosshook-native/src/utils/hostReadinessTooltips.ts` (Added)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/src/crosshook-native/assets/default_host_readiness_catalog.toml
+++ b/src/crosshook-native/assets/default_host_readiness_catalog.toml
@@ -264,8 +264,8 @@ alternatives = "Package may not exist; install on CachyOS or follow upstream gui
 
 [[tool.install]]
 distro_family = "Nix"
-command = "nix profile install nixpkgs#game-performance"
-alternatives = "If missing from nixpkgs, use CachyOS packages or build from source."
+command = ""
+alternatives = "The game-performance binary is not provided as nixpkgs#game-performance; use CachyOS packages, Distrobox/toolbox, or build from source."
 
 [[tool.install]]
 distro_family = "SteamOS"

--- a/src/crosshook-native/assets/default_host_readiness_catalog.toml
+++ b/src/crosshook-native/assets/default_host_readiness_catalog.toml
@@ -1,0 +1,453 @@
+# Host dependency readiness catalog — embedded default. Override via
+# ~/.config/crosshook/host_readiness_catalog.toml (merge by tool_id).
+catalog_version = 1
+
+# --- umu-launcher (runtime; required for best experience on Flatpak) ---
+[[tool]]
+tool_id = "umu_run"
+binary_name = "umu-run"
+display_name = "umu-launcher"
+description = "Improved Proton runtime bootstrapping for non-Steam launches when available."
+docs_url = "https://github.com/Open-Wine-Components/umu-launcher"
+required = false
+category = "runtime"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S umu-launcher"
+alternatives = "If unavailable in mirrors, use upstream docs for source or user-level install."
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install umu-launcher"
+alternatives = "If the packaged build is unavailable, fall back to upstream docs."
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install pipx && pipx install umu-launcher"
+alternatives = "Check upstream docs for current Fedora packaging."
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install pipx && pipx install umu-launcher"
+alternatives = "If pipx is unsuitable, use upstream source or user-level install."
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#umu-launcher"
+alternatives = "Or add pkgs.umu-launcher to NixOS / Home Manager."
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Pre-installed on SteamOS; no separate install step."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Usually pre-installed on gaming-focused immutable images; use distro docs if missing."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install umu-launcher"
+alternatives = "Or use pipx in a toolbox: toolbox create && toolbox enter …"
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "pipx install umu-launcher"
+alternatives = "See upstream docs for source, uv, or other user-level installs."
+
+# --- Steam Deck caveats (informational; not a host binary — empty binary_name skips catalog checks) ---
+[[tool]]
+tool_id = "steam_deck_caveats"
+binary_name = ""
+display_name = "Steam Deck caveats"
+description = "Platform-specific notes when using CrossHook on Steam Deck (dismissal is stored like other readiness nags)."
+docs_url = "https://github.com/ValveSoftware/gamescope/issues"
+required = false
+category = "compatibility"
+
+# --- gamescope ---
+[[tool]]
+tool_id = "gamescope"
+binary_name = "gamescope"
+display_name = "Gamescope"
+description = "Micro-compositor for scaling, HDR, and nested session features."
+docs_url = "https://github.com/ValveSoftware/gamescope"
+required = false
+category = "performance"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S gamescope"
+alternatives = "Use mesa-git or distro gaming repos if the stock package is old."
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install gamescope"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install gamescope"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install gamescope"
+alternatives = "Package name may differ on Ubuntu LTS; check distro gaming guides."
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#gamescope"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Pre-installed on SteamOS."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Usually pre-installed; use rpm-ostree or distro gaming guide if missing."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install gamescope"
+alternatives = "Or install in a Fedora toolbox."
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "See https://github.com/ValveSoftware/gamescope#installing"
+alternatives = "Build from source or use your distro's gaming repository."
+
+# --- MangoHud ---
+[[tool]]
+tool_id = "mangohud"
+binary_name = "mangohud"
+display_name = "MangoHud"
+description = "Vulkan/OpenGL overlay for frame time and performance stats."
+docs_url = "https://github.com/flightlessmango/MangoHud"
+required = false
+category = "overlay"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S mangohud"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install mangohud"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install mangohud"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install mangohud"
+alternatives = "Or use MangoHud release binaries from GitHub."
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#mangohud"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Pre-installed on SteamOS."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Usually pre-installed; check Flathub or rpm-ostree if missing."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install mangohud"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "See MangoHud releases or your distro package manager."
+alternatives = ""
+
+# --- GameMode (gamemoderun) ---
+[[tool]]
+tool_id = "gamemode"
+binary_name = "gamemoderun"
+display_name = "GameMode"
+description = "Requests CPU governor and I/O priority tweaks while games run."
+docs_url = "https://github.com/FeralInteractive/gamemode"
+required = false
+category = "performance"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S gamemode lib32-gamemode"
+alternatives = "32-bit lib may be needed for some Proton titles."
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install gamemode"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install gamemode"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install gamemode"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#gamemode"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Pre-installed on SteamOS."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Usually pre-installed."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install gamemode"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "See GameMode install instructions for your distribution."
+alternatives = ""
+
+# --- CachyOS game-performance (optional; binary is CachyOS-specific) ---
+[[tool]]
+tool_id = "game_performance"
+binary_name = "game-performance"
+display_name = "game-performance"
+description = "CachyOS helper for gaming performance tweaks and profiles."
+docs_url = "https://wiki.cachyos.org/"
+required = false
+category = "performance"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S game-performance"
+alternatives = "Package is provided on CachyOS. On vanilla Arch, use CachyOS repos or an AUR helper if available."
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install game-performance"
+alternatives = "May be unavailable; this tool is primarily distributed for CachyOS."
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install game-performance"
+alternatives = "May be unavailable outside CachyOS; check your distro or CachyOS documentation."
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install game-performance"
+alternatives = "Package may not exist; install on CachyOS or follow upstream guidance."
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#game-performance"
+alternatives = "If missing from nixpkgs, use CachyOS packages or build from source."
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Not typically pre-installed; CachyOS-specific package—install on CachyOS or skip."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "May be unavailable on this image; primarily a CachyOS package."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install game-performance"
+alternatives = "Package may be missing; prefer CachyOS or Distrobox/toolbox install."
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "See https://wiki.cachyos.org/ for CachyOS install paths."
+alternatives = "Primarily distributed for CachyOS."
+
+# --- winetricks ---
+[[tool]]
+tool_id = "winetricks"
+binary_name = "winetricks"
+display_name = "Winetricks"
+description = "Helper to install Windows DLLs and components into Wine prefixes."
+docs_url = "https://github.com/Winetricks/winetricks"
+required = false
+category = "prefix_tools"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S winetricks"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install winetricks"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install winetricks"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install winetricks"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#winetricks"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Often available; if missing use distro packages or upstream script."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Install via distro package manager or Distrobox."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install winetricks"
+alternatives = "Or run inside toolbox."
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "curl -sL https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -o ~/.local/bin/winetricks && chmod +x ~/.local/bin/winetricks"
+alternatives = "Ensure ~/.local/bin is on PATH."
+
+# --- protontricks ---
+[[tool]]
+tool_id = "protontricks"
+binary_name = "protontricks"
+display_name = "Protontricks"
+description = "Winetricks wrapper for Proton prefixes (Steam games)."
+docs_url = "https://github.com/Matoking/protontricks"
+required = false
+category = "prefix_tools"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S protontricks"
+alternatives = "Or pip: pip install --user protontricks"
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install protontricks"
+alternatives = "Or Flatpak: com.github.Matoking.protontricks"
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install protontricks"
+alternatives = "Or pip/Flatpak as above."
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install protontricks"
+alternatives = "Or pip install --user protontricks"
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#protontricks"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "Install via pip, Flatpak, or distro package when available."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Flatpak com.github.Matoking.protontricks is a common choice."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "pip install --user protontricks"
+alternatives = "Use toolbox or Distrobox for pip if the host is immutable."
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "pip install --user protontricks"
+alternatives = "See upstream docs."
+
+# --- Wine Wayland (presence of wine; PROTON_ENABLE_WAYLAND is catalog-level hint) ---
+[[tool]]
+tool_id = "wine_wayland"
+binary_name = "wine"
+display_name = "Wine (Wayland driver support)"
+description = "Wine on the host enables Proton/Wine Wayland experiments when combined with PROTON_ENABLE_WAYLAND=1."
+docs_url = "https://wiki.winehq.org/"
+required = false
+category = "compatibility"
+
+[[tool.install]]
+distro_family = "Arch"
+command = "sudo pacman -S wine"
+alternatives = "Use wine-staging or distro gaming wine builds."
+
+[[tool.install]]
+distro_family = "Nobara"
+command = "sudo dnf install wine"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Fedora"
+command = "sudo dnf install wine"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Debian"
+command = "sudo apt install wine"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Nix"
+command = "nix profile install nixpkgs#wine"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "SteamOS"
+command = ""
+alternatives = "SteamOS provides Wine/Proton via Steam; host wine may be optional."
+
+[[tool.install]]
+distro_family = "GamingImmutable"
+command = ""
+alternatives = "Use distro packages or Flatpak wine as appropriate."
+
+[[tool.install]]
+distro_family = "BareImmutable"
+command = "rpm-ostree install wine"
+alternatives = ""
+
+[[tool.install]]
+distro_family = "Unknown"
+command = "Install Wine from your distribution; then enable PROTON_ENABLE_WAYLAND in CrossHook when supported."
+alternatives = ""

--- a/src/crosshook-native/crates/crosshook-core/src/export/diagnostics.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/export/diagnostics.rs
@@ -444,7 +444,7 @@ fn collect_launch_logs_from(dir: &Path) -> Vec<(String, Vec<u8>)> {
         .collect();
 
     // Sort by modification time descending (most recent first).
-    log_files.sort_by(|a, b| b.1.cmp(&a.1));
+    log_files.sort_by_key(|entry| std::cmp::Reverse(entry.1));
     log_files.truncate(MAX_LAUNCH_LOG_FILES);
 
     log_files

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs
@@ -189,6 +189,15 @@ pub fn run_migrations(conn: &Connection) -> Result<(), MetadataStoreError> {
             })?;
     }
 
+    if version < 21 {
+        migrate_20_to_21(conn)?;
+        conn.pragma_update(None, "user_version", 21_u32)
+            .map_err(|source| MetadataStoreError::Database {
+                action: "set user_version to 21",
+                source,
+            })?;
+    }
+
     Ok(())
 }
 
@@ -898,6 +907,52 @@ fn migrate_19_to_20(conn: &Connection) -> Result<(), MetadataStoreError> {
     Ok(())
 }
 
+/// Host readiness catalog, nag dismissals, and last snapshot (issue #269).
+fn migrate_20_to_21(conn: &Connection) -> Result<(), MetadataStoreError> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS host_readiness_catalog (
+            tool_id TEXT PRIMARY KEY NOT NULL,
+            binary_name TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            docs_url TEXT NOT NULL DEFAULT '',
+            required INTEGER NOT NULL DEFAULT 0,
+            category TEXT NOT NULL DEFAULT '',
+            install_commands_json TEXT NOT NULL DEFAULT '[]',
+            source TEXT NOT NULL DEFAULT 'default',
+            catalog_version INTEGER NOT NULL DEFAULT 1,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS readiness_nag_dismissals (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tool_id TEXT NOT NULL,
+            dismissed_at TEXT NOT NULL,
+            expires_at TEXT NOT NULL
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_readiness_nag_dismissals_tool_id
+            ON readiness_nag_dismissals(tool_id);
+
+        CREATE TABLE IF NOT EXISTS host_readiness_snapshots (
+            id INTEGER PRIMARY KEY NOT NULL,
+            detected_distro_family TEXT NOT NULL,
+            tool_results_json TEXT NOT NULL,
+            all_passed INTEGER NOT NULL,
+            critical_failures INTEGER NOT NULL,
+            warnings INTEGER NOT NULL,
+            checked_at TEXT NOT NULL
+        );
+        ",
+    )
+    .map_err(|source| MetadataStoreError::Database {
+        action: "run metadata migration 20 to 21",
+        source,
+    })?;
+
+    Ok(())
+}
+
 fn migrate_16_to_17(conn: &Connection) -> Result<(), MetadataStoreError> {
     conn.execute_batch(
         "
@@ -1319,5 +1374,46 @@ mod tests {
             )
             .unwrap();
         assert_eq!(empty, None, "defaults_json should default to NULL");
+    }
+
+    #[test]
+    fn migration_20_to_21_creates_readiness_tables() {
+        let conn = db::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let version: u32 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert!(
+            version >= 21,
+            "schema version should be at least 21 after migration 20→21, got {version}"
+        );
+
+        for table in [
+            "host_readiness_catalog",
+            "readiness_nag_dismissals",
+            "host_readiness_snapshots",
+        ] {
+            let exists: bool = conn
+                .prepare(&format!(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='{table}'"
+                ))
+                .unwrap()
+                .exists([])
+                .unwrap();
+            assert!(exists, "table {table} should exist");
+        }
+
+        let idx_exists: bool = conn
+            .prepare(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_readiness_nag_dismissals_tool_id'",
+            )
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(
+            idx_exists,
+            "unique index idx_readiness_nag_dismissals_tool_id should exist"
+        );
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs
@@ -15,6 +15,9 @@ mod prefix_deps_store;
 mod prefix_storage_store;
 mod preset_store;
 pub mod profile_sync;
+mod readiness_catalog_store;
+mod readiness_dismissal_store;
+mod readiness_snapshot_store;
 mod suggestion_store;
 mod version_store;
 
@@ -31,6 +34,7 @@ pub use models::{
 };
 pub use offline_store::{CommunityTapOfflineRow, OfflineReadinessRow, TrainerHashCacheRow};
 pub use profile_sync::sha256_hex;
+pub use readiness_snapshot_store::HostReadinessSnapshotRow;
 pub use version_store::{compute_correlation_status, hash_trainer_file};
 
 use crate::community::taps::CommunityTapSyncResult;
@@ -1382,6 +1386,44 @@ impl MetadataStore {
     ) -> Result<(), MetadataStoreError> {
         self.with_conn_mut("persist optimization catalog", |conn| {
             optimization_catalog_store::persist_optimization_catalog(conn, entries, catalog_version)
+        })
+    }
+
+    pub fn persist_readiness_catalog(
+        &self,
+        entries: &[crate::onboarding::HostToolEntry],
+        catalog_version: u32,
+    ) -> Result<(), MetadataStoreError> {
+        self.with_conn_mut("persist readiness catalog", |conn| {
+            readiness_catalog_store::persist_readiness_catalog(conn, entries, catalog_version)
+        })
+    }
+
+    pub fn upsert_host_readiness_snapshot(
+        &self,
+        tool_checks: &[crate::onboarding::HostToolCheckResult],
+        detected_distro_family: &str,
+        all_passed: bool,
+        critical_failures: usize,
+        warnings: usize,
+    ) -> Result<(), MetadataStoreError> {
+        self.with_conn_mut("upsert host readiness snapshot", |conn| {
+            readiness_snapshot_store::upsert_host_readiness_snapshot_impl(
+                conn,
+                tool_checks,
+                detected_distro_family,
+                all_passed,
+                critical_failures,
+                warnings,
+            )
+        })
+    }
+
+    pub fn get_host_readiness_snapshot(
+        &self,
+    ) -> Result<Option<HostReadinessSnapshotRow>, MetadataStoreError> {
+        self.with_conn("get host readiness snapshot", |conn| {
+            readiness_snapshot_store::get_host_readiness_snapshot_impl(conn)
         })
     }
 

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/readiness_catalog_store.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/readiness_catalog_store.rs
@@ -1,0 +1,62 @@
+use rusqlite::Connection;
+
+use super::MetadataStoreError;
+use crate::onboarding::HostToolEntry;
+
+/// Persists the merged host readiness catalog to SQLite (full snapshot).
+pub fn persist_readiness_catalog(
+    conn: &mut Connection,
+    entries: &[HostToolEntry],
+    catalog_version: u32,
+) -> Result<(), MetadataStoreError> {
+    let tx = conn
+        .transaction()
+        .map_err(|source| MetadataStoreError::Database {
+            action: "begin host readiness catalog transaction",
+            source,
+        })?;
+
+    tx.execute("DELETE FROM host_readiness_catalog", [])
+        .map_err(|source| MetadataStoreError::Database {
+            action: "clear host readiness catalog",
+            source,
+        })?;
+
+    let now = chrono::Utc::now().to_rfc3339();
+
+    for entry in entries {
+        let install_json =
+            serde_json::to_string(&entry.install_commands).unwrap_or_else(|_| "[]".to_string());
+
+        tx.execute(
+            "INSERT INTO host_readiness_catalog (
+                tool_id, binary_name, display_name, description, docs_url,
+                required, category, install_commands_json, source, catalog_version, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            rusqlite::params![
+                entry.tool_id,
+                entry.binary_name,
+                entry.display_name,
+                entry.description,
+                entry.docs_url,
+                entry.required as i64,
+                entry.category,
+                install_json,
+                "default",
+                catalog_version as i64,
+                now,
+            ],
+        )
+        .map_err(|source| MetadataStoreError::Database {
+            action: "insert host readiness catalog entry",
+            source,
+        })?;
+    }
+
+    tx.commit().map_err(|source| MetadataStoreError::Database {
+        action: "commit host readiness catalog transaction",
+        source,
+    })?;
+
+    Ok(())
+}

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/readiness_dismissal_store.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/readiness_dismissal_store.rs
@@ -1,0 +1,91 @@
+use std::collections::HashSet;
+
+use chrono::{Duration, Utc};
+
+use super::MetadataStore;
+use crate::metadata::MetadataStoreError;
+
+impl MetadataStore {
+    /// Record a dismissed readiness nag with TTL in days (system-global).
+    pub fn dismiss_readiness_nag(
+        &self,
+        tool_id: &str,
+        ttl_days: u32,
+    ) -> Result<(), MetadataStoreError> {
+        let now = Utc::now();
+        let dismissed_at = now.to_rfc3339();
+        let expires_at = (now + Duration::days(i64::from(ttl_days))).to_rfc3339();
+
+        self.with_conn_mut("dismiss readiness nag", |conn| {
+            conn.execute(
+                "INSERT INTO readiness_nag_dismissals (tool_id, dismissed_at, expires_at)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(tool_id) DO UPDATE SET
+                    dismissed_at = excluded.dismissed_at,
+                    expires_at = excluded.expires_at",
+                rusqlite::params![tool_id, dismissed_at, expires_at],
+            )
+            .map_err(|source| MetadataStoreError::Database {
+                action: "dismiss readiness nag",
+                source,
+            })?;
+            Ok(())
+        })
+    }
+
+    /// Active dismissed tool IDs, evicting expired rows first.
+    pub fn get_dismissed_readiness_nags(&self) -> Result<HashSet<String>, MetadataStoreError> {
+        let now = Utc::now().to_rfc3339();
+
+        self.with_conn_mut("get dismissed readiness nags", |conn| {
+            conn.execute(
+                "DELETE FROM readiness_nag_dismissals WHERE expires_at < ?1",
+                rusqlite::params![now],
+            )
+            .map_err(|source| MetadataStoreError::Database {
+                action: "evict expired readiness nag dismissals",
+                source,
+            })?;
+
+            let mut stmt = conn
+                .prepare("SELECT tool_id FROM readiness_nag_dismissals")
+                .map_err(|source| MetadataStoreError::Database {
+                    action: "prepare get dismissed readiness nags",
+                    source,
+                })?;
+
+            let keys = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|source| MetadataStoreError::Database {
+                    action: "query dismissed readiness nags",
+                    source,
+                })?
+                .collect::<Result<HashSet<String>, _>>()
+                .map_err(|source| MetadataStoreError::Database {
+                    action: "decode readiness nag dismissal row",
+                    source,
+                })?;
+
+            Ok(keys)
+        })
+    }
+
+    /// Evict all expired readiness nag dismissals. Returns rows deleted.
+    pub fn evict_expired_readiness_dismissals(&self) -> Result<usize, MetadataStoreError> {
+        let now = Utc::now().to_rfc3339();
+
+        self.with_conn_mut("evict all expired readiness nag dismissals", |conn| {
+            let count = conn
+                .execute(
+                    "DELETE FROM readiness_nag_dismissals WHERE expires_at < ?1",
+                    rusqlite::params![now],
+                )
+                .map_err(|source| MetadataStoreError::Database {
+                    action: "evict all expired readiness nag dismissals",
+                    source,
+                })?;
+
+            Ok(count)
+        })
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/readiness_snapshot_store.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/readiness_snapshot_store.rs
@@ -1,0 +1,77 @@
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::metadata::MetadataStoreError;
+use crate::onboarding::HostToolCheckResult;
+
+/// Cached last host readiness snapshot row (single logical row `id = 1`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostReadinessSnapshotRow {
+    pub detected_distro_family: String,
+    pub tool_results_json: String,
+    pub all_passed: bool,
+    pub critical_failures: i64,
+    pub warnings: i64,
+    pub checked_at: String,
+}
+
+pub fn upsert_host_readiness_snapshot_impl(
+    conn: &mut Connection,
+    tool_checks: &[HostToolCheckResult],
+    detected_distro_family: &str,
+    all_passed: bool,
+    critical_failures: usize,
+    warnings: usize,
+) -> Result<(), MetadataStoreError> {
+    let tool_json = serde_json::to_string(tool_checks).map_err(|e| {
+        MetadataStoreError::Validation(format!("serialize host readiness tool_checks: {e}"))
+    })?;
+    let now = chrono::Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT OR REPLACE INTO host_readiness_snapshots (
+            id, detected_distro_family, tool_results_json,
+            all_passed, critical_failures, warnings, checked_at
+        ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6)",
+        rusqlite::params![
+            detected_distro_family,
+            tool_json,
+            all_passed as i64,
+            critical_failures as i64,
+            warnings as i64,
+            now,
+        ],
+    )
+    .map_err(|source| MetadataStoreError::Database {
+        action: "upsert host readiness snapshot",
+        source,
+    })?;
+
+    Ok(())
+}
+
+pub fn get_host_readiness_snapshot_impl(
+    conn: &Connection,
+) -> Result<Option<HostReadinessSnapshotRow>, MetadataStoreError> {
+    let row = conn
+        .query_row(
+            "SELECT detected_distro_family, tool_results_json, all_passed, critical_failures, warnings, checked_at
+             FROM host_readiness_snapshots WHERE id = 1",
+            [],
+            |row| {
+                Ok(HostReadinessSnapshotRow {
+                    detected_distro_family: row.get(0)?,
+                    tool_results_json: row.get(1)?,
+                    all_passed: row.get::<_, i64>(2)? != 0,
+                    critical_failures: row.get(3)?,
+                    warnings: row.get(4)?,
+                    checked_at: row.get(5)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|source| MetadataStoreError::Database {
+            action: "query host readiness snapshot",
+            source,
+        })?;
+    Ok(row)
+}

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/catalog.rs
@@ -1,0 +1,272 @@
+//! Host readiness catalog — embedded TOML, optional user override, merge + global accessor.
+//!
+//! Mirrors [`crate::launch::catalog`] patterns.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+use super::{HostDistroFamily, HostToolEntry, HostToolInstallCommand};
+
+/// Embedded default catalog TOML (compile time).
+pub const DEFAULT_READINESS_CATALOG_TOML: &str =
+    include_str!("../../../../assets/default_host_readiness_catalog.toml");
+
+const VALID_CATEGORIES: &[&str] = &[
+    "runtime",
+    "performance",
+    "overlay",
+    "compatibility",
+    "prefix_tools",
+];
+
+#[derive(Debug, Deserialize)]
+struct RawReadinessCatalogFile {
+    #[serde(default)]
+    catalog_version: u32,
+    #[serde(rename = "tool", default)]
+    tools: Vec<RawTool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTool {
+    tool_id: String,
+    binary_name: String,
+    display_name: String,
+    description: String,
+    docs_url: String,
+    required: bool,
+    category: String,
+    #[serde(default)]
+    install: Vec<HostToolInstallCommand>,
+}
+
+/// Validated in-memory readiness catalog.
+#[derive(Debug, Clone)]
+pub struct ReadinessCatalog {
+    pub catalog_version: u32,
+    pub entries: Vec<HostToolEntry>,
+}
+
+impl ReadinessCatalog {
+    pub fn from_entries(catalog_version: u32, entries: Vec<HostToolEntry>) -> Self {
+        Self {
+            catalog_version: catalog_version.max(1),
+            entries,
+        }
+    }
+
+    pub fn find_by_id(&self, id: &str) -> Option<&HostToolEntry> {
+        self.entries.iter().find(|e| e.tool_id == id)
+    }
+
+    /// Resolve install hint for a distro, falling back to `Unknown` if present.
+    pub fn install_for_distro(
+        entry: &HostToolEntry,
+        distro: HostDistroFamily,
+    ) -> Option<HostToolInstallCommand> {
+        let key = distro.as_str();
+        entry
+            .install_commands
+            .iter()
+            .find(|c| c.distro_family == key)
+            .cloned()
+            .or_else(|| {
+                entry
+                    .install_commands
+                    .iter()
+                    .find(|c| c.distro_family == "Unknown")
+                    .cloned()
+            })
+    }
+}
+
+/// Parse TOML; returns valid entries, warnings for skipped rows, and `catalog_version` from the file.
+pub fn parse_readiness_catalog_toml(
+    toml_text: &str,
+    source_label: &str,
+) -> (Vec<HostToolEntry>, Vec<String>, u32) {
+    let mut warnings: Vec<String> = Vec::new();
+
+    let raw: RawReadinessCatalogFile = match toml::from_str(toml_text) {
+        Ok(raw) => raw,
+        Err(err) => {
+            warnings.push(format!(
+                "readiness catalog '{source_label}' failed to parse: {err}"
+            ));
+            return (Vec::new(), warnings, 1);
+        }
+    };
+    let catalog_version = raw.catalog_version.max(1);
+
+    let mut valid = Vec::new();
+    let mut seen_ids = HashSet::new();
+
+    for tool in raw.tools {
+        if tool.tool_id.is_empty() {
+            warnings.push("skipping readiness tool with empty tool_id".to_string());
+            continue;
+        }
+        if !seen_ids.insert(tool.tool_id.clone()) {
+            warnings.push(format!(
+                "skipping duplicate readiness tool_id: {}",
+                tool.tool_id
+            ));
+            continue;
+        }
+        if tool.display_name.is_empty() {
+            warnings.push(format!(
+                "skipping readiness tool '{}': empty display_name",
+                tool.tool_id
+            ));
+            continue;
+        }
+        if tool.category.is_empty() {
+            warnings.push(format!(
+                "skipping readiness tool '{}': empty category",
+                tool.tool_id
+            ));
+            continue;
+        }
+        if !VALID_CATEGORIES.contains(&tool.category.as_str()) {
+            warnings.push(format!(
+                "skipping readiness tool '{}': unrecognized category '{}'",
+                tool.tool_id, tool.category
+            ));
+            continue;
+        }
+
+        valid.push(HostToolEntry {
+            tool_id: tool.tool_id,
+            binary_name: tool.binary_name,
+            display_name: tool.display_name,
+            description: tool.description,
+            docs_url: tool.docs_url,
+            required: tool.required,
+            category: tool.category,
+            install_commands: tool.install,
+        });
+    }
+
+    (valid, warnings, catalog_version)
+}
+
+/// Merge default entries with user overrides (same-id replaces in-place; novel IDs append).
+pub fn merge_readiness_catalogs(
+    default_entries: Vec<HostToolEntry>,
+    override_entries: Vec<HostToolEntry>,
+) -> Vec<HostToolEntry> {
+    let mut result = default_entries;
+    for over in override_entries {
+        if let Some(pos) = result.iter().position(|e| e.tool_id == over.tool_id) {
+            result[pos] = over;
+        } else {
+            result.push(over);
+        }
+    }
+    result
+}
+
+/// Load embedded default → optional user `host_readiness_catalog.toml`.
+pub fn load_readiness_catalog(user_config_dir: Option<&Path>) -> ReadinessCatalog {
+    let (default_entries, default_warnings, catalog_version) =
+        parse_readiness_catalog_toml(DEFAULT_READINESS_CATALOG_TOML, "embedded default");
+    for w in &default_warnings {
+        tracing::warn!(warning = %w, "default host readiness catalog warning");
+    }
+
+    let mut merged = default_entries;
+
+    let (user_entries, user_catalog_version_override) = user_config_dir
+        .map(|dir| dir.join("host_readiness_catalog.toml"))
+        .filter(|p| p.exists())
+        .and_then(|path| {
+            std::fs::read_to_string(&path)
+                .map_err(|err| {
+                    tracing::warn!(
+                        path = %path.display(),
+                        %err,
+                        "failed to read user host readiness catalog"
+                    );
+                })
+                .ok()
+        })
+        .map(|text| {
+            let (entries, warnings, user_ver) =
+                parse_readiness_catalog_toml(&text, "user override");
+            for w in &warnings {
+                tracing::warn!(warning = %w, "user host readiness catalog warning");
+            }
+            (entries, Some(user_ver))
+        })
+        .unwrap_or((Vec::new(), None));
+
+    merged = merge_readiness_catalogs(merged, user_entries);
+
+    let final_catalog_version = user_catalog_version_override.unwrap_or(catalog_version);
+    ReadinessCatalog::from_entries(final_catalog_version, merged)
+}
+
+static GLOBAL_READINESS_CATALOG: OnceLock<ReadinessCatalog> = OnceLock::new();
+
+pub fn initialize_readiness_catalog(catalog: ReadinessCatalog) {
+    let _ = GLOBAL_READINESS_CATALOG.set(catalog);
+}
+
+/// Process-global readiness catalog (default embedded if unset).
+pub fn global_readiness_catalog() -> &'static ReadinessCatalog {
+    GLOBAL_READINESS_CATALOG.get_or_init(|| load_readiness_catalog(None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_default_embedded_catalog_has_tools() {
+        let (entries, warnings, _) =
+            parse_readiness_catalog_toml(DEFAULT_READINESS_CATALOG_TOML, "embedded");
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+        assert!(
+            entries.iter().any(|e| e.tool_id == "umu_run"),
+            "expected umu_run"
+        );
+        assert!(
+            entries.iter().any(|e| e.tool_id == "gamescope"),
+            "expected gamescope"
+        );
+        assert!(
+            entries.iter().any(|e| e.tool_id == "game_performance"),
+            "expected game_performance"
+        );
+    }
+
+    #[test]
+    fn merge_replaces_by_tool_id() {
+        let a = HostToolEntry {
+            tool_id: "gamescope".to_string(),
+            binary_name: "gamescope".to_string(),
+            display_name: "Gamescope".to_string(),
+            description: "d".to_string(),
+            docs_url: "u".to_string(),
+            required: false,
+            category: "performance".to_string(),
+            install_commands: vec![],
+        };
+        let b = HostToolEntry {
+            tool_id: "gamescope".to_string(),
+            binary_name: "gamescope".to_string(),
+            display_name: "Patched".to_string(),
+            description: "d".to_string(),
+            docs_url: "u".to_string(),
+            required: false,
+            category: "performance".to_string(),
+            install_commands: vec![],
+        };
+        let merged = merge_readiness_catalogs(vec![a], vec![b]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].display_name, "Patched");
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/catalog.rs
@@ -199,7 +199,11 @@ pub fn load_readiness_catalog(user_config_dir: Option<&Path>) -> ReadinessCatalo
             for w in &warnings {
                 tracing::warn!(warning = %w, "user host readiness catalog warning");
             }
-            (entries, Some(user_ver))
+            // Only treat user_ver as an override when TOML parsed; on parse failure we still
+            // return catalog_version=1 from the parser but must not override embedded version.
+            let parse_failed = warnings.iter().any(|w| w.contains("failed to parse:"));
+            let version_override = if parse_failed { None } else { Some(user_ver) };
+            (entries, version_override)
         })
         .unwrap_or((Vec::new(), None));
 
@@ -268,5 +272,23 @@ mod tests {
         let merged = merge_readiness_catalogs(vec![a], vec![b]);
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].display_name, "Patched");
+    }
+
+    #[test]
+    fn load_readiness_catalog_invalid_user_file_keeps_embedded_catalog_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("host_readiness_catalog.toml"),
+            "not valid toml [[[",
+        )
+        .expect("write invalid catalog");
+        let loaded = load_readiness_catalog(Some(dir.path()));
+        let (_, _, embedded_ver) =
+            parse_readiness_catalog_toml(DEFAULT_READINESS_CATALOG_TOML, "embedded");
+        assert_eq!(
+            loaded.catalog_version,
+            embedded_ver.max(1),
+            "parse failure must not force user catalog_version override"
+        );
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/mod.rs
@@ -1,12 +1,106 @@
+pub mod catalog;
 pub mod readiness;
 
 use serde::{Deserialize, Serialize};
 
 use crate::profile::health::HealthIssue;
 
-pub use readiness::{
-    apply_install_nag_dismissal, apply_steam_deck_caveats_dismissal, check_system_readiness,
+pub use catalog::{
+    global_readiness_catalog, initialize_readiness_catalog, load_readiness_catalog,
+    ReadinessCatalog,
 };
+pub use readiness::{
+    apply_install_nag_dismissal, apply_readiness_nag_dismissals,
+    apply_steam_deck_caveats_dismissal, check_generalized_readiness, check_system_readiness,
+    detect_host_distro_family_from_os_release,
+};
+
+/// Host distribution family for install guidance (from `/etc/os-release` on the host).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum HostDistroFamily {
+    Arch,
+    Nobara,
+    Fedora,
+    Debian,
+    Nix,
+    Unknown,
+    /// SteamOS / Steam Deck image.
+    SteamOS,
+    /// Gaming-first immutables (e.g. Bazzite, ChimeraOS).
+    GamingImmutable,
+    /// Bare immutables without a full gaming stack pre-installed (e.g. Fedora Atomic variants).
+    BareImmutable,
+}
+
+impl HostDistroFamily {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HostDistroFamily::Arch => "Arch",
+            HostDistroFamily::Nobara => "Nobara",
+            HostDistroFamily::Fedora => "Fedora",
+            HostDistroFamily::Debian => "Debian",
+            HostDistroFamily::Nix => "Nix",
+            HostDistroFamily::Unknown => "Unknown",
+            HostDistroFamily::SteamOS => "SteamOS",
+            HostDistroFamily::GamingImmutable => "GamingImmutable",
+            HostDistroFamily::BareImmutable => "BareImmutable",
+        }
+    }
+
+    /// Parse from catalog `distro_family` string (PascalCase, matching [`Self::as_str`]).
+    pub fn from_catalog_key(s: &str) -> Option<Self> {
+        match s {
+            "Arch" => Some(Self::Arch),
+            "Nobara" => Some(Self::Nobara),
+            "Fedora" => Some(Self::Fedora),
+            "Debian" => Some(Self::Debian),
+            "Nix" => Some(Self::Nix),
+            "Unknown" => Some(Self::Unknown),
+            "SteamOS" => Some(Self::SteamOS),
+            "GamingImmutable" => Some(Self::GamingImmutable),
+            "BareImmutable" => Some(Self::BareImmutable),
+            _ => None,
+        }
+    }
+}
+
+/// One install-hint row for a host tool and distro family (from TOML / DB).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostToolInstallCommand {
+    pub distro_family: String,
+    pub command: String,
+    pub alternatives: String,
+}
+
+/// A host tool definition from the readiness catalog.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostToolEntry {
+    pub tool_id: String,
+    pub binary_name: String,
+    pub display_name: String,
+    pub description: String,
+    pub docs_url: String,
+    pub required: bool,
+    pub category: String,
+    #[serde(default)]
+    pub install_commands: Vec<HostToolInstallCommand>,
+}
+
+/// Result row for one host tool probe (onboarding / generalized readiness).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostToolCheckResult {
+    pub tool_id: String,
+    pub display_name: String,
+    pub is_available: bool,
+    pub is_required: bool,
+    pub category: String,
+    /// Project docs / upstream URL for this tool (from catalog).
+    #[serde(default)]
+    pub docs_url: String,
+    /// Populated when the tool is missing and guidance applies (e.g. Flatpak).
+    pub install_guidance: Option<HostToolInstallCommand>,
+}
 
 /// Actionable installation guidance for umu-launcher on the host, emitted when
 /// running inside a Flatpak sandbox and `umu-run` cannot be resolved from the
@@ -33,7 +127,7 @@ pub struct SteamDeckCaveats {
     pub docs_url: String,
 }
 
-/// System readiness check result returned by `check_system_readiness`.
+/// System readiness check result returned by `check_system_readiness` / `check_generalized_readiness`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadinessCheckResult {
     pub checks: Vec<HealthIssue>,
@@ -47,6 +141,12 @@ pub struct ReadinessCheckResult {
     /// Known Steam Deck caveats surfaced during onboarding when the system is
     /// identified as a Steam Deck. `None` on non-Steam-Deck systems.
     pub steam_deck_caveats: Option<SteamDeckCaveats>,
+    /// Host tool rows from the readiness catalog (empty unless `check_generalized_readiness` ran).
+    #[serde(default)]
+    pub tool_checks: Vec<HostToolCheckResult>,
+    /// Detected host distro family key (e.g. `Arch`, `SteamOS`).
+    #[serde(default)]
+    pub detected_distro_family: String,
 }
 
 /// A single trainer source or loading mode entry in onboarding guidance.

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
@@ -432,29 +432,11 @@ fn evaluate_host_tool_checks(
     let mut extra_warnings = 0usize;
     let mut extra_critical = 0usize;
 
-    let gaming_assumed = matches!(
-        distro,
-        HostDistroFamily::SteamOS | HostDistroFamily::GamingImmutable
-    );
-
     for entry in &catalog.entries {
         if entry.tool_id == "umu_run" {
             continue;
         }
         if entry.binary_name.trim().is_empty() {
-            continue;
-        }
-
-        if gaming_assumed && !entry.required {
-            tool_checks.push(HostToolCheckResult {
-                tool_id: entry.tool_id.clone(),
-                display_name: entry.display_name.clone(),
-                is_available: true,
-                is_required: entry.required,
-                category: entry.category.clone(),
-                docs_url: entry.docs_url.clone(),
-                install_guidance: None,
-            });
             continue;
         }
 

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
@@ -139,7 +139,14 @@ fn detect_host_distro_family() -> HostDistroFamily {
 fn build_umu_install_advice(distro_family: HostDistroFamily) -> UmuInstallAdvice {
     let catalog = global_readiness_catalog();
     if let Some(entry) = catalog.find_by_id("umu_run") {
-        if let Some(cmd) = ReadinessCatalog::install_for_distro(entry, distro_family) {
+        let install_command = ReadinessCatalog::install_for_distro(entry, distro_family)
+            .filter(|cmd| !cmd.command.trim().is_empty())
+            .or_else(|| {
+                ReadinessCatalog::install_for_distro(entry, HostDistroFamily::Unknown)
+                    .filter(|cmd| !cmd.command.trim().is_empty())
+            });
+
+        if let Some(cmd) = install_command {
             let guidance = UmuInstallGuidance {
                 install_command: cmd.command.clone(),
                 docs_url: entry.docs_url.clone(),
@@ -845,6 +852,28 @@ mod tests {
         assert_eq!(
             nix.guidance.install_command,
             "nix profile install nixpkgs#umu-launcher"
+        );
+    }
+
+    #[test]
+    fn build_umu_install_advice_skips_empty_catalog_commands() {
+        let cat = crate::onboarding::load_readiness_catalog(None);
+        crate::onboarding::initialize_readiness_catalog(cat);
+
+        let steam_os = build_umu_install_advice(HostDistroFamily::SteamOS);
+        assert_eq!(
+            steam_os.guidance.install_command,
+            "pipx install umu-launcher"
+        );
+        assert!(
+            steam_os.remediation.contains("pipx install umu-launcher"),
+            "SteamOS fallback should stay actionable when the catalog command is blank"
+        );
+
+        let gaming_immutable = build_umu_install_advice(HostDistroFamily::GamingImmutable);
+        assert_eq!(
+            gaming_immutable.guidance.install_command,
+            "pipx install umu-launcher"
         );
     }
 

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
@@ -1,8 +1,12 @@
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
 use crate::launch::runtime_helpers::resolve_umu_run_path;
-use crate::onboarding::{ReadinessCheckResult, UmuInstallGuidance};
+use crate::onboarding::catalog::{global_readiness_catalog, ReadinessCatalog};
+use crate::onboarding::{
+    HostDistroFamily, HostToolCheckResult, ReadinessCheckResult, UmuInstallGuidance,
+};
 use crate::profile::health::{HealthIssue, HealthIssueSeverity};
 use crate::steam::{discover_compat_tools, discover_steam_root_candidates, ProtonInstall};
 
@@ -11,16 +15,6 @@ const UMU_LAUNCHER_DOCS_URL: &str = "https://github.com/Open-Wine-Components/umu
 const STEAM_DECK_CAVEATS_DOCS_URL: &str = "https://github.com/ValveSoftware/gamescope/issues";
 const STEAM_DECK_CAVEATS_DESCRIPTION: &str =
     "CrossHook works on Steam Deck desktop mode today. In gaming mode you may hit these documented upstream issues on SteamOS 3.7+:";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HostDistroFamily {
-    Arch,
-    Nobara,
-    Fedora,
-    Debian,
-    Nix,
-    Unknown,
-}
 
 #[derive(Debug, Clone)]
 struct UmuInstallAdvice {
@@ -51,28 +45,60 @@ where
     read_file("/etc/os-release")
 }
 
-fn detect_host_distro_family() -> HostDistroFamily {
-    detect_host_distro_family_from_os_release(read_host_os_release().as_deref())
-}
-
-fn detect_host_distro_family_from_os_release(os_release: Option<&str>) -> HostDistroFamily {
+/// Detect host distro family from `/etc/os-release` body (shared with tests).
+pub fn detect_host_distro_family_from_os_release(os_release: Option<&str>) -> HostDistroFamily {
     let Some(os_release) = os_release else {
         return HostDistroFamily::Unknown;
     };
 
     let mut distro_tokens = Vec::new();
+    let mut variant_tokens = Vec::new();
     for line in os_release.lines() {
         let Some((key, raw_value)) = line.split_once('=') else {
             continue;
         };
-        if key != "ID" && key != "ID_LIKE" {
+        if key != "ID" && key != "ID_LIKE" && key != "VARIANT_ID" {
             continue;
         }
         let normalized = raw_value
             .trim()
             .trim_matches(|ch| ch == '"' || ch == '\'')
             .to_ascii_lowercase();
-        distro_tokens.extend(normalized.split_whitespace().map(str::to_string));
+        let tokens: Vec<String> = normalized.split_whitespace().map(str::to_string).collect();
+        if key == "VARIANT_ID" {
+            variant_tokens.extend(tokens);
+        } else {
+            distro_tokens.extend(tokens);
+        }
+    }
+
+    // SteamOS / Steam Deck
+    if distro_tokens.iter().any(|t| t == "steamos")
+        || variant_tokens.iter().any(|t| t == "steamdeck")
+    {
+        return HostDistroFamily::SteamOS;
+    }
+
+    // Gaming-first immutables
+    if distro_tokens
+        .iter()
+        .any(|t| t == "bazzite" || t == "chimeraos")
+        || distro_tokens.iter().any(|t| t.contains("universal-blue"))
+    {
+        return HostDistroFamily::GamingImmutable;
+    }
+
+    // Bare immutables (Fedora Atomic family, Vanilla OS, etc.)
+    if distro_tokens.iter().any(|t| t == "vanilla")
+        || variant_tokens.iter().any(|v| {
+            v.contains("kinoite")
+                || v.contains("silverblue")
+                || v.contains("sericea")
+                || v.contains("onyx")
+                || v.contains("atomic")
+        })
+    {
+        return HostDistroFamily::BareImmutable;
     }
 
     if distro_tokens
@@ -106,7 +132,36 @@ fn detect_host_distro_family_from_os_release(os_release: Option<&str>) -> HostDi
     HostDistroFamily::Unknown
 }
 
+fn detect_host_distro_family() -> HostDistroFamily {
+    detect_host_distro_family_from_os_release(read_host_os_release().as_deref())
+}
+
 fn build_umu_install_advice(distro_family: HostDistroFamily) -> UmuInstallAdvice {
+    let catalog = global_readiness_catalog();
+    if let Some(entry) = catalog.find_by_id("umu_run") {
+        if let Some(cmd) = ReadinessCatalog::install_for_distro(entry, distro_family) {
+            let guidance = UmuInstallGuidance {
+                install_command: cmd.command.clone(),
+                docs_url: entry.docs_url.clone(),
+                description: entry.description.clone(),
+            };
+            let alt = if cmd.alternatives.trim().is_empty() {
+                String::new()
+            } else {
+                format!("{} ", cmd.alternatives.trim())
+            };
+            let remediation = format!(
+                "Install umu-launcher on your host: `{}`. {}See {} for full instructions.",
+                guidance.install_command, alt, guidance.docs_url,
+            );
+            return UmuInstallAdvice {
+                guidance,
+                remediation,
+            };
+        }
+    }
+
+    // Fallback (tests / empty catalog)
     let (description, install_command, alternatives) = match distro_family {
         HostDistroFamily::Arch => (
             "Install umu-launcher on your Arch-based host to enable improved Proton runtime bootstrapping for non-Steam launches.",
@@ -138,6 +193,13 @@ fn build_umu_install_advice(distro_family: HostDistroFamily) -> UmuInstallAdvice
             "pipx install umu-launcher",
             "Other options include upstream source, user-level, or uv-based installs described in the project docs.",
         ),
+        HostDistroFamily::SteamOS
+        | HostDistroFamily::GamingImmutable
+        | HostDistroFamily::BareImmutable => (
+            "Install umu-launcher on your host to enable improved Proton runtime bootstrapping for non-Steam launches.",
+            "pipx install umu-launcher",
+            "See distribution documentation for immutable-friendly install paths.",
+        ),
     };
 
     let guidance = UmuInstallGuidance {
@@ -167,11 +229,6 @@ fn home_to_tilde(path_str: &str) -> String {
 }
 
 /// Run all system-level first-run readiness checks synchronously.
-///
-/// Checks: Steam installed, Proton available, game launched once, trainer available,
-/// umu-run available.
-/// Path strings in the returned `HealthIssue` values have the home directory
-/// replaced with `~` for display safety.
 pub fn check_system_readiness() -> ReadinessCheckResult {
     let mut diagnostics: Vec<String> = Vec::new();
     let steam_roots = discover_steam_root_candidates("", &mut diagnostics);
@@ -185,8 +242,6 @@ pub fn check_system_readiness() -> ReadinessCheckResult {
     evaluate_checks(&steam_roots, &proton_tools)
 }
 
-/// Core evaluation logic — separated so tests can supply explicit Proton tool lists
-/// to avoid depending on system-level compat tool directories.
 fn evaluate_checks(
     steam_roots: &[PathBuf],
     proton_tools: &[ProtonInstall],
@@ -203,8 +258,6 @@ fn evaluate_checks(
     )
 }
 
-/// Inner evaluation logic with injectable umu resolution and platform context so
-/// unit tests can exercise both the native and Flatpak code paths deterministically.
 fn evaluate_checks_inner(
     steam_roots: &[PathBuf],
     proton_tools: &[ProtonInstall],
@@ -214,7 +267,6 @@ fn evaluate_checks_inner(
 ) -> ReadinessCheckResult {
     let mut checks: Vec<HealthIssue> = Vec::new();
 
-    // Check 1: Steam installed
     if steam_roots.is_empty() {
         checks.push(HealthIssue {
             field: "steam_installed".to_string(),
@@ -235,7 +287,6 @@ fn evaluate_checks_inner(
         });
     }
 
-    // Check 2: Proton available
     if proton_tools.is_empty() {
         checks.push(HealthIssue {
             field: "proton_available".to_string(),
@@ -255,7 +306,6 @@ fn evaluate_checks_inner(
         });
     }
 
-    // Check 3: Game launched once — scan steamapps/compatdata/*/pfx
     let has_compatdata = steam_roots.iter().any(|root| {
         let compatdata = root.join("steamapps").join("compatdata");
         match fs::read_dir(&compatdata) {
@@ -284,7 +334,6 @@ fn evaluate_checks_inner(
         });
     }
 
-    // Check 4: Trainer available — always informational at system check stage
     checks.push(HealthIssue {
         field: "trainer_available".to_string(),
         path: String::new(),
@@ -293,7 +342,6 @@ fn evaluate_checks_inner(
         severity: HealthIssueSeverity::Info,
     });
 
-    // Check 5: umu-run optional launcher
     let mut umu_install_guidance: Option<UmuInstallGuidance> = None;
     {
         match umu_path {
@@ -369,11 +417,122 @@ fn evaluate_checks_inner(
         warnings,
         umu_install_guidance,
         steam_deck_caveats,
+        tool_checks: Vec::new(),
+        detected_distro_family: String::new(),
     }
 }
 
-/// When the user has dismissed the Flatpak umu install reminder, clear the structured
-/// guidance payload so readiness stays consistent across reruns and wizard reopen.
+/// Host tool rows from catalog (skips `umu_run` — covered by core umu check).
+fn evaluate_host_tool_checks(
+    catalog: &ReadinessCatalog,
+    distro: HostDistroFamily,
+    is_flatpak: bool,
+) -> (Vec<HostToolCheckResult>, usize, usize) {
+    let mut tool_checks = Vec::new();
+    let mut extra_warnings = 0usize;
+    let mut extra_critical = 0usize;
+
+    let gaming_assumed = matches!(
+        distro,
+        HostDistroFamily::SteamOS | HostDistroFamily::GamingImmutable
+    );
+
+    for entry in &catalog.entries {
+        if entry.tool_id == "umu_run" {
+            continue;
+        }
+        if entry.binary_name.trim().is_empty() {
+            continue;
+        }
+
+        if gaming_assumed && !entry.required {
+            tool_checks.push(HostToolCheckResult {
+                tool_id: entry.tool_id.clone(),
+                display_name: entry.display_name.clone(),
+                is_available: true,
+                is_required: entry.required,
+                category: entry.category.clone(),
+                docs_url: entry.docs_url.clone(),
+                install_guidance: None,
+            });
+            continue;
+        }
+
+        let available = crate::platform::host_command_exists(&entry.binary_name);
+        if available {
+            tool_checks.push(HostToolCheckResult {
+                tool_id: entry.tool_id.clone(),
+                display_name: entry.display_name.clone(),
+                is_available: true,
+                is_required: entry.required,
+                category: entry.category.clone(),
+                docs_url: entry.docs_url.clone(),
+                install_guidance: None,
+            });
+            continue;
+        }
+
+        let guidance = if is_flatpak {
+            ReadinessCatalog::install_for_distro(entry, distro)
+        } else {
+            None
+        };
+
+        if entry.required {
+            extra_critical += 1;
+        } else {
+            extra_warnings += 1;
+        }
+
+        tool_checks.push(HostToolCheckResult {
+            tool_id: entry.tool_id.clone(),
+            display_name: entry.display_name.clone(),
+            is_available: false,
+            is_required: entry.required,
+            category: entry.category.clone(),
+            docs_url: entry.docs_url.clone(),
+            install_guidance: guidance,
+        });
+    }
+
+    (tool_checks, extra_warnings, extra_critical)
+}
+
+/// Full readiness: core checks plus catalog host tools.
+pub fn check_generalized_readiness(catalog: &ReadinessCatalog) -> ReadinessCheckResult {
+    let mut result = check_system_readiness();
+    let distro = detect_host_distro_family();
+    let is_flatpak = crate::platform::is_flatpak();
+    result.detected_distro_family = distro.as_str().to_string();
+
+    let (tool_checks, tw, tc) = evaluate_host_tool_checks(catalog, distro, is_flatpak);
+    result.tool_checks = tool_checks;
+
+    result.warnings = result.warnings.saturating_add(tw);
+    result.critical_failures = result.critical_failures.saturating_add(tc);
+    result.all_passed = result.critical_failures == 0 && result.warnings == 0;
+
+    result
+}
+
+/// Clear structured payloads for tool IDs present in `dismissed` (DB-backed nag dismissals).
+pub fn apply_readiness_nag_dismissals(
+    result: &mut ReadinessCheckResult,
+    dismissed: &HashSet<String>,
+) {
+    if dismissed.contains("umu_run") {
+        result.umu_install_guidance = None;
+    }
+    if dismissed.contains("steam_deck_caveats") {
+        result.steam_deck_caveats = None;
+    }
+    for t in &mut result.tool_checks {
+        if dismissed.contains(&t.tool_id) {
+            t.install_guidance = None;
+        }
+    }
+}
+
 pub fn apply_install_nag_dismissal(
     result: &mut ReadinessCheckResult,
     install_nag_dismissed_at: &Option<String>,
@@ -383,8 +542,6 @@ pub fn apply_install_nag_dismissal(
     }
 }
 
-/// When the user has dismissed the Steam Deck caveats notice, clear the structured
-/// caveats payload so readiness stays consistent across reruns and wizard reopen.
 pub fn apply_steam_deck_caveats_dismissal(
     result: &mut ReadinessCheckResult,
     dismissed_at: &Option<String>,
@@ -412,14 +569,12 @@ mod tests {
         }
     }
 
-    /// Creates a minimal Steam root with a `steamapps` directory.
     fn setup_steam_root(base: &Path) -> PathBuf {
         let steam_root = base.to_path_buf();
         fs::create_dir_all(steam_root.join("steamapps")).expect("steamapps");
         steam_root
     }
 
-    /// Creates a fake `ProtonInstall` under `steamapps/common/Proton-9`.
     fn make_proton_install(steam_root: &Path) -> ProtonInstall {
         use std::collections::BTreeSet;
         let proton_dir = steam_root.join("steamapps/common/Proton-9");
@@ -434,7 +589,6 @@ mod tests {
         }
     }
 
-    /// Adds a fake compatdata prefix at `steamapps/compatdata/12345/pfx`.
     fn add_compatdata(steam_root: &Path) {
         let pfx = steam_root.join("steamapps/compatdata/12345/pfx");
         fs::create_dir_all(&pfx).expect("pfx dir");
@@ -492,7 +646,7 @@ mod tests {
         );
 
         assert_eq!(result.critical_failures, 2);
-        assert_eq!(result.warnings, 2); // game_launched_once + umu missing
+        assert_eq!(result.warnings, 2);
     }
 
     #[test]
@@ -500,7 +654,6 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let steam_root = setup_steam_root(tmp.path());
         add_compatdata(&steam_root);
-        // Intentionally no Proton tools passed
 
         let result = evaluate_checks_inner(&[steam_root], &[], None, false, false);
 
@@ -527,7 +680,7 @@ mod tests {
         );
 
         assert_eq!(result.critical_failures, 1);
-        assert_eq!(result.warnings, 1); // umu missing
+        assert_eq!(result.warnings, 1);
     }
 
     #[test]
@@ -535,7 +688,6 @@ mod tests {
         let tmp = tempdir().expect("tempdir");
         let steam_root = setup_steam_root(tmp.path());
         let proton = make_proton_install(&steam_root);
-        // Intentionally no compatdata
 
         let result = evaluate_checks_inner(
             &[steam_root],
@@ -547,7 +699,7 @@ mod tests {
 
         assert!(!result.all_passed);
         assert_eq!(result.critical_failures, 0);
-        assert_eq!(result.warnings, 1); // game_launched_once only (umu present)
+        assert_eq!(result.warnings, 1);
 
         let game_check = result
             .checks
@@ -587,7 +739,6 @@ mod tests {
             result.umu_install_guidance.is_none(),
             "native missing umu must not produce a guidance payload"
         );
-        // umu being absent is a warning — all_passed reflects this
         assert!(
             !result.all_passed,
             "missing umu (Warning) should set all_passed=false; checks: {:?}",
@@ -597,6 +748,9 @@ mod tests {
 
     #[test]
     fn flatpak_missing_umu_reports_actionable_guidance() {
+        let _catalog = crate::onboarding::load_readiness_catalog(None);
+        crate::onboarding::initialize_readiness_catalog(_catalog);
+
         let tmp = tempdir().expect("tempdir");
         let steam_root = setup_steam_root(tmp.path());
         let proton = make_proton_install(&steam_root);
@@ -640,7 +794,6 @@ mod tests {
             "guidance description must be non-empty"
         );
 
-        // umu being absent on Flatpak is a warning — all_passed reflects this
         assert!(
             !result.all_passed,
             "Flatpak missing umu (Warning) should set all_passed=false; checks: {:?}",
@@ -679,21 +832,45 @@ mod tests {
     }
 
     #[test]
+    fn detect_host_distro_family_recognizes_steamos() {
+        let distro =
+            detect_host_distro_family_from_os_release(Some("ID=steamos\nVARIANT_ID=steamdeck\n"));
+        assert_eq!(distro, HostDistroFamily::SteamOS);
+    }
+
+    #[test]
+    fn detect_host_distro_family_recognizes_bazzite() {
+        let distro = detect_host_distro_family_from_os_release(Some("ID=bazzite\n"));
+        assert_eq!(distro, HostDistroFamily::GamingImmutable);
+    }
+
+    #[test]
+    fn detect_host_distro_family_recognizes_silverblue() {
+        let distro =
+            detect_host_distro_family_from_os_release(Some("ID=fedora\nVARIANT_ID=silverblue\n"));
+        assert_eq!(distro, HostDistroFamily::BareImmutable);
+    }
+
+    #[test]
     fn build_umu_install_advice_uses_primary_command_per_distro() {
+        let cat = crate::onboarding::load_readiness_catalog(None);
+        crate::onboarding::initialize_readiness_catalog(cat);
         let arch = build_umu_install_advice(HostDistroFamily::Arch);
         assert_eq!(arch.guidance.install_command, "sudo pacman -S umu-launcher");
-        assert!(arch.remediation.contains("source or user-level install"));
+        assert!(arch.remediation.contains("github.com") || arch.remediation.contains("umu"));
 
         let nix = build_umu_install_advice(HostDistroFamily::Nix);
         assert_eq!(
             nix.guidance.install_command,
             "nix profile install nixpkgs#umu-launcher"
         );
-        assert!(nix.remediation.contains("Home Manager"));
     }
 
     #[test]
     fn install_nag_dismissal_clears_flatpak_umu_guidance() {
+        let cat = crate::onboarding::load_readiness_catalog(None);
+        crate::onboarding::initialize_readiness_catalog(cat);
+
         let tmp = tempdir().expect("tempdir");
         let steam_root = setup_steam_root(tmp.path());
         let proton = make_proton_install(&steam_root);
@@ -710,8 +887,6 @@ mod tests {
             "dismissed install nag must strip umu_install_guidance on subsequent readiness"
         );
     }
-
-    // ── Steam Deck caveats tests ─────────────────────────────────────────────
 
     #[test]
     fn caveats_absent_when_not_steam_deck() {
@@ -770,7 +945,6 @@ mod tests {
         let proton = make_proton_install(&steam_root);
         add_compatdata(&steam_root);
 
-        // umu present so guidance payload is absent — only caveats are tested here
         let result = evaluate_checks_inner(
             &[steam_root],
             &[proton],
@@ -835,12 +1009,14 @@ mod tests {
 
     #[test]
     fn caveats_present_even_when_umu_absent_and_flatpak() {
+        let cat = crate::onboarding::load_readiness_catalog(None);
+        crate::onboarding::initialize_readiness_catalog(cat);
+
         let tmp = tempdir().expect("tempdir");
         let steam_root = setup_steam_root(tmp.path());
         let proton = make_proton_install(&steam_root);
         add_compatdata(&steam_root);
 
-        // Flatpak + missing umu + Steam Deck: both payloads must be populated
         let result = evaluate_checks_inner(&[steam_root], &[proton], None, true, true);
 
         assert!(
@@ -860,7 +1036,6 @@ mod tests {
         let proton = make_proton_install(&steam_root);
         add_compatdata(&steam_root);
 
-        // All checks green, umu present, Steam Deck — caveats are informational only
         let result = evaluate_checks_inner(
             &[steam_root],
             &[proton],

--- a/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/onboarding/readiness.rs
@@ -511,6 +511,11 @@ pub fn apply_readiness_nag_dismissals(
 ) {
     if dismissed.contains("umu_run") {
         result.umu_install_guidance = None;
+        for issue in &mut result.checks {
+            if issue.field == "umu_run_available" {
+                issue.remediation.clear();
+            }
+        }
     }
     if dismissed.contains("steam_deck_caveats") {
         result.steam_deck_caveats = None;

--- a/src/crosshook-native/crates/crosshook-core/src/protondb/suggestions.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protondb/suggestions.rs
@@ -215,10 +215,9 @@ pub fn derive_suggestions(
         }
     }
 
-    catalog_suggestions.sort_by(|a, b| b.supporting_report_count.cmp(&a.supporting_report_count));
-    env_var_suggestions.sort_by(|a, b| b.supporting_report_count.cmp(&a.supporting_report_count));
-    launch_option_suggestions
-        .sort_by(|a, b| b.supporting_report_count.cmp(&a.supporting_report_count));
+    catalog_suggestions.sort_by_key(|item| std::cmp::Reverse(item.supporting_report_count));
+    env_var_suggestions.sort_by_key(|item| std::cmp::Reverse(item.supporting_report_count));
+    launch_option_suggestions.sort_by_key(|item| std::cmp::Reverse(item.supporting_report_count));
 
     let is_stale = lookup.cache.as_ref().is_some_and(|c| c.is_stale);
     let tier = snapshot.tier.clone();

--- a/src/crosshook-native/crates/crosshook-core/src/settings/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/settings/mod.rs
@@ -219,9 +219,15 @@ pub struct AppSettingsData {
     #[serde(default)]
     pub umu_preference: UmuPreference,
     /// RFC 3339 timestamp of when the user dismissed the umu install nag; `None` = not dismissed.
+    ///
+    /// TODO(#269): Canonical dismissals live in SQLite `readiness_nag_dismissals`; this field remains
+    /// for settings.toml backward compatibility and startup migration into the DB.
     pub install_nag_dismissed_at: Option<String>,
     /// RFC 3339 timestamp of when the user dismissed the Steam Deck gaming-mode caveats;
     /// `None` = not dismissed.
+    ///
+    /// TODO(#269): Canonical dismissals live in SQLite `readiness_nag_dismissals`; this field remains
+    /// for settings.toml backward compatibility and startup migration into the DB.
     pub steam_deck_caveats_dismissed_at: Option<String>,
 }
 

--- a/src/crosshook-native/src-tauri/src/commands/onboarding.rs
+++ b/src/crosshook-native/src-tauri/src/commands/onboarding.rs
@@ -12,6 +12,16 @@ use tauri::State;
 
 use super::shared::sanitize_display_path;
 
+fn require_readiness_metadata(metadata: &MetadataStore) -> Result<(), String> {
+    if metadata.is_available() {
+        Ok(())
+    } else {
+        Err(
+            "readiness nag dismissals require the SQLite metadata store; dismiss_umu_install_nag and dismiss_steam_deck_caveats remain available via settings.toml".to_string(),
+        )
+    }
+}
+
 #[tauri::command]
 pub fn check_readiness(
     store: State<'_, SettingsStore>,
@@ -118,9 +128,7 @@ pub fn dismiss_readiness_nag(
     tool_id: String,
     ttl_days: Option<u32>,
 ) -> Result<(), String> {
-    if !metadata.is_available() {
-        return Ok(());
-    }
+    require_readiness_metadata(&metadata)?;
     let catalog = global_readiness_catalog();
     if catalog.find_by_id(&tool_id).is_none() {
         return Err(format!(
@@ -212,6 +220,24 @@ mod tests {
         let _ = dismiss_readiness_nag
             as fn(State<'_, MetadataStore>, String, Option<u32>) -> Result<(), String>;
         let _ = get_trainer_guidance as fn() -> TrainerGuidanceContent;
+    }
+
+    #[test]
+    fn require_readiness_metadata_rejects_disabled_store() {
+        let metadata = MetadataStore::disabled();
+        let error = require_readiness_metadata(&metadata).expect_err(
+            "disabled metadata store should surface an error so the frontend does not pretend dismissal succeeded",
+        );
+        assert!(
+            error.contains("SQLite metadata store"),
+            "error should explain why per-tool readiness dismissal could not be persisted"
+        );
+    }
+
+    #[test]
+    fn require_readiness_metadata_accepts_available_store() {
+        let metadata = MetadataStore::open_in_memory().expect("in-memory metadata store");
+        require_readiness_metadata(&metadata).expect("available metadata store should be accepted");
     }
 
     /// Exercises the underlying mutation that `dismiss_umu_install_nag` performs,

--- a/src/crosshook-native/src-tauri/src/commands/onboarding.rs
+++ b/src/crosshook-native/src-tauri/src/commands/onboarding.rs
@@ -100,9 +100,12 @@ pub fn dismiss_umu_install_nag(
         .map_err(|e| e.to_string())?
         .unwrap();
     if metadata.is_available() {
-        metadata
-            .dismiss_readiness_nag("umu_run", 3650)
-            .map_err(|e| e.to_string())?;
+        if let Err(err) = metadata.dismiss_readiness_nag("umu_run", 3650) {
+            tracing::warn!(
+                error = %err,
+                "failed to persist SQLite readiness nag dismissal for umu_run after settings save"
+            );
+        }
     }
     Ok(())
 }
@@ -120,9 +123,12 @@ pub fn dismiss_steam_deck_caveats(
         .map_err(|e| e.to_string())?
         .unwrap();
     if metadata.is_available() {
-        metadata
-            .dismiss_readiness_nag("steam_deck_caveats", 3650)
-            .map_err(|e| e.to_string())?;
+        if let Err(err) = metadata.dismiss_readiness_nag("steam_deck_caveats", 3650) {
+            tracing::warn!(
+                error = %err,
+                "failed to persist SQLite readiness nag dismissal for steam_deck_caveats after settings save"
+            );
+        }
     }
     Ok(())
 }

--- a/src/crosshook-native/src-tauri/src/commands/onboarding.rs
+++ b/src/crosshook-native/src-tauri/src/commands/onboarding.rs
@@ -41,13 +41,8 @@ pub fn check_generalized_readiness(
     let settings = store.load().map_err(|e| e.to_string())?;
     let catalog = global_readiness_catalog();
     let mut result = eval_generalized_readiness(catalog);
-    apply_install_nag_dismissal(&mut result, &settings.install_nag_dismissed_at);
-    apply_steam_deck_caveats_dismissal(&mut result, &settings.steam_deck_caveats_dismissed_at);
+    // Persist probe-derived snapshot before dismissal overlays mutate the IPC payload.
     if metadata.is_available() {
-        let dismissed = metadata
-            .get_dismissed_readiness_nags()
-            .map_err(|e| e.to_string())?;
-        apply_readiness_nag_dismissals(&mut result, &dismissed);
         metadata
             .upsert_host_readiness_snapshot(
                 &result.tool_checks,
@@ -57,6 +52,14 @@ pub fn check_generalized_readiness(
                 result.warnings,
             )
             .map_err(|e| e.to_string())?;
+    }
+    apply_install_nag_dismissal(&mut result, &settings.install_nag_dismissed_at);
+    apply_steam_deck_caveats_dismissal(&mut result, &settings.steam_deck_caveats_dismissed_at);
+    if metadata.is_available() {
+        let dismissed = metadata
+            .get_dismissed_readiness_nags()
+            .map_err(|e| e.to_string())?;
+        apply_readiness_nag_dismissals(&mut result, &dismissed);
     }
     for issue in &mut result.checks {
         issue.path = sanitize_display_path(&issue.path);

--- a/src/crosshook-native/src-tauri/src/commands/onboarding.rs
+++ b/src/crosshook-native/src-tauri/src/commands/onboarding.rs
@@ -8,6 +8,7 @@ use crosshook_core::onboarding::{
     global_readiness_catalog, ReadinessCheckResult, TrainerGuidanceContent, TrainerGuidanceEntry,
 };
 use crosshook_core::settings::SettingsStore;
+use std::convert::Infallible;
 use tauri::State;
 
 use super::shared::sanitize_display_path;
@@ -89,17 +90,20 @@ pub fn dismiss_umu_install_nag(
     store: State<'_, SettingsStore>,
     metadata: State<'_, MetadataStore>,
 ) -> Result<(), String> {
+    // Persist settings first so we never record metadata dismissal without the
+    // legacy settings.toml timestamp (used by check_readiness / check_generalized_readiness).
+    store
+        .update(|settings| {
+            settings.install_nag_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
+            Ok::<(), Infallible>(())
+        })
+        .map_err(|e| e.to_string())?
+        .unwrap();
     if metadata.is_available() {
         metadata
             .dismiss_readiness_nag("umu_run", 3650)
             .map_err(|e| e.to_string())?;
     }
-    store
-        .update(|settings| {
-            settings.install_nag_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
-            Ok::<(), String>(())
-        })
-        .map_err(|e| e.to_string())??;
     Ok(())
 }
 
@@ -108,17 +112,18 @@ pub fn dismiss_steam_deck_caveats(
     store: State<'_, SettingsStore>,
     metadata: State<'_, MetadataStore>,
 ) -> Result<(), String> {
+    store
+        .update(|settings| {
+            settings.steam_deck_caveats_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
+            Ok::<(), Infallible>(())
+        })
+        .map_err(|e| e.to_string())?
+        .unwrap();
     if metadata.is_available() {
         metadata
             .dismiss_readiness_nag("steam_deck_caveats", 3650)
             .map_err(|e| e.to_string())?;
     }
-    store
-        .update(|settings| {
-            settings.steam_deck_caveats_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
-            Ok::<(), String>(())
-        })
-        .map_err(|e| e.to_string())??;
     Ok(())
 }
 
@@ -199,6 +204,7 @@ pub fn get_trainer_guidance() -> TrainerGuidanceContent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::Infallible;
 
     #[test]
     fn command_signatures_match_expected_ipc_contract() {
@@ -256,7 +262,7 @@ mod tests {
         store
             .update(|settings| {
                 settings.install_nag_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
-                Ok::<(), String>(())
+                Ok::<(), Infallible>(())
             })
             .unwrap()
             .unwrap();
@@ -289,7 +295,7 @@ mod tests {
         store
             .update(|settings| {
                 settings.steam_deck_caveats_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
-                Ok::<(), String>(())
+                Ok::<(), Infallible>(())
             })
             .unwrap()
             .unwrap();

--- a/src/crosshook-native/src-tauri/src/commands/onboarding.rs
+++ b/src/crosshook-native/src-tauri/src/commands/onboarding.rs
@@ -1,7 +1,11 @@
-use crosshook_core::onboarding::readiness::apply_steam_deck_caveats_dismissal;
+use crosshook_core::metadata::MetadataStore;
+use crosshook_core::onboarding::readiness::{
+    apply_install_nag_dismissal, apply_readiness_nag_dismissals,
+    apply_steam_deck_caveats_dismissal, check_generalized_readiness as eval_generalized_readiness,
+    check_system_readiness,
+};
 use crosshook_core::onboarding::{
-    apply_install_nag_dismissal, check_system_readiness, ReadinessCheckResult,
-    TrainerGuidanceContent, TrainerGuidanceEntry,
+    global_readiness_catalog, ReadinessCheckResult, TrainerGuidanceContent, TrainerGuidanceEntry,
 };
 use crosshook_core::settings::SettingsStore;
 use tauri::State;
@@ -9,11 +13,51 @@ use tauri::State;
 use super::shared::sanitize_display_path;
 
 #[tauri::command]
-pub fn check_readiness(store: State<'_, SettingsStore>) -> Result<ReadinessCheckResult, String> {
+pub fn check_readiness(
+    store: State<'_, SettingsStore>,
+    metadata: State<'_, MetadataStore>,
+) -> Result<ReadinessCheckResult, String> {
     let settings = store.load().map_err(|e| e.to_string())?;
     let mut result = check_system_readiness();
     apply_install_nag_dismissal(&mut result, &settings.install_nag_dismissed_at);
     apply_steam_deck_caveats_dismissal(&mut result, &settings.steam_deck_caveats_dismissed_at);
+    if metadata.is_available() {
+        let dismissed = metadata
+            .get_dismissed_readiness_nags()
+            .map_err(|e| e.to_string())?;
+        apply_readiness_nag_dismissals(&mut result, &dismissed);
+    }
+    for issue in &mut result.checks {
+        issue.path = sanitize_display_path(&issue.path);
+    }
+    Ok(result)
+}
+
+#[tauri::command]
+pub fn check_generalized_readiness(
+    store: State<'_, SettingsStore>,
+    metadata: State<'_, MetadataStore>,
+) -> Result<ReadinessCheckResult, String> {
+    let settings = store.load().map_err(|e| e.to_string())?;
+    let catalog = global_readiness_catalog();
+    let mut result = eval_generalized_readiness(catalog);
+    apply_install_nag_dismissal(&mut result, &settings.install_nag_dismissed_at);
+    apply_steam_deck_caveats_dismissal(&mut result, &settings.steam_deck_caveats_dismissed_at);
+    if metadata.is_available() {
+        let dismissed = metadata
+            .get_dismissed_readiness_nags()
+            .map_err(|e| e.to_string())?;
+        apply_readiness_nag_dismissals(&mut result, &dismissed);
+        metadata
+            .upsert_host_readiness_snapshot(
+                &result.tool_checks,
+                &result.detected_distro_family,
+                result.all_passed,
+                result.critical_failures,
+                result.warnings,
+            )
+            .map_err(|e| e.to_string())?;
+    }
     for issue in &mut result.checks {
         issue.path = sanitize_display_path(&issue.path);
     }
@@ -28,23 +72,61 @@ pub fn dismiss_onboarding(store: State<'_, SettingsStore>) -> Result<(), String>
 }
 
 #[tauri::command]
-pub fn dismiss_umu_install_nag(store: State<'_, SettingsStore>) -> Result<(), String> {
+pub fn dismiss_umu_install_nag(
+    store: State<'_, SettingsStore>,
+    metadata: State<'_, MetadataStore>,
+) -> Result<(), String> {
+    if metadata.is_available() {
+        metadata
+            .dismiss_readiness_nag("umu_run", 3650)
+            .map_err(|e| e.to_string())?;
+    }
     store
         .update(|settings| {
             settings.install_nag_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
             Ok::<(), String>(())
         })
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())??;
+    Ok(())
 }
 
 #[tauri::command]
-pub fn dismiss_steam_deck_caveats(store: State<'_, SettingsStore>) -> Result<(), String> {
+pub fn dismiss_steam_deck_caveats(
+    store: State<'_, SettingsStore>,
+    metadata: State<'_, MetadataStore>,
+) -> Result<(), String> {
+    if metadata.is_available() {
+        metadata
+            .dismiss_readiness_nag("steam_deck_caveats", 3650)
+            .map_err(|e| e.to_string())?;
+    }
     store
         .update(|settings| {
             settings.steam_deck_caveats_dismissed_at = Some(chrono::Utc::now().to_rfc3339());
             Ok::<(), String>(())
         })
-        .map_err(|e| e.to_string())?
+        .map_err(|e| e.to_string())??;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn dismiss_readiness_nag(
+    metadata: State<'_, MetadataStore>,
+    tool_id: String,
+    ttl_days: Option<u32>,
+) -> Result<(), String> {
+    if !metadata.is_available() {
+        return Ok(());
+    }
+    let catalog = global_readiness_catalog();
+    if catalog.find_by_id(&tool_id).is_none() {
+        return Err(format!(
+            "unknown readiness tool_id: {tool_id}. Use a tool id from the host readiness catalog."
+        ));
+    }
+    metadata
+        .dismiss_readiness_nag(&tool_id, ttl_days.unwrap_or(90))
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -109,11 +191,23 @@ mod tests {
 
     #[test]
     fn command_signatures_match_expected_ipc_contract() {
-        let _ =
-            check_readiness as fn(State<'_, SettingsStore>) -> Result<ReadinessCheckResult, String>;
+        let _ = check_readiness
+            as fn(
+                State<'_, SettingsStore>,
+                State<'_, MetadataStore>,
+            ) -> Result<ReadinessCheckResult, String>;
+        let _ = check_generalized_readiness
+            as fn(
+                State<'_, SettingsStore>,
+                State<'_, MetadataStore>,
+            ) -> Result<ReadinessCheckResult, String>;
         let _ = dismiss_onboarding as fn(State<'_, SettingsStore>) -> Result<(), String>;
-        let _ = dismiss_umu_install_nag as fn(State<'_, SettingsStore>) -> Result<(), String>;
-        let _ = dismiss_steam_deck_caveats as fn(State<'_, SettingsStore>) -> Result<(), String>;
+        let _ = dismiss_umu_install_nag
+            as fn(State<'_, SettingsStore>, State<'_, MetadataStore>) -> Result<(), String>;
+        let _ = dismiss_steam_deck_caveats
+            as fn(State<'_, SettingsStore>, State<'_, MetadataStore>) -> Result<(), String>;
+        let _ = dismiss_readiness_nag
+            as fn(State<'_, MetadataStore>, String, Option<u32>) -> Result<(), String>;
         let _ = get_trainer_guidance as fn() -> TrainerGuidanceContent;
     }
 
@@ -144,7 +238,6 @@ mod tests {
             "dismiss_umu_install_nag must persist a non-None timestamp"
         );
 
-        // Onboarding completion is independent of the install-nag dismissal
         assert!(
             !reloaded.onboarding_completed,
             "install-nag dismissal must not affect onboarding_completed"
@@ -178,7 +271,6 @@ mod tests {
             "dismiss_steam_deck_caveats must persist a non-None timestamp"
         );
 
-        // Onboarding completion is independent of the caveats dismissal
         assert!(
             !reloaded.onboarding_completed,
             "caveats dismissal must not affect onboarding_completed"
@@ -192,14 +284,12 @@ mod tests {
         use crosshook_core::onboarding::SteamDeckCaveats;
 
         let mut result = crosshook_core::onboarding::check_system_readiness();
-        // Manually inject a caveats payload to simulate the Steam Deck path.
         result.steam_deck_caveats = Some(SteamDeckCaveats {
             description: "test caveats".to_string(),
             items: vec!["caveat one".to_string()],
             docs_url: "https://example.com".to_string(),
         });
 
-        // A non-None dismissal timestamp must clear the payload.
         let dismissed_at = Some("2026-04-15T12:00:00Z".to_string());
         apply_steam_deck_caveats_dismissal(&mut result, &dismissed_at);
         assert!(
@@ -207,7 +297,6 @@ mod tests {
             "apply_steam_deck_caveats_dismissal must clear steam_deck_caveats when dismissed"
         );
 
-        // A None timestamp must leave the payload untouched.
         result.steam_deck_caveats = Some(SteamDeckCaveats {
             description: "test caveats".to_string(),
             items: vec!["caveat one".to_string()],

--- a/src/crosshook-native/src-tauri/src/lib.rs
+++ b/src/crosshook-native/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use crosshook_core::launch::{initialize_catalog, load_catalog};
 use crosshook_core::logging;
 use crosshook_core::metadata::MetadataStore;
 use crosshook_core::offline::{initialize_trainer_type_catalog, load_trainer_type_catalog};
+use crosshook_core::onboarding::{initialize_readiness_catalog, load_readiness_catalog};
 use crosshook_core::platform::override_xdg_for_flatpak_host_access;
 use crosshook_core::profile::ProfileStore;
 use crosshook_core::settings::{AppSettingsData, RecentFilesStore, SettingsStore};
@@ -129,6 +130,9 @@ pub fn run() {
     let trainer_type_catalog = load_trainer_type_catalog(Some(&settings_store.base_path), &[]);
     initialize_trainer_type_catalog(trainer_type_catalog);
 
+    let readiness_catalog = load_readiness_catalog(Some(&settings_store.base_path));
+    initialize_readiness_catalog(readiness_catalog);
+
     tauri::Builder::default()
         .setup({
             let profile_store = profile_store.clone();
@@ -162,6 +166,30 @@ pub fn run() {
                         catalog.catalog_version,
                     ) {
                         tracing::warn!(%error, "failed to persist optimization catalog to metadata db");
+                    }
+                }
+
+                {
+                    let rc = crosshook_core::onboarding::global_readiness_catalog();
+                    if let Err(error) = metadata_for_startup.persist_readiness_catalog(
+                        &rc.entries,
+                        rc.catalog_version,
+                    ) {
+                        tracing::warn!(%error, "failed to persist readiness catalog to metadata db");
+                    }
+                }
+
+                {
+                    let settings = settings_store
+                        .load()
+                        .unwrap_or_else(|_| AppSettingsData::default());
+                    if metadata_for_startup.is_available() {
+                        if settings.install_nag_dismissed_at.is_some() {
+                            let _ = metadata_for_startup.dismiss_readiness_nag("umu_run", 36500);
+                        }
+                        if settings.steam_deck_caveats_dismissed_at.is_some() {
+                            let _ = metadata_for_startup.dismiss_readiness_nag("steam_deck_caveats", 36500);
+                        }
                     }
                 }
 
@@ -391,9 +419,11 @@ pub fn run() {
             commands::version::set_trainer_version,
             commands::version::acknowledge_version_change,
             commands::onboarding::check_readiness,
+            commands::onboarding::check_generalized_readiness,
             commands::onboarding::dismiss_onboarding,
             commands::onboarding::dismiss_umu_install_nag,
             commands::onboarding::dismiss_steam_deck_caveats,
+            commands::onboarding::dismiss_readiness_nag,
             commands::onboarding::get_trainer_guidance,
             commands::catalog::get_optimization_catalog,
             commands::catalog::get_mangohud_presets,

--- a/src/crosshook-native/src/components/LaunchPanel.tsx
+++ b/src/crosshook-native/src/components/LaunchPanel.tsx
@@ -21,9 +21,13 @@ import type { GameProfile } from '../types/profile';
 import { copyToClipboard } from '../utils/clipboard';
 import { LAUNCH_PANEL_ACTION_BUTTON_STYLE } from '../utils/launchPanelActionButtonStyle';
 import { sortIssuesBySeverity } from '../utils/mapValidationToNode';
+import { InfoCircleIcon } from './icons/SidebarIcons';
 import { LaunchPipeline } from './LaunchPipeline';
 import { CollapsibleSection } from './ui/CollapsibleSection';
 import '../styles/preview.css';
+
+const UMU_DATABASE_MISSING_HINT =
+  'umu has no known entry for this app id in the current umu database. The database only tracks titles needing protonfixes — most titles work fine without an entry.';
 
 /* ───────── Focus-trap helpers (mirrors ProfileReviewModal) ───────── */
 
@@ -456,9 +460,21 @@ function PreviewModal({ preview, profileId, onClose, onLaunch }: PreviewModalPro
                           umu protonfix coverage: <code>{preview.umu_decision.csv_coverage}</code>
                         </div>
                         {preview.umu_decision.will_use_umu && preview.umu_decision.csv_coverage === 'missing' ? (
-                          <div className="crosshook-preview-modal__umu-decision-info" style={{ marginTop: 6 }}>
-                            ℹ umu has no known entry for this app id in the current umu database. The database only
-                            tracks titles needing protonfixes — most titles work fine without an entry.
+                          <div
+                            className="crosshook-preview-modal__umu-decision-info"
+                            style={{ marginTop: 6, display: 'flex', alignItems: 'flex-start', gap: 8 }}
+                          >
+                            <InfoCircleIcon
+                              width={14}
+                              height={14}
+                              aria-hidden
+                              style={{
+                                flexShrink: 0,
+                                marginTop: 2,
+                                color: 'var(--crosshook-color-info)',
+                              }}
+                            />
+                            <span>{UMU_DATABASE_MISSING_HINT}</span>
                           </div>
                         ) : null}
                       </div>

--- a/src/crosshook-native/src/components/LaunchPanel.tsx
+++ b/src/crosshook-native/src/components/LaunchPanel.tsx
@@ -460,19 +460,12 @@ function PreviewModal({ preview, profileId, onClose, onLaunch }: PreviewModalPro
                           umu protonfix coverage: <code>{preview.umu_decision.csv_coverage}</code>
                         </div>
                         {preview.umu_decision.will_use_umu && preview.umu_decision.csv_coverage === 'missing' ? (
-                          <div
-                            className="crosshook-preview-modal__umu-decision-info"
-                            style={{ marginTop: 6, display: 'flex', alignItems: 'flex-start', gap: 8 }}
-                          >
+                          <div className="crosshook-preview-modal__umu-decision-info">
                             <InfoCircleIcon
+                              className="crosshook-preview-modal__umu-decision-info-icon"
                               width={14}
                               height={14}
                               aria-hidden
-                              style={{
-                                flexShrink: 0,
-                                marginTop: 2,
-                                color: 'var(--crosshook-color-info)',
-                              }}
                             />
                             <span>{UMU_DATABASE_MISSING_HINT}</span>
                           </div>

--- a/src/crosshook-native/src/components/OnboardingWizard.tsx
+++ b/src/crosshook-native/src/components/OnboardingWizard.tsx
@@ -115,6 +115,7 @@ export function OnboardingWizard({ open, mode = 'create', onComplete, onDismiss 
     dismiss,
     dismissUmuInstallNag,
     dismissSteamDeckCaveats,
+    dismissReadinessNag,
     setCompletedProfileName,
   } = useOnboarding();
 
@@ -476,6 +477,7 @@ export function OnboardingWizard({ open, mode = 'create', onComplete, onDismiss 
                 onDismissUmuInstallNag={() => void dismissUmuInstallNag()}
                 steamDeckCaveats={steamDeckCaveats}
                 onDismissSteamDeckCaveats={() => void dismissSteamDeckCaveats()}
+                onDismissReadinessNag={(toolId) => void dismissReadinessNag(toolId)}
               />
             </section>
           )}

--- a/src/crosshook-native/src/components/PinnedProfilesStrip.tsx
+++ b/src/crosshook-native/src/components/PinnedProfilesStrip.tsx
@@ -1,3 +1,5 @@
+import { InfoCircleIcon } from './icons/SidebarIcons';
+
 interface PinnedProfilesStripProps {
   favoriteProfiles: string[];
   selectedProfile: string;
@@ -38,7 +40,7 @@ export function PinnedProfilesStrip({
                     title="umu has no known entry for this app id in the current umu database. The database only tracks titles needing protonfixes — most titles work fine without an entry."
                     aria-label="no umu-database protonfix row for this profile"
                   >
-                    ℹ
+                    <InfoCircleIcon width={14} height={14} />
                   </span>
                 ) : null}
               </button>

--- a/src/crosshook-native/src/components/ReadinessChecklist.tsx
+++ b/src/crosshook-native/src/components/ReadinessChecklist.tsx
@@ -1,4 +1,9 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { open as openUrl } from '@/lib/plugin-stubs/shell';
 import type { HealthIssue, HealthIssueSeverity } from '../types/health';
+import type { HostToolCheckResult } from '../types/onboarding';
+import { getHostToolTooltipContent } from '../utils/hostReadinessTooltips';
+import { InfoTooltip } from './ui/InfoTooltip';
 
 interface ReadinessChecklistProps {
   checks: HealthIssue[];
@@ -65,6 +70,224 @@ function CheckCard({ check }: CheckCardProps) {
       </div>
       {check.remediation ? <div className="crosshook-readiness-checklist__remediation">{check.remediation}</div> : null}
     </div>
+  );
+}
+
+const HOST_TOOL_CATEGORY_ORDER = ['runtime', 'performance', 'overlay', 'compatibility', 'prefix_tools'] as const;
+
+function formatHostToolCategoryLabel(category: string): string {
+  const key = category.trim().toLowerCase();
+  switch (key) {
+    case 'runtime':
+      return 'Runtime';
+    case 'performance':
+      return 'Performance';
+    case 'overlay':
+      return 'Overlay';
+    case 'compatibility':
+      return 'Compatibility';
+    case 'prefix_tools':
+      return 'Prefix tools';
+    default:
+      return category || 'Other';
+  }
+}
+
+function groupHostToolsByCategory(
+  toolChecks: HostToolCheckResult[]
+): { label: string; tools: HostToolCheckResult[] }[] {
+  const map = new Map<string, HostToolCheckResult[]>();
+  for (const t of toolChecks) {
+    const key = (t.category || 'other').toLowerCase();
+    let bucket = map.get(key);
+    if (bucket === undefined) {
+      bucket = [];
+      map.set(key, bucket);
+    }
+    bucket.push(t);
+  }
+  const keys = new Set(map.keys());
+  const ordered: string[] = [];
+  for (const k of HOST_TOOL_CATEGORY_ORDER) {
+    if (keys.has(k)) ordered.push(k);
+  }
+  const rest = [...keys]
+    .filter((k) => !HOST_TOOL_CATEGORY_ORDER.includes(k as (typeof HOST_TOOL_CATEGORY_ORDER)[number]))
+    .sort((a, b) => a.localeCompare(b));
+  ordered.push(...rest);
+  return ordered.map((key) => ({
+    label: formatHostToolCategoryLabel(key === 'other' ? 'other' : key),
+    tools: map.get(key) ?? [],
+  }));
+}
+
+export interface HostToolsReadinessSectionProps {
+  toolChecks: HostToolCheckResult[];
+  detectedDistroFamily: string;
+  /** Clears install nag for this tool in SQLite (TTL). */
+  onDismissReadinessNag?: (toolId: string) => void;
+}
+
+/**
+ * Host catalog tools from generalized readiness — grouped by category with
+ * copy-command / docs / dismiss when Flatpak guidance is present.
+ */
+export function HostToolsReadinessSection({
+  toolChecks,
+  detectedDistroFamily,
+  onDismissReadinessNag,
+}: HostToolsReadinessSectionProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [copiedToolId, setCopiedToolId] = useState<string | null>(null);
+  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyResetTimerRef.current !== null) {
+        clearTimeout(copyResetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyCommand = useCallback(async (toolId: string, command: string) => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopiedToolId(toolId);
+      if (copyResetTimerRef.current !== null) {
+        clearTimeout(copyResetTimerRef.current);
+      }
+      copyResetTimerRef.current = setTimeout(() => {
+        copyResetTimerRef.current = null;
+        setCopiedToolId(null);
+      }, 2000);
+    } catch {
+      // Clipboard unavailable
+    }
+  }, []);
+
+  if (toolChecks.length === 0) {
+    return null;
+  }
+
+  const groups = groupHostToolsByCategory(toolChecks);
+
+  return (
+    <section aria-label="Host tools" style={{ marginTop: 16 }}>
+      <div className="crosshook-install-section-title">Host Tools</div>
+      {detectedDistroFamily ? (
+        <p className="crosshook-help-text" style={{ marginBottom: 8 }}>
+          Detected host: <strong>{detectedDistroFamily}</strong>
+        </p>
+      ) : null}
+      {groups.map(({ label, tools }) => (
+        <div key={label} style={{ marginBottom: 12 }}>
+          <div className="crosshook-help-text" style={{ fontWeight: 600, marginBottom: 6 }}>
+            {label}
+          </div>
+          <ul className="crosshook-onboarding-wizard__review-list">
+            {tools.map((tool) => {
+              const variant = tool.is_available ? 'found' : tool.is_required ? 'not-found' : 'ambiguous';
+              const icon = tool.is_available ? '✓' : tool.is_required ? '✕' : '⚠';
+              const badge = tool.is_available ? 'OK' : tool.is_required ? 'Missing' : 'Optional';
+              const guidance = tool.install_guidance;
+              const hasGuidance = guidance != null && guidance.command.trim() !== '';
+              const docs = (tool.docs_url ?? '').trim();
+              const expanded = expandedId === tool.tool_id;
+
+              return (
+                <li
+                  key={tool.tool_id}
+                  className="crosshook-onboarding-wizard__review-row"
+                  style={{ flexDirection: 'column', alignItems: 'stretch' }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, width: '100%' }}>
+                    <span
+                      aria-hidden="true"
+                      className={`crosshook-auto-populate__field-state--${variant}`}
+                      style={{ minWidth: '1.25rem' }}
+                    >
+                      {icon}
+                    </span>
+                    <span
+                      className="crosshook-onboarding-wizard__review-label"
+                      style={{ flex: 1, display: 'inline-flex', alignItems: 'center', gap: 6 }}
+                    >
+                      {tool.display_name}
+                      <InfoTooltip content={getHostToolTooltipContent(tool.tool_id)} size={14} />
+                    </span>
+                    <span
+                      className={`crosshook-readiness-checklist__badge crosshook-auto-populate__field-state--${variant}`}
+                    >
+                      {badge}
+                    </span>
+                    {hasGuidance ? (
+                      <button
+                        type="button"
+                        className="crosshook-button crosshook-button--ghost crosshook-button--sm"
+                        aria-expanded={expanded}
+                        onClick={() => setExpandedId((id) => (id === tool.tool_id ? null : tool.tool_id))}
+                      >
+                        {expanded ? 'Hide' : 'Install help'}
+                      </button>
+                    ) : null}
+                  </div>
+                  {hasGuidance && expanded ? (
+                    <div
+                      className="crosshook-onboarding-wizard__umu-guidance"
+                      style={{ marginTop: 8, marginLeft: '1.75rem' }}
+                    >
+                      <p className="crosshook-help-text" style={{ marginBottom: 6 }}>
+                        <span className="crosshook-help-text" style={{ fontWeight: 600 }}>
+                          {guidance.distro_family}:{' '}
+                        </span>
+                        <code style={{ wordBreak: 'break-all' }}>{guidance.command}</code>
+                      </p>
+                      {guidance.alternatives.trim() ? (
+                        <p className="crosshook-help-text" style={{ marginBottom: 8 }}>
+                          {guidance.alternatives}
+                        </p>
+                      ) : null}
+                      <div className="crosshook-onboarding-wizard__umu-guidance-actions">
+                        <button
+                          type="button"
+                          className="crosshook-button crosshook-button--secondary crosshook-button--sm"
+                          onClick={() => void handleCopyCommand(tool.tool_id, guidance.command)}
+                          title={guidance.command}
+                        >
+                          {copiedToolId === tool.tool_id ? 'Copied!' : 'Copy command'}
+                        </button>
+                        {docs ? (
+                          <button
+                            type="button"
+                            className="crosshook-button crosshook-button--secondary crosshook-button--sm"
+                            onClick={() => {
+                              void openUrl(docs).catch((err) => {
+                                console.error('Failed to open host tool docs', err);
+                              });
+                            }}
+                          >
+                            Open docs
+                          </button>
+                        ) : null}
+                        {onDismissReadinessNag ? (
+                          <button
+                            type="button"
+                            className="crosshook-button crosshook-button--ghost crosshook-button--sm"
+                            onClick={() => onDismissReadinessNag(tool.tool_id)}
+                          >
+                            Dismiss reminder
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </section>
   );
 }
 

--- a/src/crosshook-native/src/components/ReadinessChecklist.tsx
+++ b/src/crosshook-native/src/components/ReadinessChecklist.tsx
@@ -122,17 +122,17 @@ function groupHostToolsByCategory(
 }
 
 function hasExpandableGuidance(tool: HostToolCheckResult): boolean {
+  if ((tool.docs_url ?? '').trim() !== '') {
+    return true;
+  }
   const guidance = tool.install_guidance;
-  if (guidance == null) {
-    return false;
-  }
-  if (guidance.command.trim() !== '') {
+  if ((guidance?.command ?? '').trim() !== '') {
     return true;
   }
-  if (guidance.alternatives.trim() !== '') {
+  if ((guidance?.alternatives ?? '').trim() !== '') {
     return true;
   }
-  return (tool.docs_url ?? '').trim() !== '';
+  return false;
 }
 
 export interface HostToolsReadinessSectionProps {

--- a/src/crosshook-native/src/components/ReadinessChecklist.tsx
+++ b/src/crosshook-native/src/components/ReadinessChecklist.tsx
@@ -121,6 +121,20 @@ function groupHostToolsByCategory(
   }));
 }
 
+function hasExpandableGuidance(tool: HostToolCheckResult): boolean {
+  const guidance = tool.install_guidance;
+  if (guidance == null) {
+    return false;
+  }
+  if (guidance.command.trim() !== '') {
+    return true;
+  }
+  if (guidance.alternatives.trim() !== '') {
+    return true;
+  }
+  return (tool.docs_url ?? '').trim() !== '';
+}
+
 export interface HostToolsReadinessSectionProps {
   toolChecks: HostToolCheckResult[];
   detectedDistroFamily: string;
@@ -190,8 +204,12 @@ export function HostToolsReadinessSection({
               const icon = tool.is_available ? '✓' : tool.is_required ? '✕' : '⚠';
               const badge = tool.is_available ? 'OK' : tool.is_required ? 'Missing' : 'Optional';
               const guidance = tool.install_guidance;
-              const hasGuidance = guidance != null && guidance.command.trim() !== '';
               const docs = (tool.docs_url ?? '').trim();
+              const hasGuidance = hasExpandableGuidance(tool);
+              const hasCommand = guidance != null && guidance.command.trim() !== '';
+              const command = guidance?.command ?? '';
+              const distroFamily = guidance?.distro_family ?? '';
+              const alternatives = guidance?.alternatives.trim() ?? '';
               const expanded = expandedId === tool.tool_id;
 
               return (
@@ -236,26 +254,30 @@ export function HostToolsReadinessSection({
                       className="crosshook-onboarding-wizard__umu-guidance"
                       style={{ marginTop: 8, marginLeft: '1.75rem' }}
                     >
-                      <p className="crosshook-help-text" style={{ marginBottom: 6 }}>
-                        <span className="crosshook-help-text" style={{ fontWeight: 600 }}>
-                          {guidance.distro_family}:{' '}
-                        </span>
-                        <code style={{ wordBreak: 'break-all' }}>{guidance.command}</code>
-                      </p>
-                      {guidance.alternatives.trim() ? (
+                      {hasCommand ? (
+                        <p className="crosshook-help-text" style={{ marginBottom: 6 }}>
+                          <span className="crosshook-help-text" style={{ fontWeight: 600 }}>
+                            {distroFamily}:{' '}
+                          </span>
+                          <code style={{ wordBreak: 'break-all' }}>{command}</code>
+                        </p>
+                      ) : null}
+                      {alternatives ? (
                         <p className="crosshook-help-text" style={{ marginBottom: 8 }}>
-                          {guidance.alternatives}
+                          {alternatives}
                         </p>
                       ) : null}
                       <div className="crosshook-onboarding-wizard__umu-guidance-actions">
-                        <button
-                          type="button"
-                          className="crosshook-button crosshook-button--secondary crosshook-button--sm"
-                          onClick={() => void handleCopyCommand(tool.tool_id, guidance.command)}
-                          title={guidance.command}
-                        >
-                          {copiedToolId === tool.tool_id ? 'Copied!' : 'Copy command'}
-                        </button>
+                        {hasCommand ? (
+                          <button
+                            type="button"
+                            className="crosshook-button crosshook-button--secondary crosshook-button--sm"
+                            onClick={() => void handleCopyCommand(tool.tool_id, command)}
+                            title={command}
+                          >
+                            {copiedToolId === tool.tool_id ? 'Copied!' : 'Copy command'}
+                          </button>
+                        ) : null}
                         {docs ? (
                           <button
                             type="button"

--- a/src/crosshook-native/src/components/profile-sections/RuntimeSection.tsx
+++ b/src/crosshook-native/src/components/profile-sections/RuntimeSection.tsx
@@ -9,6 +9,7 @@ import { deriveSteamClientInstallPath } from '../../utils/steam';
 import AutoPopulate from '../AutoPopulate';
 import type { ProtonInstallOption } from '../ProfileFormSections';
 import { FieldRow, LauncherMetadataFields, OptionalSection, ProtonPathField } from '../ProfileFormSections';
+import { InfoTooltip } from '../ui/InfoTooltip';
 import { ThemedSelect } from '../ui/ThemedSelect';
 
 function resolveUmuAppId(profile: GameProfile): string {
@@ -247,13 +248,11 @@ export function RuntimeSection({
               <label className="crosshook-label" htmlFor="profile-umu-preference" id="profile-umu-preference-label">
                 Runner
                 {showUmuCoverageNote ? (
-                  <span
-                    className="crosshook-runner-coverage-info"
-                    title={`umu has no known entry for Steam app id ${umuAppId} in the current umu database. The database only tracks titles needing protonfixes — most titles work fine without an entry.`}
-                    aria-label={`no umu-database protonfix row for app id ${umuAppId}`}
-                    role="img"
-                  >
-                    {' ℹ'}
+                  <span className="crosshook-runner-coverage-info">
+                    <InfoTooltip
+                      content={`umu has no known entry for Steam app id ${umuAppId} in the current umu database. The database only tracks titles needing protonfixes — most titles work fine without an entry.`}
+                      size={14}
+                    />
                   </span>
                 ) : null}
               </label>
@@ -283,7 +282,7 @@ export function RuntimeSection({
               </p>
               {showUmuCoverageNote ? (
                 <p className="crosshook-help-text crosshook-runner-coverage-info__hint">
-                  ℹ umu has no known entry for this app id in the current umu database. The database only tracks titles
+                  umu has no known entry for this app id in the current umu database. The database only tracks titles
                   needing protonfixes — most titles work fine without an entry.
                 </p>
               ) : null}

--- a/src/crosshook-native/src/components/wizard/WizardReviewSummary.tsx
+++ b/src/crosshook-native/src/components/wizard/WizardReviewSummary.tsx
@@ -154,7 +154,7 @@ export function WizardReviewSummary({
               <HostToolsReadinessSection
                 toolChecks={readinessResult.tool_checks ?? []}
                 detectedDistroFamily={readinessResult.detected_distro_family ?? ''}
-                onDismissReadinessNag={onDismissReadinessNag ? (id) => onDismissReadinessNag(id) : undefined}
+                onDismissReadinessNag={onDismissReadinessNag}
               />
             ) : null}
           </>

--- a/src/crosshook-native/src/components/wizard/WizardReviewSummary.tsx
+++ b/src/crosshook-native/src/components/wizard/WizardReviewSummary.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { open as openUrl } from '@/lib/plugin-stubs/shell';
 import type { ReadinessCheckResult, SteamDeckCaveats, UmuInstallGuidance } from '../../types/onboarding';
+import { HostToolsReadinessSection } from '../ReadinessChecklist';
 import { resolveCheckColor, resolveCheckIcon } from './checkBadges';
 import type { WizardValidationResult } from './wizardValidation';
 
@@ -16,6 +17,8 @@ export interface WizardReviewSummaryProps {
   steamDeckCaveats?: SteamDeckCaveats | null;
   /** Called when the user dismisses Steam Deck caveats. Must persist dismissal via parent/hook. */
   onDismissSteamDeckCaveats?: () => void;
+  /** Per-tool readiness nag (host catalog tools). */
+  onDismissReadinessNag?: (toolId: string) => void;
 }
 
 /**
@@ -44,6 +47,7 @@ export function WizardReviewSummary({
   onDismissUmuInstallNag,
   steamDeckCaveats,
   onDismissSteamDeckCaveats,
+  onDismissReadinessNag,
 }: WizardReviewSummaryProps) {
   const [copied, setCopied] = useState(false);
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -146,6 +150,13 @@ export function WizardReviewSummary({
                 </li>
               ))}
             </ul>
+            {(readinessResult.tool_checks?.length ?? 0) > 0 ? (
+              <HostToolsReadinessSection
+                toolChecks={readinessResult.tool_checks ?? []}
+                detectedDistroFamily={readinessResult.detected_distro_family ?? ''}
+                onDismissReadinessNag={onDismissReadinessNag ? (id) => onDismissReadinessNag(id) : undefined}
+              />
+            ) : null}
           </>
         )}
 

--- a/src/crosshook-native/src/hooks/useOnboarding.ts
+++ b/src/crosshook-native/src/hooks/useOnboarding.ts
@@ -43,6 +43,8 @@ export interface UseOnboardingResult {
   steamDeckCaveats: SteamDeckCaveats | null;
   /** Persists the Steam Deck caveats dismissal via the backend and clears local caveats state. */
   dismissSteamDeckCaveats: () => Promise<void>;
+  /** Dismiss a per-tool readiness nag (SQLite TTL); clears local install guidance for that tool. */
+  dismissReadinessNag: (toolId: string, ttlDays?: number) => Promise<void>;
 }
 
 function deriveStatusText(stage: OnboardingWizardStage): string {
@@ -126,7 +128,7 @@ export function useOnboarding(): UseOnboardingResult {
   const runChecks = useCallback(async () => {
     setIsRunningChecks(true);
     try {
-      const result = await callCommand<ReadinessCheckResult>('check_readiness');
+      const result = await callCommand<ReadinessCheckResult>('check_generalized_readiness');
       setReadinessResult(result);
       setCheckError(null);
       setLastCheckedAt(new Date().toLocaleTimeString());
@@ -194,6 +196,29 @@ export function useOnboarding(): UseOnboardingResult {
     }
   }, []);
 
+  const dismissReadinessNag = useCallback(async (toolId: string, ttlDays?: number) => {
+    try {
+      await callCommand<void>('dismiss_readiness_nag', {
+        toolId,
+        ttlDays: ttlDays ?? null,
+      });
+      setCheckError(null);
+      setReadinessResult((prev) => {
+        if (prev == null) return null;
+        return {
+          ...prev,
+          tool_checks: (prev.tool_checks ?? []).map((t) =>
+            t.tool_id === toolId ? { ...t, install_guidance: null } : t
+          ),
+          umu_install_guidance: toolId === 'umu_run' ? null : prev.umu_install_guidance,
+          steam_deck_caveats: toolId === 'steam_deck_caveats' ? null : prev.steam_deck_caveats,
+        };
+      });
+    } catch (error) {
+      setCheckError(error instanceof Error ? error.message : 'Could not save readiness reminder preference.');
+    }
+  }, []);
+
   const reset = useCallback(() => {
     const initial = createInitialOnboardingState();
     setStage(initial.stage);
@@ -237,5 +262,6 @@ export function useOnboarding(): UseOnboardingResult {
     setCompletedProfileName: setLastCreatedProfileName,
     steamDeckCaveats,
     dismissSteamDeckCaveats,
+    dismissReadinessNag,
   };
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
@@ -55,39 +55,94 @@ function maybeSynthesizeOnboardingEvent(): void {
 // the second call from `registerOnboarding()` a no-op.
 maybeSynthesizeOnboardingEvent();
 
+function buildMockReadinessResult(): ReadinessCheckResult {
+  const store = getStore();
+  const toggles = getActiveToggles();
+  const dismissed = store.settings.install_nag_dismissed_at != null;
+  return {
+    checks: [],
+    all_passed: true,
+    critical_failures: 0,
+    warnings: 0,
+    umu_install_guidance: dismissed
+      ? null
+      : {
+          install_command: 'pipx install umu-launcher',
+          docs_url: 'https://github.com/Open-Wine-Components/umu-launcher',
+          description:
+            'Install umu-launcher on your host to enable improved Proton runtime bootstrapping for non-Steam launches.',
+        },
+    steam_deck_caveats:
+      toggles.showSteamDeckCaveats && store.settings.steam_deck_caveats_dismissed_at == null
+        ? {
+            description:
+              'CrossHook works on Steam Deck desktop mode today. In gaming mode you may hit these documented upstream issues on SteamOS 3.7+:',
+            items: [
+              'Black screen until Shader Pre-Caching completes — enable it in Steam Settings → Downloads → Shader Pre-Caching',
+              'Steam overlay can render below the game under gamescope + Flatpak',
+              'HDR + gamescope + Flatpak regression on SteamOS 3.7.13 (toggle HDR off if the screen tints or flickers)',
+            ],
+            docs_url: 'https://github.com/ValveSoftware/gamescope/issues',
+          }
+        : null,
+    tool_checks: [
+      {
+        tool_id: 'gamescope',
+        display_name: 'Gamescope',
+        is_available: false,
+        is_required: false,
+        category: 'performance',
+        docs_url: 'https://github.com/ValveSoftware/gamescope',
+        install_guidance: {
+          distro_family: 'Arch',
+          command: 'sudo pacman -S gamescope',
+          alternatives: 'Also available on the AUR as gamescope-git.',
+        },
+      },
+      {
+        tool_id: 'mangohud',
+        display_name: 'MangoHud',
+        is_available: true,
+        is_required: false,
+        category: 'overlay',
+        docs_url: 'https://github.com/flightlessmango/MangoHud',
+        install_guidance: null,
+      },
+      {
+        tool_id: 'game_performance',
+        display_name: 'game-performance',
+        is_available: false,
+        is_required: false,
+        category: 'performance',
+        docs_url: 'https://wiki.cachyos.org/',
+        install_guidance: {
+          distro_family: 'Arch',
+          command: 'sudo pacman -S game-performance',
+          alternatives: 'CachyOS package; on vanilla Arch use CachyOS repos or AUR if available.',
+        },
+      },
+      {
+        tool_id: 'gamemode',
+        display_name: 'GameMode',
+        is_available: true,
+        is_required: false,
+        category: 'performance',
+        docs_url: 'https://github.com/FeralInteractive/gamemode',
+        install_guidance: null,
+      },
+    ],
+    detected_distro_family: 'Arch',
+  };
+}
+
 export function registerOnboarding(map: Map<string, Handler>): void {
   maybeSynthesizeOnboardingEvent();
   map.set('check_readiness', async (): Promise<ReadinessCheckResult> => {
-    const store = getStore();
-    const toggles = getActiveToggles();
-    const dismissed = store.settings.install_nag_dismissed_at != null;
-    return {
-      checks: [],
-      all_passed: true,
-      critical_failures: 0,
-      warnings: 0,
-      umu_install_guidance: dismissed
-        ? null
-        : {
-            install_command: 'pipx install umu-launcher',
-            docs_url: 'https://github.com/Open-Wine-Components/umu-launcher',
-            description:
-              'Install umu-launcher on your host to enable improved Proton runtime bootstrapping for non-Steam launches.',
-          },
-      steam_deck_caveats:
-        toggles.showSteamDeckCaveats && store.settings.steam_deck_caveats_dismissed_at == null
-          ? {
-              description:
-                'CrossHook works on Steam Deck desktop mode today. In gaming mode you may hit these documented upstream issues on SteamOS 3.7+:',
-              items: [
-                'Black screen until Shader Pre-Caching completes — enable it in Steam Settings → Downloads → Shader Pre-Caching',
-                'Steam overlay can render below the game under gamescope + Flatpak',
-                'HDR + gamescope + Flatpak regression on SteamOS 3.7.13 (toggle HDR off if the screen tints or flickers)',
-              ],
-              docs_url: 'https://github.com/ValveSoftware/gamescope/issues',
-            }
-          : null,
-    };
+    return buildMockReadinessResult();
+  });
+
+  map.set('check_generalized_readiness', async (): Promise<ReadinessCheckResult> => {
+    return buildMockReadinessResult();
   });
 
   map.set('dismiss_onboarding', async (): Promise<null> => {
@@ -105,6 +160,10 @@ export function registerOnboarding(map: Map<string, Handler>): void {
 
   map.set('dismiss_steam_deck_caveats', async (): Promise<null> => {
     getStore().settings.steam_deck_caveats_dismissed_at = new Date().toISOString();
+    return null;
+  });
+
+  map.set('dismiss_readiness_nag', async (): Promise<null> => {
     return null;
   });
 

--- a/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
@@ -21,6 +21,18 @@ const ONBOARDING_EMIT_INITIAL_MS = 500;
 const ONBOARDING_EMIT_RETRY_MS = 200;
 const ONBOARDING_EMIT_MAX_ATTEMPTS = 25;
 
+interface DismissReadinessNagArgs {
+  toolId: string;
+}
+
+function isDismissReadinessNagArgs(value: unknown): value is DismissReadinessNagArgs {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as { toolId?: unknown };
+  return typeof candidate.toolId === 'string' && candidate.toolId.trim() !== '';
+}
+
 function maybeSynthesizeOnboardingEvent(): void {
   if (onboardingEventSynthesized) return;
   if (!getActiveToggles().showOnboarding) return;
@@ -59,6 +71,60 @@ function buildMockReadinessResult(): ReadinessCheckResult {
   const store = getStore();
   const toggles = getActiveToggles();
   const dismissed = store.settings.install_nag_dismissed_at != null;
+  const toolChecks: ReadinessCheckResult['tool_checks'] = [
+    {
+      tool_id: 'gamescope',
+      display_name: 'Gamescope',
+      is_available: false,
+      is_required: false,
+      category: 'performance',
+      docs_url: 'https://github.com/ValveSoftware/gamescope',
+      install_guidance: {
+        distro_family: 'Arch',
+        command: 'sudo pacman -S gamescope',
+        alternatives: 'Also available on the AUR as gamescope-git.',
+      },
+    },
+    {
+      tool_id: 'mangohud',
+      display_name: 'MangoHud',
+      is_available: true,
+      is_required: false,
+      category: 'overlay',
+      docs_url: 'https://github.com/flightlessmango/MangoHud',
+      install_guidance: null,
+    },
+    {
+      tool_id: 'game_performance',
+      display_name: 'game-performance',
+      is_available: false,
+      is_required: false,
+      category: 'performance',
+      docs_url: 'https://wiki.cachyos.org/',
+      install_guidance: {
+        distro_family: 'Arch',
+        command: 'sudo pacman -S game-performance',
+        alternatives: 'CachyOS package; on vanilla Arch use CachyOS repos or AUR if available.',
+      },
+    },
+    {
+      tool_id: 'gamemode',
+      display_name: 'GameMode',
+      is_available: true,
+      is_required: false,
+      category: 'performance',
+      docs_url: 'https://github.com/FeralInteractive/gamemode',
+      install_guidance: null,
+    },
+  ].map((tool) =>
+    store.dismissedReadinessToolIds.has(tool.tool_id)
+      ? {
+          ...tool,
+          install_guidance: null,
+        }
+      : tool
+  );
+
   return {
     checks: [],
     all_passed: true,
@@ -85,52 +151,7 @@ function buildMockReadinessResult(): ReadinessCheckResult {
             docs_url: 'https://github.com/ValveSoftware/gamescope/issues',
           }
         : null,
-    tool_checks: [
-      {
-        tool_id: 'gamescope',
-        display_name: 'Gamescope',
-        is_available: false,
-        is_required: false,
-        category: 'performance',
-        docs_url: 'https://github.com/ValveSoftware/gamescope',
-        install_guidance: {
-          distro_family: 'Arch',
-          command: 'sudo pacman -S gamescope',
-          alternatives: 'Also available on the AUR as gamescope-git.',
-        },
-      },
-      {
-        tool_id: 'mangohud',
-        display_name: 'MangoHud',
-        is_available: true,
-        is_required: false,
-        category: 'overlay',
-        docs_url: 'https://github.com/flightlessmango/MangoHud',
-        install_guidance: null,
-      },
-      {
-        tool_id: 'game_performance',
-        display_name: 'game-performance',
-        is_available: false,
-        is_required: false,
-        category: 'performance',
-        docs_url: 'https://wiki.cachyos.org/',
-        install_guidance: {
-          distro_family: 'Arch',
-          command: 'sudo pacman -S game-performance',
-          alternatives: 'CachyOS package; on vanilla Arch use CachyOS repos or AUR if available.',
-        },
-      },
-      {
-        tool_id: 'gamemode',
-        display_name: 'GameMode',
-        is_available: true,
-        is_required: false,
-        category: 'performance',
-        docs_url: 'https://github.com/FeralInteractive/gamemode',
-        install_guidance: null,
-      },
-    ],
+    tool_checks: toolChecks,
     detected_distro_family: 'Arch',
   };
 }
@@ -163,7 +184,11 @@ export function registerOnboarding(map: Map<string, Handler>): void {
     return null;
   });
 
-  map.set('dismiss_readiness_nag', async (): Promise<null> => {
+  map.set('dismiss_readiness_nag', async (args: unknown): Promise<null> => {
+    if (!isDismissReadinessNagArgs(args)) {
+      throw new Error('dismiss_readiness_nag requires a non-empty toolId');
+    }
+    getStore().dismissedReadinessToolIds.add(args.toolId);
     return null;
   });
 

--- a/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
@@ -124,12 +124,36 @@ function buildMockReadinessResult(): ReadinessCheckResult {
         }
       : tool
   );
+  const warnings = toolChecks.filter((tool) => !tool.is_available && !tool.is_required).length;
+  const criticalFailures = toolChecks.filter((tool) => !tool.is_available && tool.is_required).length;
+  const checks: ReadinessCheckResult['checks'] = toolChecks.map((tool) => {
+    if (tool.is_available) {
+      return {
+        field: tool.tool_id,
+        path: '',
+        message: `${tool.display_name} is available.`,
+        remediation: '',
+        severity: 'info',
+      };
+    }
+    const guidance = tool.install_guidance;
+    const remediationParts = [(guidance?.command ?? '').trim(), (guidance?.alternatives ?? '').trim()].filter(
+      (part) => part !== ''
+    );
+    return {
+      field: tool.tool_id,
+      path: '',
+      message: `${tool.display_name} is missing.`,
+      remediation: remediationParts.join(' ').trim(),
+      severity: tool.is_required ? 'error' : 'warning',
+    };
+  });
 
   return {
-    checks: [],
-    all_passed: true,
-    critical_failures: 0,
-    warnings: 0,
+    checks,
+    all_passed: criticalFailures === 0 && warnings === 0,
+    critical_failures: criticalFailures,
+    warnings,
     umu_install_guidance: dismissed
       ? null
       : {

--- a/src/crosshook-native/src/lib/mocks/store.ts
+++ b/src/crosshook-native/src/lib/mocks/store.ts
@@ -9,6 +9,7 @@ export interface MockStore {
   profiles: Map<string, GameProfile>;
   activeProfileId: string | null;
   defaultSteamClientInstallPath: string;
+  dismissedReadinessToolIds: Set<string>;
 }
 
 const EMPTY_RECENT_FILES: RecentFilesData = {
@@ -27,6 +28,7 @@ export function getStore(): MockStore {
       profiles: new Map(),
       activeProfileId: null,
       defaultSteamClientInstallPath: '/home/devuser/.steam/steam',
+      dismissedReadinessToolIds: new Set(),
     };
   }
   return store;

--- a/src/crosshook-native/src/lib/mocks/wrapHandler.ts
+++ b/src/crosshook-native/src/lib/mocks/wrapHandler.ts
@@ -51,6 +51,7 @@ const EXPLICIT_READ_COMMANDS: ReadonlySet<string> = new Set<string>([
   'check_gamescope_session',
   'launch_platform_status',
   'check_readiness',
+  'check_generalized_readiness',
   'preview_launch',
   'validate_launch',
   'build_steam_launch_options_command',

--- a/src/crosshook-native/src/lib/mocks/wrapHandler.ts
+++ b/src/crosshook-native/src/lib/mocks/wrapHandler.ts
@@ -51,7 +51,9 @@ const EXPLICIT_READ_COMMANDS: ReadonlySet<string> = new Set<string>([
   'check_gamescope_session',
   'launch_platform_status',
   'check_readiness',
-  'check_generalized_readiness',
+  // `check_generalized_readiness` is omitted: the real command persists a host readiness
+  // snapshot via `upsert_host_readiness_snapshot` (see onboarding.rs), so it is not a
+  // pure read. It still matches `READ_VERB_RE` (`check_` prefix) for test rendering.
   'preview_launch',
   'validate_launch',
   'build_steam_launch_options_command',

--- a/src/crosshook-native/src/styles/preview.css
+++ b/src/crosshook-native/src/styles/preview.css
@@ -186,8 +186,18 @@
 }
 
 .crosshook-preview-modal__umu-decision-info {
+  margin-top: 6px;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   color: var(--crosshook-color-info);
   font-size: 0.9rem;
+}
+
+.crosshook-preview-modal__umu-decision-info-icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--crosshook-color-info);
 }
 
 .crosshook-preview-modal__sub-label {

--- a/src/crosshook-native/src/types/onboarding.ts
+++ b/src/crosshook-native/src/types/onboarding.ts
@@ -22,6 +22,26 @@ export interface SteamDeckCaveats {
   docs_url: string;
 }
 
+/** One distro-specific install hint row from the host readiness catalog. */
+export interface HostToolInstallCommand {
+  distro_family: string;
+  command: string;
+  alternatives: string;
+}
+
+/** Result for a single host tool probe (generalized readiness). */
+export interface HostToolCheckResult {
+  tool_id: string;
+  display_name: string;
+  is_available: boolean;
+  is_required: boolean;
+  category: string;
+  /** Upstream / project documentation URL from the catalog. */
+  docs_url?: string;
+  /** Present when the tool is missing and Flatpak host guidance applies. */
+  install_guidance: HostToolInstallCommand | null;
+}
+
 export interface ReadinessCheckResult {
   checks: HealthIssue[];
   all_passed: boolean;
@@ -31,6 +51,10 @@ export interface ReadinessCheckResult {
   umu_install_guidance: UmuInstallGuidance | null;
   /** Steam Deck-specific caveats; non-null only when running on a Steam Deck. */
   steam_deck_caveats: SteamDeckCaveats | null;
+  /** Host tool rows from `check_generalized_readiness` (empty for legacy `check_readiness` unless backend merges). */
+  tool_checks?: HostToolCheckResult[];
+  /** Detected host distro key from `/etc/os-release` (e.g. `Arch`, `SteamOS`). */
+  detected_distro_family?: string;
 }
 
 export type OnboardingWizardStage = 'identity_game' | 'runtime' | 'trainer' | 'media' | 'review' | 'completed';

--- a/src/crosshook-native/src/utils/hostReadinessTooltips.ts
+++ b/src/crosshook-native/src/utils/hostReadinessTooltips.ts
@@ -13,6 +13,8 @@ const HOST_TOOL_TOOLTIPS: Record<string, string> = {
     'GameMode requests CPU governor and I/O tweaks while games run. Without it: no automatic GameMode tuning from the host binary.',
   game_performance:
     'CachyOS utility for gaming performance tweaks. Without it: CachyOS game-performance integration will not run. CachyOS-specific utility; available on CachyOS repositories.',
+  steam_deck_caveats:
+    'Steam Deck–specific runtime notes (shader pre-caching, overlay ordering, HDR quirks). When shown: review these before assuming a generic Linux setup; when dismissed or absent: CrossHook will not surface that reminder block.',
   winetricks:
     'Winetricks installs Windows DLLs/components into Wine prefixes. Without it: harder to fix prefix dependencies without manual steps.',
   protontricks:

--- a/src/crosshook-native/src/utils/hostReadinessTooltips.ts
+++ b/src/crosshook-native/src/utils/hostReadinessTooltips.ts
@@ -1,0 +1,31 @@
+/**
+ * Short tooltip copy for host readiness catalog tools: purpose + what you lose if missing.
+ * Keys match `tool_id` in `default_host_readiness_catalog.toml`.
+ */
+const HOST_TOOL_TOOLTIPS: Record<string, string> = {
+  umu_run:
+    'umu-launcher improves Proton runtime bootstrapping for non-Steam launches. Without it: CrossHook falls back to Proton directly and may miss umu-specific fixes.',
+  gamescope:
+    'Gamescope is a micro-compositor for nested sessions, scaling, and HDR. Without it: no host gamescope for Gamescope session features CrossHook checks.',
+  mangohud:
+    'MangoHud shows an on-screen FPS and frame-time overlay. Without it: no MangoHud overlay on host-run commands.',
+  gamemode:
+    'GameMode requests CPU governor and I/O tweaks while games run. Without it: no automatic GameMode tuning from the host binary.',
+  game_performance:
+    'CachyOS utility for gaming performance tweaks. Without it: CachyOS game-performance integration will not run. CachyOS-specific utility; available on CachyOS repositories.',
+  winetricks:
+    'Winetricks installs Windows DLLs/components into Wine prefixes. Without it: harder to fix prefix dependencies without manual steps.',
+  protontricks:
+    'Protontricks applies winetricks to Proton prefixes for Steam games. Without it: no protontricks CLI for Proton prefix fixes.',
+  wine_wayland:
+    'Host Wine enables Wayland-related experiments with PROTON_ENABLE_WAYLAND. Without it: host Wine/Wayland checks CrossHook uses cannot succeed.',
+};
+
+/** Tooltip for a host catalog tool; falls back to a generic message for unknown IDs. */
+export function getHostToolTooltipContent(toolId: string): string {
+  const text = HOST_TOOL_TOOLTIPS[toolId];
+  if (text !== undefined) {
+    return text;
+  }
+  return 'Host tool used during readiness checks. Without it: related host features CrossHook probes may be unavailable.';
+}


### PR DESCRIPTION
## Summary

Implements database-backed host readiness for Flatpak: embedded TOML catalog merged with optional user override, SQLite persistence (migration 20→21), TTL nag dismissals, snapshot cache, generalized readiness IPC, onboarding UI with per-tool tooltips (including CachyOS `game-performance`), and docs for schema v21. Replaces Unicode ℹ with SVG info icons for umu-database hints where they looked like "i umu".

Closes #269

## Changes

- Add `default_host_readiness_catalog.toml`, `onboarding/catalog.rs`, and migration `migrate_20_to_21` (`host_readiness_catalog`, `readiness_nag_dismissals`, `host_readiness_snapshots`).
- Wire `MetadataStore` stores, startup catalog persist + legacy TOML dismissal migration.
- IPC: `check_generalized_readiness`, `dismiss_readiness_nag`; legacy `check_readiness` respects DB dismissals.
- Frontend: generalized readiness in wizard, `HostToolsReadinessSection`, `hostReadinessTooltips.ts`, mocks.
- Docs: `AGENTS.md`, `.cursorrules`, `CLAUDE.md` schema v21 summary.
- UI: `InfoTooltip` / `InfoCircleIcon` for umu CSV coverage hints (Runtime, Launch preview, pinned strip).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## Testing

- `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core`
- `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-native`
- `npm run typecheck` / `npm run lint` in `src/crosshook-native` (via lefthook on commit)

### Environment

- **Platform**: Linux (dev)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog-driven host readiness: new "Host Tools" section with per-tool status, distro-aware install guidance, copy-to-clipboard, docs links, and dismiss actions.
  * Generalized readiness check, startup persistence of the readiness catalog, and cached host-readiness snapshot with snapshot persistence.

* **New APIs / Commands (UI-visible)**
  * UI and IPC commands to dismiss per-tool readiness nags (TTL-based) and apply dismissals.

* **Documentation**
  * Metadata DB docs updated and a default host readiness catalog added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->