### PR TITLE
feat(protonup): native Proton download manager with AppImage/Flatpak parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ ground-truth facts change. Never duplicate `CLAUDE.md` policy prose here.
 
 - **Platform**: CrossHook is a **native Linux** desktop app (Tauri v2, AppImage). It does **not** run under Wine/Proton; it **orchestrates** launching Windows games via Proton/Wine.
 - **Host-tool gateway**: Host-tool execution at the Flatpak boundary **must** route through `src/crosshook-native/crates/crosshook-core/src/platform.rs` (`host_command`, `host_std_command`, `host_command_with_env`, `host_command_exists`, and friends). Direct `Command::new("<host-tool>")` for tools in the denylist (`proton`, `umu-run`, `gamescope`, `mangohud`, `winetricks`, `protontricks`, `gamemoderun`) is rejected by `scripts/check-host-gateway.sh`. See [`docs/architecture/adr-0001-platform-host-gateway.md`](docs/architecture/adr-0001-platform-host-gateway.md) for the full contract, scope boundary (does not apply to in-sandbox subprocess code), and escape hatches.
+- **Proton download manager**: Native Proton version management (AppImage + Flatpak parity, provider catalog, install/uninstall) is handled by the dedicated Proton Manager at the `/proton-manager` route. Catalog data lives in the `proton_release_catalog` SQLite table (v22). Architecture decisions are documented in [`docs/architecture/adr-0003-proton-download-manager.md`](docs/architecture/adr-0003-proton-download-manager.md).
 - **Architecture**: Business logic lives in `crosshook-core`. Keep `crosshook-cli` and `src-tauri` thin (IPC and CLI only).
 - **Trainer execution parity**: Treat trainer subprocesses by their **actual runtime path**, not just the parent game launch method. Steam profiles still launch trainers through Proton, so Steam trainer launches must stay aligned with `proton_run` semantics for `effective_trainer_gamescope()`, launch optimization env, and `runtime.working_directory`. In Flatpak, if the shell-helper path diverges from the working `proton_run` trainer path, prefer reusing the direct Proton trainer builder and record/analyze the execution as `proton_run` rather than keeping a separate helper-only env reconstruction path.
 - **Tauri IPC**: Expose backend operations as `#[tauri::command]` handlers with **`snake_case` names** matching frontend `invoke()` calls. Use **Serde** on all types that cross the IPC boundary.
@@ -171,35 +172,36 @@ src/crosshook-native/              # Primary source root
 **Location**: `~/.local/share/crosshook/metadata.db`
 **Mode**: WAL (write-ahead logging)
 **Permissions**: `0600` (owner read/write only)
-**Current schema version**: 21
+**Current schema version**: 23
 **Access**: `MetadataStore::try_new()` in `crosshook-core`
 **Migrations**: `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`
 
 ### Table inventory
 
-| Table                            | Since schema | Purpose                                                                |
-| -------------------------------- | :----------: | ---------------------------------------------------------------------- |
-| `profiles`                       |      v1      | Core profile records                                                   |
-| `profile_name_history`           |      v1      | Rename audit trail                                                     |
-| `launchers`                      |      v3      | Known launcher executables                                             |
-| `launch_operations`              |      v3      | Per-launch history and diagnostics                                     |
-| `community_taps`                 |      v4      | Subscribed community tap sources                                       |
-| `community_profiles`             |      v4      | Fetched community profile snapshots                                    |
-| `external_cache_entries`         |      v4      | Generic HTTP response cache (512 KiB payload cap per entry)            |
-| `collections`                    |      v4      | Named profile collections                                              |
-| `collection_profiles`            |      v4      | Collection ↔ profile membership                                        |
-| `health_snapshots`               |      v6      | Periodic profile health check results                                  |
-| `version_snapshots`              |      v9      | Game/trainer version correlation records; includes `trainer_file_hash` |
-| `bundled_optimization_presets`   |     v10      | Built-in optimization preset definitions                               |
-| `profile_launch_preset_metadata` |     v10      | Per-profile preset activation state                                    |
-| `config_revisions`               |     v11      | TOML snapshots with SHA-256 for config history/rollback                |
-| `optimization_catalog`           |     v12      | Data-driven optimization catalog entries                               |
-| `trainer_hash_cache`             |     v13      | SHA-256 hash per trainer per profile                                   |
-| `offline_readiness_snapshots`    |     v13      | Offline readiness state snapshots                                      |
-| `community_tap_offline_state`    |     v13      | Per-tap offline availability state                                     |
-| `host_readiness_catalog`         |     v21      | Persisted host-tool readiness catalog (from TOML merge)                |
-| `readiness_nag_dismissals`       |     v21      | TTL dismissals for per-tool readiness nags (global)                    |
-| `host_readiness_snapshots`       |     v21      | Last cached generalized host readiness snapshot (single row)           |
+| Table                            | Since schema | Purpose                                                                                                                                                     |
+| -------------------------------- | :----------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `profiles`                       |      v1      | Core profile records                                                                                                                                        |
+| `profile_name_history`           |      v1      | Rename audit trail                                                                                                                                          |
+| `launchers`                      |      v3      | Known launcher executables                                                                                                                                  |
+| `launch_operations`              |      v3      | Per-launch history and diagnostics                                                                                                                          |
+| `community_taps`                 |      v4      | Subscribed community tap sources                                                                                                                            |
+| `community_profiles`             |      v4      | Fetched community profile snapshots                                                                                                                         |
+| `external_cache_entries`         |      v4      | Generic HTTP response cache (512 KiB payload cap per entry)                                                                                                 |
+| `collections`                    |      v4      | Named profile collections                                                                                                                                   |
+| `collection_profiles`            |      v4      | Collection ↔ profile membership                                                                                                                             |
+| `health_snapshots`               |      v6      | Periodic profile health check results                                                                                                                       |
+| `version_snapshots`              |      v9      | Game/trainer version correlation records; includes `trainer_file_hash`                                                                                      |
+| `bundled_optimization_presets`   |     v10      | Built-in optimization preset definitions                                                                                                                    |
+| `profile_launch_preset_metadata` |     v10      | Per-profile preset activation state                                                                                                                         |
+| `config_revisions`               |     v11      | TOML snapshots with SHA-256 for config history/rollback                                                                                                     |
+| `optimization_catalog`           |     v12      | Data-driven optimization catalog entries                                                                                                                    |
+| `trainer_hash_cache`             |     v13      | SHA-256 hash per trainer per profile                                                                                                                        |
+| `offline_readiness_snapshots`    |     v13      | Offline readiness state snapshots                                                                                                                           |
+| `community_tap_offline_state`    |     v13      | Per-tap offline availability state                                                                                                                          |
+| `host_readiness_catalog`         |     v21      | Persisted host-tool readiness catalog (from TOML merge)                                                                                                     |
+| `readiness_nag_dismissals`       |     v21      | TTL dismissals for per-tool readiness nags (global)                                                                                                         |
+| `host_readiness_snapshots`       |     v21      | Last cached generalized host readiness snapshot (single row)                                                                                                |
+| `proton_release_catalog`         |     v22      | Cached Proton release metadata (per-provider, per-version). TTL-driven. Legacy `external_cache_entries` `protonup:catalog:*` keys are evicted on migration. |
 
 ### Persistence design classification
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 This file is generated with `git-cliff` from the repository history and release tags.
-## [v0.2.11] - 2026-04-15
 
+## [v0.2.11] - 2026-04-15
 
 ### Bug Fixes
 
@@ -16,13 +16,11 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **ui:** A11y pass and biome lint cleanup ([#232](https://github.com/yandy-r/crosshook/issues/232)) ([`63ec452`](https://github.com/yandy-r/crosshook/commit/63ec452824dd742b1af47c422d27c2086e7e8c98))
 
-
 ### Documentation
 
 - **prps:** Add auto-trainer gamescope plan and spec ([`69dca48`](https://github.com/yandy-r/crosshook/commit/69dca480e1ebe8cffcd81dc54f9b4b4e3aeae203))
 
 - **prd:** Add GitHub issue tables to umu-launcher migration PRD ([`92ac832`](https://github.com/yandy-r/crosshook/commit/92ac832052334fd2a5e23137d8906e91317a60b5))
-
 
 ### Features
 
@@ -36,9 +34,7 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **launch:** Add umu opt-in for non-Steam launches (Phase 3) ([#264](https://github.com/yandy-r/crosshook/issues/264)) ([`d8a851c`](https://github.com/yandy-r/crosshook/commit/d8a851c4e282485b9e6af5a1710944dcee6c5817))
 
-
 ## [v0.2.10-flatpak] - 2026-04-13
-
 
 ### Bug Fixes
 
@@ -52,18 +48,15 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **launch:** Align Steam trainer with proton_run and Flatpak parity ([#227](https://github.com/yandy-r/crosshook/issues/227)) ([`7fd52b2`](https://github.com/yandy-r/crosshook/commit/7fd52b2b8708ecc392864a18a634e20c84c71a50))
 
-
 ### Build
 
 - **icons:** Automate AppImage icon sync pipeline ([`bf56733`](https://github.com/yandy-r/crosshook/commit/bf567336f00afce8eb0ee3acf2903a3d387449cd))
 
 - **lint:** Add code quality tooling standard ([`cada9bb`](https://github.com/yandy-r/crosshook/commit/cada9bbde1c575d03efbc7753920cccddc36843a))
 
-
 ### Documentation
 
 - Add issue asset and task log for trainer gamescope tracking ([`5e33353`](https://github.com/yandy-r/crosshook/commit/5e33353c939f541320563517844de4deccd8cdc6))
-
 
 ### Features
 
@@ -79,16 +72,13 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **flatpak:** Harden phase 3 process execution ([#214](https://github.com/yandy-r/crosshook/issues/214)) ([`f8eada9`](https://github.com/yandy-r/crosshook/commit/f8eada95e7a843e1010f91cedad78e2b10313ee0))
 
-
 ## [v0.2.9] - 2026-04-09
-
 
 ### Bug Fixes
 
 - **build:** Resolve blank AppImage on Intel+NVIDIA hybrid GPU systems ([`67bd326`](https://github.com/yandy-r/crosshook/commit/67bd3262c7256115c859b23f19e21147aed4bd98))
 
 - **build:** Rename plugin-stub sentinel prefix to avoid CI mock-code check ([`157b884`](https://github.com/yandy-r/crosshook/commit/157b884f943b82688dbef5ea78e7f864d5fba86d))
-
 
 ### Features
 
@@ -114,14 +104,11 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **ui:** Profile collections polish, integration tests, Steam Deck validation — Phase 5 ([#181](https://github.com/yandy-r/crosshook/issues/181)) ([#186](https://github.com/yandy-r/crosshook/issues/186)) ([`842e70a`](https://github.com/yandy-r/crosshook/commit/842e70aa757f007ccfecd461144e1a46af7c250a))
 
-
 ## [v0.2.8] - 2026-04-07
-
 
 ### Bug Fixes
 
 - **discovery:** Harden external search and trainer-source validation ([`6cdf96d`](https://github.com/yandy-r/crosshook/commit/6cdf96d4c72ad33b771f40eefd1b5d7beeed515e))
-
 
 ### Features
 
@@ -143,14 +130,11 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **protonup:** In-app Proton runtime management ([#159](https://github.com/yandy-r/crosshook/issues/159)) ([`4b86144`](https://github.com/yandy-r/crosshook/commit/4b86144375cc194a6ebb9a94a012cf38a9c45a9e))
 
-
 ## [v0.2.7] - 2026-04-04
-
 
 ### Bug Fixes
 
 - **launch:** Revert umu-run preference, use direct proton for all launch paths ([`e5f182c`](https://github.com/yandy-r/crosshook/commit/e5f182cf6d2781adfa5f7ef482c42a24154a02f3))
-
 
 ### Features
 
@@ -168,9 +152,7 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **launch:** Protontricks/winetricks integration for prefix dependencies ([#151](https://github.com/yandy-r/crosshook/issues/151)) ([`4a2ce3d`](https://github.com/yandy-r/crosshook/commit/4a2ce3d30e91b3fed39a8f1c8c602b744490c653))
 
-
 ## [v0.2.6] - 2026-04-02
-
 
 ### Bug Fixes
 
@@ -179,7 +161,6 @@ This file is generated with `git-cliff` from the repository history and release 
 - **ui:** Route layout, panel decor, and polish across routes ([#138](https://github.com/yandy-r/crosshook/issues/138)) ([`883b622`](https://github.com/yandy-r/crosshook/commit/883b622812dce93472c13bac7b6a9238845967a0))
 
 - **cli:** Include mangohud in LaunchRequest from profile ([`6bb5010`](https://github.com/yandy-r/crosshook/commit/6bb5010631ea56c09f6e30430b2e4b682a809b96))
-
 
 ### Features
 
@@ -201,9 +182,7 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **ui:** Add Library Home page with poster art grid ([#139](https://github.com/yandy-r/crosshook/issues/139)) ([`1aff9c0`](https://github.com/yandy-r/crosshook/commit/1aff9c08f64195103f50b33e0d9583d0502cdbdb))
 
-
 ## [v0.2.5] - 2026-03-31
-
 
 ### Bug Fixes
 
@@ -217,11 +196,9 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **branchlet:** Update terminal command in .branchlet.json to use GUI editor ([`e0ece59`](https://github.com/yandy-r/crosshook/commit/e0ece592fe73c54766af83de2ca3c5c62c057a6e))
 
-
 ### Documentation
 
 - **ref:** Add feature specification and research documents for CLI command wiring ([`08bb988`](https://github.com/yandy-r/crosshook/commit/08bb9885b0d92e07e82f54034271d467475e5925))
-
 
 ### Features
 
@@ -249,9 +226,7 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **cli:** Wire all placeholder commands to crosshook-core and extend launch support ([#127](https://github.com/yandy-r/crosshook/issues/127)) ([`2cba5f1`](https://github.com/yandy-r/crosshook/commit/2cba5f1d4be8f48dfbdadac05b8e1625c5a8db30))
 
-
 ## [v0.2.4] - 2026-03-29
-
 
 ### Bug Fixes
 
@@ -263,7 +238,6 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **ui:** Smooth launcher preview modal scrolling ([#97](https://github.com/yandy-r/crosshook/issues/97)) ([`3123cdd`](https://github.com/yandy-r/crosshook/commit/3123cdd243d569725674c554048ca286306b075f))
 
-
 ### Documentation
 
 - **profile-health:** Revise health dashboard spec and integrate SQLite metadata layer ([`ed0bd03`](https://github.com/yandy-r/crosshook/commit/ed0bd03d853061be8750ff7347346d52fa5b720b))
@@ -271,7 +245,6 @@ This file is generated with `git-cliff` from the repository history and release 
 - **health:** Add Health Dashboard Page for profile diagnostics ([`5aca99e`](https://github.com/yandy-r/crosshook/commit/5aca99e7c05a8c7f01e82d73b6308613e6239f66))
 
 - **health:** Add implementation plan for Health Dashboard Page ([`70ae03e`](https://github.com/yandy-r/crosshook/commit/70ae03e9ac6730c410e019d46008b9997d0030b9))
-
 
 ### Features
 
@@ -309,14 +282,11 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **diagnostics:** Add diagnostic bundle export ([`01dd2ac`](https://github.com/yandy-r/crosshook/commit/01dd2ac339f734b3b55a00d7681d30fc8b692625))
 
-
 ## [v0.2.3] - 2026-03-27
-
 
 ### Bug Fixes
 
 - **launch:** Add actionable validation guidance and reset page scroll ([#79](https://github.com/yandy-r/crosshook/issues/79)) ([`98fdf18`](https://github.com/yandy-r/crosshook/commit/98fdf1840dc09ca86d4a0dacc66e28827e047b64))
-
 
 ### Features
 
@@ -334,9 +304,7 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **profile:** Add rename with overwrite protection and launcher cascade ([#83](https://github.com/yandy-r/crosshook/issues/83)) ([`5866808`](https://github.com/yandy-r/crosshook/commit/5866808e3a4d0c4f2067b447593783f28b87f0e8))
 
-
 ## [v0.2.2] - 2026-03-26
-
 
 ### Bug Fixes
 
@@ -352,7 +320,6 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **ui:** Adjust padding and border styles for content areas ([`1ab02da`](https://github.com/yandy-r/crosshook/commit/1ab02da9f3a07f55b9daaf6952633a496370f5ba))
 
-
 ### Features
 
 - **profile:** Add install review modal flow ([#29](https://github.com/yandy-r/crosshook/issues/29)) ([`62a8f08`](https://github.com/yandy-r/crosshook/commit/62a8f08d585ebb6ed5c862b3647cc04213c4ea22))
@@ -365,9 +332,7 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **launch:** Add per-profile trainer loading modes ([#35](https://github.com/yandy-r/crosshook/issues/35)) ([`86949dd`](https://github.com/yandy-r/crosshook/commit/86949dd8dd5c22a617cd82c4b4a6355c4b639b3d))
 
-
 ## [v0.2.1] - 2026-03-25
-
 
 ### Bug Fixes
 
@@ -377,16 +342,13 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **release:** Restore and validate native workspace manifest ([`6bd2589`](https://github.com/yandy-r/crosshook/commit/6bd25893d972f7b95dc0fbc21b3b1ccfca8e1fa7))
 
-
 ### Features
 
 - **native:** Implement install game workflow ([#23](https://github.com/yandy-r/crosshook/issues/23)) ([`704c478`](https://github.com/yandy-r/crosshook/commit/704c4780f32b721d1c72f0b25149bebcf3cb5517))
 
 - **launcher:** Implement launcher lifecycle management ([#25](https://github.com/yandy-r/crosshook/issues/25)) ([`fa51a74`](https://github.com/yandy-r/crosshook/commit/fa51a74f22762749ba2de7c6375050102c3fa62c))
 
-
 ## [v0.2.0] - 2026-03-23
-
 
 ### Bug Fixes
 
@@ -394,14 +356,11 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - **native:** Restore workspace release manifest ([`9275fce`](https://github.com/yandy-r/crosshook/commit/9275fceaeed943e525422147b00a680eba0dfebe))
 
-
 ### Features
 
 - Implement the platform-native-ui native app feature set ([#20](https://github.com/yandy-r/crosshook/issues/20)) ([`84242d4`](https://github.com/yandy-r/crosshook/commit/84242d482a399f19abb0cefe5a42bc82dfd7ba7a))
 
-
 ## [v0.1.1] - 2026-03-23
-
 
 ### Features
 
@@ -411,8 +370,6 @@ This file is generated with `git-cliff` from the repository history and release 
 
 - Expand platform-native UI analysis and documentation ([`ca1bc92`](https://github.com/yandy-r/crosshook/commit/ca1bc927e7b0e620e83d26ec9efcf91f5e4e2a5f))
 
-
 ## [v0.1.0] - 2026-03-19
-
 
 <!-- generated by git-cliff -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,9 @@ For storage changes, plans must also:
 
 Operational metadata lives in **`~/.local/share/crosshook/metadata.db`** (WAL, `0600`). Migrations: `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`.
 
-- **Current schema version**: **21**
+- **Current schema version**: **23**
+- **Migration v22→v23**: evicts `proton_release_catalog` rows so additive DTO fields (e.g. `published_at`) repopulate on next fetch. No schema change.
+- **Tables added in v22**: `proton_release_catalog` (native Proton download manager catalog cache; migration also evicts legacy `protonup:catalog:*` entries from `external_cache_entries`)
 - **Tables added in v21**: `host_readiness_catalog`, `readiness_nag_dismissals`, `host_readiness_snapshots`
 
 Full table inventory, persistence classification, and `external_cache_entries` payload limits: [`AGENTS.md`](AGENTS.md) § _SQLite Metadata DB_.

--- a/docs/architecture/adr-0003-proton-download-manager.md
+++ b/docs/architecture/adr-0003-proton-download-manager.md
@@ -63,16 +63,19 @@ catalog fetch and download URL resolution:
 
 - `supports_install() -> bool` — signals whether the provider has enough
   metadata (download URL, file size) to drive the install orchestrator in
-  `install.rs`. Providers with incomplete API responses (e.g. a future
-  Proton-EM integration) set this to `false` and are surfaced as
-  browse-only in the UI.
+  `install.rs`. Providers with incomplete API responses set this to `false`
+  and are surfaced as browse-only in the UI. Providers such as Proton-EM
+  can still opt into installation when the catalog supplies the required
+  archive metadata even if checksum coverage is unavailable.
 - `checksum_kind() -> ChecksumKind` — declares one of `Sha512Sidecar`
   (GE-Proton: a separate `.sha512sum` sidecar file), `Sha256Manifest`
   (a provider that embeds checksums in the release body), or `None`
-  (provider supplies no checksum; install is allowed but flagged). The
-  install orchestrator in `install.rs` reads this discriminant and selects
-  the matching verification path, keeping the orchestrator free of
-  per-provider conditionals.
+  (provider supplies no checksum; install is still allowed, but the
+  verification phase emits a warning and continues). `None` is a
+  first-class, explicitly flagged install path today and is used by
+  Proton-EM. The install orchestrator in `install.rs` reads this
+  discriminant and selects the matching verification path, keeping the
+  orchestrator free of per-provider conditionals.
 
 The existing `ProtonUpProvider` enum in `protonup/mod.rs` and the
 `CatalogProviderConfig` struct in `catalog.rs` are refactored to delegate

--- a/docs/architecture/adr-0003-proton-download-manager.md
+++ b/docs/architecture/adr-0003-proton-download-manager.md
@@ -1,0 +1,261 @@
+# ADR-0003: Native Proton download manager architecture
+
+**Status**: Accepted — 2026-04-17
+
+---
+
+## Context
+
+CrossHook is a native Linux desktop application (Tauri v2, AppImage today,
+Flatpak target tracked under issue [#276]). Issue [#274] adds a native Proton
+version manager — download, verify, and extract GE-Proton and Proton-CachyOS
+releases — that works consistently in both AppImage and Flatpak without
+bundling a sandbox helper or shelling out to a host-side tool.
+
+The design is grounded in three research anchors from the Flatpak deep-research
+series:
+
+- `docs/research/flatpak-bundling/14-recommendations.md` §3.1 (Proton version
+  download manager) and §3.2 (Flatpak Steam write access negotiation): §3.1
+  defines the GitHub API client + extract-to-`compatibilitytools.d/` approach
+  that this ADR implements; §3.2 establishes the write-access constraint that
+  makes install-root resolution non-trivial under Flatpak Steam.
+- `docs/research/flatpak-bundling/13-opportunities.md` SO-2 (Build Proton
+  version management as a native feature): identifies this as a high-effort /
+  high-impact strategic opportunity that eliminates the `protonup-qt` host
+  dependency without requiring `flatpak-spawn --host`.
+- `docs/research/flatpak-bundling/11-patterns.md` Tier 3 (Should Build as
+  Native Feature): classifies Proton download/management as in-process Rust
+  work, not host-tool delegation, explicitly noting that
+  `protonup_binary_path` was the placeholder setting.
+
+Today the repo has partial scaffolding in
+`src/crosshook-native/crates/crosshook-core/src/protonup/`: `catalog.rs`
+handles cache-first GitHub Releases API fetch for GE-Proton and
+Proton-CachyOS, `install.rs` handles SHA-512 verification and archive
+extraction, and `matching.rs` provides community-version-to-install-name
+matching. `mod.rs` defines the shared DTOs (`ProtonUpProvider`,
+`ProtonUpAvailableVersion`, `ProtonUpInstallRequest`, `ProtonUpInstallResult`,
+etc.) that cross the Tauri IPC boundary via Serde. Settings fields
+(`protonup_default_provider`, `protonup_default_install_root`,
+`protonup_include_prereleases`) already exist in
+`src/crosshook-native/crates/crosshook-core/src/settings/mod.rs`.
+
+This ADR captures the architecture for completing that scaffolding to full
+parity: the provider trait model, install-root resolution, the host-gateway
+exemption, the SQLite cache boundary, and the rescan-is-truth rule for
+installed inventory.
+
+[#274]: https://github.com/yandy-r/crosshook/issues/274
+[#276]: https://github.com/yandy-r/crosshook/issues/276
+
+---
+
+## Decision
+
+### Provider trait
+
+An async `ProtonReleaseProvider` trait lives in
+`crosshook-core::protonup::providers`. Each upstream is a separate module
+that implements this trait (`ge_proton.rs`, `proton_cachyos.rs`, and any
+future providers). The trait declares two capability methods in addition to
+catalog fetch and download URL resolution:
+
+- `supports_install() -> bool` — signals whether the provider has enough
+  metadata (download URL, file size) to drive the install orchestrator in
+  `install.rs`. Providers with incomplete API responses (e.g. a future
+  Proton-EM integration) set this to `false` and are surfaced as
+  browse-only in the UI.
+- `checksum_kind() -> ChecksumKind` — declares one of `Sha512Sidecar`
+  (GE-Proton: a separate `.sha512sum` sidecar file), `Sha256Manifest`
+  (a provider that embeds checksums in the release body), or `None`
+  (provider supplies no checksum; install is allowed but flagged). The
+  install orchestrator in `install.rs` reads this discriminant and selects
+  the matching verification path, keeping the orchestrator free of
+  per-provider conditionals.
+
+The existing `ProtonUpProvider` enum in `protonup/mod.rs` and the
+`CatalogProviderConfig` struct in `catalog.rs` are refactored to delegate
+to the trait implementations rather than using a `match` arm per provider.
+
+### Install-root resolution
+
+An environment-aware resolver returns an ordered list of
+`InstallRootCandidate` values. Each candidate carries the path, a display
+label, and a `writable: bool` determined by probing the filesystem at
+resolution time (not cached).
+
+Two canonical roots are checked:
+
+1. **Native Steam**: `~/.local/share/Steam/compatibilitytools.d` — always
+   writable if the directory exists (CrossHook's Flatpak manifest declares
+   `--filesystem=home`).
+2. **Flatpak Steam**: `~/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d`
+   — the Flathub manifest for Steam mounts this path `:ro` in some
+   configurations. The resolver probes writability at runtime; if the path
+   is read-only it is included in the candidate list with `writable: false`
+   so the UI can surface it, but the install orchestrator refuses to write
+   there. When both candidates are writable, the native-Steam candidate
+   sorts first (closer to the host filesystem, less mount-remapping
+   ambiguity). The §3.2 research task (negotiating a Flatpak Steam `:rw`
+   upgrade on Flathub) is tracked under [#274] and does not block this ADR;
+   the resolver handles both present-day `:ro` and future `:rw` without a
+   code change.
+
+### Host-gateway exemption
+
+Download (`reqwest`), decompression (`flate2` for `.tar.gz`, `xz2` for
+`.tar.xz`), and extraction (`tar`) are in-sandbox library code — they run
+inside the CrossHook process, not as host subprocesses. They are explicitly
+outside the scope of [ADR-0001]'s host-command gateway contract and its
+denylist enforced by `scripts/check-host-gateway.sh`.
+
+No Proton install step shells out to a host-side `tar`, `unzstd`, or
+similar binary. All archive I/O is handled by Rust crates linked into
+`crosshook-core`. This is what makes the feature work identically in
+AppImage and Flatpak without a sandbox helper.
+
+[ADR-0001]: ./adr-0001-platform-host-gateway.md
+
+### SQLite cache boundary
+
+Remote catalog metadata (versions, download URLs, checksums, fetch
+timestamps, TTL) lives in a dedicated `proton_release_catalog` table added
+in the SQLite metadata DB at schema version 22
+(`src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`,
+migration `migrate_21_to_22`). This is operational/history metadata — the
+same classification as `external_cache_entries` — and lives in
+`~/.local/share/crosshook/metadata.db` (WAL, `0600`).
+
+The persistence boundary is explicit:
+
+| Datum                                       | Storage       |
+| ------------------------------------------- | ------------- |
+| Release catalog (versions, URLs, checksums) | SQLite v22    |
+| Default provider                            | TOML settings |
+| Default install root                        | TOML settings |
+| Include prereleases flag                    | TOML settings |
+| Installed Proton inventory                  | Runtime only  |
+
+User preferences (`protonup_default_provider`, `protonup_default_install_root`,
+`protonup_include_prereleases`) already exist in
+`src/crosshook-native/crates/crosshook-core/src/settings/mod.rs` and remain
+there; no preference moves into SQLite.
+
+### Rescan-is-truth rule
+
+`discover_compat_tools_with_roots` in
+`src/crosshook-native/crates/crosshook-core/src/steam/proton.rs` is
+authoritative for the installed Proton inventory. The download manager does
+not maintain a persistent "installed tools" table in SQLite; it would diverge
+from the filesystem if the user manually adds, removes, or renames a
+compatibility tool directory.
+
+After any install or uninstall operation the orchestrator triggers a rescan
+via the existing `discover_compat_tools_with_roots` call path and returns the
+fresh result to the IPC caller. The UI always reflects the filesystem state,
+not a stale cache.
+
+---
+
+## Consequences
+
+### AppImage + Flatpak parity
+
+Both packaging targets work out of the box. `reqwest`, `flate2`, `xz2`, and
+`tar` link into `crosshook-core` and run in-process in both environments.
+Flatpak users whose only writable compat-tools path is native Steam
+(`~/.local/share/Steam/compatibilitytools.d`) get that path automatically;
+no manual configuration is required.
+
+### Degraded mode
+
+If the resolver finds no writable install root — for example, a Flatpak
+Steam `:ro` mount with no native Steam present — the UI surfaces a
+"read-only" badge on every candidate root and disables the install button.
+The install orchestrator never silently writes to a path that the writability
+probe marked non-writable. The feature degrades visibly, not silently.
+
+### Checksum heterogeneity
+
+Per-provider `ChecksumKind` keeps the install orchestrator in `install.rs`
+simple: it reads the discriminant and calls the matching verification path.
+Providers without a checksum (e.g. a future Proton-EM integration) are
+`ChecksumKind::None`, and the orchestrator logs a warning and proceeds
+rather than failing — making the absence of a checksum an explicit, auditable
+choice at the provider level rather than a silent skip in orchestration logic.
+
+### No sandbox bundling
+
+CrossHook does not ship any Proton build inside its Flatpak or AppImage.
+Bundling Proton into the app package is explicitly out of scope: it would
+make the package multi-gigabytes, require legal review of each Proton
+variant's license, and re-create a maintenance burden that ProtonUp-Qt
+already owns for its users. This ADR rejects that approach permanently.
+
+---
+
+## Alternatives considered
+
+### Reuse ProtonUp-Qt / protonup-rs
+
+Invoking `protonup-qt` or a wrapped `protonup-rs` binary from CrossHook
+was the approach the scaffolded `protonup_binary_path` setting anticipated.
+`docs/research/flatpak-bundling/14-recommendations.md` §3.1 rejects this in
+favor of a narrower native capability: host-tool invocation adds a Flatpak
+boundary crossing (requiring `flatpak-spawn --host` for a sandbox-installed
+`protonup-qt`, or a separate Flatpak portal for the Flathub variant), a
+hard external dependency that degrades the UX when the tool is absent, and
+version coupling to an external project's release cadence. The native Rust
+implementation has none of these drawbacks and is CrossHook-native code that
+the team maintains directly.
+
+### Persist installed tool inventory as source of truth
+
+Storing a `proton_installed_tools` SQLite table and mutating it on
+install/uninstall was considered. Rejected: the filesystem is the ground
+truth; a persistent table drifts the moment a user manually installs,
+removes, or moves a compatibility tool directory outside CrossHook.
+Rescan via `discover_compat_tools_with_roots` is cheap (a few directory
+reads) and always accurate. A redundant persistent table adds migration
+burden and a class of consistency bugs with no compensating benefit.
+
+---
+
+## Related
+
+- [ADR-0001 — `platform.rs` host-command gateway](./adr-0001-platform-host-gateway.md):
+  establishes the host-tool denylist and `flatpak-spawn` gateway contract.
+  This ADR's host-gateway exemption (in-process library code) is grounded in
+  ADR-0001's scope boundary section, which explicitly excludes in-sandbox
+  subprocess and library code from the gateway rule.
+- [ADR-0002 — Flatpak portal contracts](./adr-0002-flatpak-portal-contracts.md):
+  additive portal integrations; not directly related to Proton download, but
+  shares the same Flatpak packaging context.
+- Issue [#274] — native Proton download manager (this feature).
+- Issue [#276] — parent Flatpak distribution tracker.
+
+---
+
+## References
+
+- `docs/research/flatpak-bundling/14-recommendations.md` §3.1 and §3.2 —
+  task definitions for the Proton manager and Flatpak Steam write access
+- `docs/research/flatpak-bundling/13-opportunities.md` SO-2 — strategic
+  rationale for building Proton management as a native capability
+- `docs/research/flatpak-bundling/11-patterns.md` Tier 3 — architecture tier
+  guidance confirming in-process Rust (not host delegation) is correct
+- `src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs` —
+  existing cache-first GitHub Releases catalog fetcher
+- `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs` —
+  existing SHA-512 verify + extract orchestrator
+- `src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs` —
+  shared DTOs and `ProtonUpProvider` enum
+- `src/crosshook-native/crates/crosshook-core/src/steam/proton.rs` —
+  `discover_compat_tools_with_roots` (rescan-is-truth implementation)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs` —
+  SQLite migration chain; v22 adds `proton_release_catalog`
+- `src/crosshook-native/crates/crosshook-core/src/settings/mod.rs` —
+  TOML settings fields for provider, install root, and prerelease preference
+- `src/crosshook-native/crates/crosshook-core/src/platform/mod.rs` —
+  ADR-0001 gateway; exemption reasoning is in the scope boundary section

--- a/docs/prps/reviews/fixes/pr-281-fixes.md
+++ b/docs/prps/reviews/fixes/pr-281-fixes.md
@@ -1,77 +1,82 @@
 # Fix Report: pr-281-review
 
-**Source**: docs/prps/reviews/pr-281-review.md
+**Source**: `docs/prps/reviews/pr-281-review.md`
 **Applied**: 2026-04-17
-**Mode**: Parallel sub-agents — 2 batches, max width 3
-**Severity threshold**: HIGH (default — fixes CRITICAL + HIGH)
+**Mode**: Parallel sub-agents (1 batch, max width 6)
+**Severity threshold**: MEDIUM
 
 ## Summary
 
 - **Total findings in source**: 27
-- **Eligible this run**: 9 (F001 CRITICAL + F002–F009 HIGH)
-- **Applied this run**:
+- **Already processed before this run**:
   - Fixed: 9
   - Failed: 0
+- **Eligible this run**: 11
+- **Applied this run**:
+  - Fixed: 10
+  - Failed: 1
 - **Skipped this run**:
-  - Below severity threshold: 18 (F010–F020 MEDIUM, F021–F027 LOW) — remain `Status: Open`
+  - Below severity threshold: 7
   - No suggested fix: 0
   - Missing file: 0
 
-## Batches
-
-- **Batch 1** (3 parallel sub-agents, different file sets)
-  - Agent A — `install.rs`: F001, F002, F003, F004 (4 sequential fixes, same file)
-  - Agent B — `InstallProgressBar.tsx`: F007
-  - Agent C — `useProtonManager.ts` + `types/protonup.ts`: F008, F009
-- **Inter-batch validation gate**: cargo test (1063 pass), cargo clippy -D warnings (clean), tsc --noEmit (clean), biome check (clean)
-- **Batch 2** (1 sub-agent, providers module + catalog.rs + install.rs call site)
-  - Agent D — providers (5 files) + `providers/mod.rs` + `catalog.rs` + `install.rs:619`: F005, F006
-
 ## Fixes Applied
 
-| ID   | Severity | File(s)                                                                                                | Status | Notes                                                                                                                                                                                                                                                                                                                       |
-| ---- | -------- | ------------------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| F001 | CRITICAL | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | `validate_install_destination` now re-runs the `compatibilitytools.d` segment check AFTER `path.canonicalize()` and returns `InstallError::InvalidPath` if the resolved path escapes the compat tree. New test `rejects_symlink_redirect_escaping_compat_dir` exercises the symlink-redirect scenario via a tempdir.        |
-| F002 | HIGH     | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | Added `const MAX_CHECKSUM_BYTES: u64 = 1024 * 1024`. Both `fetch_sha512_sidecar` and `fetch_sha256_manifest` now gate on `response.content_length() > MAX_CHECKSUM_BYTES` before `.text().await`, returning `InstallError::ChecksumFailed`.                                                                                 |
-| F003 | HIGH     | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | New `InstallError::UntrustedUrl(String)` variant + `validate_release_url(url)` helper (https + host allowlist: `github.com`, `api.github.com`, `objects.githubusercontent.com`, `github-releases.githubusercontent.com`). Called for `download_url`, sha512 `checksum_url`, and sha256 `manifest_url`. 4 new unit tests.    |
-| F004 | HIGH     | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | Replaced `ok_or_else` closure in `ChecksumKind::Sha256Manifest` missing-`checksum_url` branch with explicit `match`; on `None`, calls `best_effort_cleanup`, emits `Phase::Failed` via `em`, returns `Err(InstallError::ChecksumMissing(...))` — matches pattern used by the other error branches.                          |
-| F005 | HIGH     | `crosshook-core/src/protonup/providers/{mod,ge_proton,proton_cachyos,proton_em,boxtron,luxtorpeda}.rs` | Fixed  | New `pub(super) async fn fetch_github_releases(client, url)` in `providers/mod.rs` with `const MAX_CATALOG_BYTES: u64 = 10 * 1024 * 1024` byte cap (returns `ProviderError::Parse` on overrun). All 5 provider `fetch()` methods wired through the helper.                                                                  |
-| F006 | HIGH     | `crosshook-core/src/protonup/providers/mod.rs`, `catalog.rs`, `install.rs`                             | Fixed  | Removed `include_prereleases: bool` from `registry()` signature + all call sites (install.rs, catalog.rs × 2, `describe_providers`, 2 test sites). `include_prereleases` is now threaded only where actually consumed (`provider.fetch(client, include_prereleases)`). Removed now-unused param from `persist_catalog`.     |
-| F007 | HIGH     | `src/components/proton-manager/InstallProgressBar.tsx`                                                 | Fixed  | Added `aria-label={`Cancel install ${opId.slice(0, 8)}`}` to the Cancel `<button>`, mirroring the Dismiss button pattern.                                                                                                                                                                                                   |
-| F008 | HIGH     | `src/hooks/useProtonManager.ts`                                                                        | Fixed  | Removed `console.warn` from per-provider catalog fan-out catch; catch param renamed to `_err`. Settled-promise pattern already propagates failure gracefully.                                                                                                                                                               |
-| F009 | HIGH     | `src/types/protonup.ts`, `src/hooks/useProtonManager.ts`                                               | Fixed  | Widened `ProtonUpProvider` union with `'boxtron' \| 'luxtorpeda'`. Added `KNOWN_PROVIDER_IDS: Set<ProtonUpProvider>` + `asProvider(id)` runtime narrower in `useProtonManager.ts`; replaced `(selectedProviderId ?? 'ge-proton') as ProtonUpProvider` with `asProvider(selectedProviderId)`. No downstream consumers broke. |
+| ID   | Severity | File                                                                             | Line | Status | Notes                                                                                   |
+| ---- | -------- | -------------------------------------------------------------------------------- | ---- | ------ | --------------------------------------------------------------------------------------- |
+| F010 | MEDIUM   | `docs/architecture/adr-0003-proton-download-manager.md`                          | 67   | Fixed  | ADR now documents Proton-EM as install-capable and `ChecksumKind::None` as a live path. |
+| F011 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`             | 90   | Fixed  | Added `cancelled` error kind across Rust + TS IPC types.                                |
+| F012 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`             | 407  | Fixed  | Link validation now rejects only archive links that escape the install root.            |
+| F013 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`             | 674  | Fixed  | Unsafe derived archive filenames now fail before temp-path creation.                    |
+| F014 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs`            | 39   | Fixed  | Broadcast buffer cap is now explicit and documented as intentional lossy back-pressure. |
+| F015 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs`   | 79   | Fixed  | Removed redundant catalog-only wrapper helpers in Boxtron and Luxtorpeda.               |
+| F016 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs` | 59   | Fixed  | Installable providers now share a single GitHub fetch-and-parse helper.                 |
+| F017 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs`       | 253  | Fixed  | `take(max)` now limits successfully parsed versions, not attempted releases.            |
+| F018 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs`           | 32   | Failed | Suggested `/home`/`/root` denial changes module semantics and misclassifies user paths. |
+| F019 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs`           | 147  | Fixed  | Added an exact `SystemPathRefused` regression test for explicit Steam system roots.     |
+| F020 | MEDIUM   | `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx`      | 106  | Fixed  | Replaced `window.confirm()` with inline accessible confirmation UI.                     |
 
-## Validation Results (final)
+## Files Changed
 
-| Check                   | Result                                                             |
-| ----------------------- | ------------------------------------------------------------------ |
-| `cargo test`            | Pass (1063 passed, 0 failed — up from 1058 baseline; +5 new tests) |
-| `cargo clippy`          | Pass (`-D warnings` clean)                                         |
-| `tsc --noEmit`          | Pass                                                               |
-| `biome check`           | Pass (258 files)                                                   |
-| `check-host-gateway.sh` | Pass (no direct host-tool bypasses)                                |
+- `docs/architecture/adr-0003-proton-download-manager.md` (F010)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs` (F011, F012, F013)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs` (F011)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs` (F014)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs` (F016, F017)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs` (F016)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs` (F016)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs` (F016)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs` (F015)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs` (F015)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs` (F019; F018 attempted and rejected)
+- `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx` (F020)
+- `src/crosshook-native/src/styles/proton-manager.css` (F020)
+- `src/crosshook-native/src/types/protonup.ts` (F011)
 
-## Remaining Open Findings (below severity threshold)
+## Failed Fixes
 
-### MEDIUM (11) — `Status: Open` in source review
+### F018 — `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs:32`
 
-F010, F011, F012, F013, F014, F015, F016, F017, F018, F019, F020
+**Severity**: MEDIUM  
+**Category**: Security  
+**Description**: The suggested fix pushes broad `/home` / `/root` paths through `SystemPathRefused` instead of `PathOutsideKnownRoots`.
 
-Notable security-adjacent items intentionally deferred:
+**Suggested fix (from review)**: Add `"/home"` and `"/root"` to `SYSTEM_PREFIX_DENYLIST` so broad home-directory paths produce `UninstallError::SystemPathRefused`.
 
-- **F012** (install.rs tar symlink targets) — defense-in-depth against archive-time symlink escape; F001 already closes the most obvious vector (pre-extract destination canonicalization).
-- **F013** (archive_filename sanitization) — hardening gap; defused by F001 canonicalization.
-- **F018** (uninstall.rs denylist gap — `/home`, `/root`) — the `PathOutsideKnownRoots` check still refuses, but via the "wrong gate".
+**Blocker**: That change breaks the documented uninstall contract by misclassifying normal user-owned home paths as system paths, and an earlier implementation also blocked valid native Steam uninstall roots under `$HOME/.local/share/Steam/compatibilitytools.d`.
 
-### LOW (7) — `Status: Open` in source review
+**Recommendation**: Keep the current `PathOutsideKnownRoots` behavior for unmatched home paths unless the product/API contract is deliberately changed. If explicit reclassification is still desired, update the module docs, user-facing copy, and tests first, then revisit the design in a dedicated follow-up.
 
-F021, F022, F023, F024, F025, F026, F027
+## Validation Results
+
+| Check               | Result |
+| ------------------- | ------ |
+| Type check          | Pass   |
+| Frontend type check | Pass   |
+| Tests               | Pass   |
 
 ## Next Steps
 
-1. **Re-review** to verify fixes resolved the findings:
-   - `/ycc:code-review 281`
-2. **Commit** the fixes:
-   - `/ycc:git-workflow`
-3. (Optional) **Follow-up pass** on MEDIUM findings:
-   - `/ycc:review-fix 281 --parallel --severity MEDIUM`
+- Re-run `$code-review 281` to verify the remaining open findings and confirm the fixed ones stay resolved.
+- Decide whether `F018` should remain a documentation-level disagreement or become a separate design issue.
+- Run `$git-workflow` when you want to commit the fix batch.

--- a/docs/prps/reviews/fixes/pr-281-fixes.md
+++ b/docs/prps/reviews/fixes/pr-281-fixes.md
@@ -1,0 +1,77 @@
+# Fix Report: pr-281-review
+
+**Source**: docs/prps/reviews/pr-281-review.md
+**Applied**: 2026-04-17
+**Mode**: Parallel sub-agents — 2 batches, max width 3
+**Severity threshold**: HIGH (default — fixes CRITICAL + HIGH)
+
+## Summary
+
+- **Total findings in source**: 27
+- **Eligible this run**: 9 (F001 CRITICAL + F002–F009 HIGH)
+- **Applied this run**:
+  - Fixed: 9
+  - Failed: 0
+- **Skipped this run**:
+  - Below severity threshold: 18 (F010–F020 MEDIUM, F021–F027 LOW) — remain `Status: Open`
+  - No suggested fix: 0
+  - Missing file: 0
+
+## Batches
+
+- **Batch 1** (3 parallel sub-agents, different file sets)
+  - Agent A — `install.rs`: F001, F002, F003, F004 (4 sequential fixes, same file)
+  - Agent B — `InstallProgressBar.tsx`: F007
+  - Agent C — `useProtonManager.ts` + `types/protonup.ts`: F008, F009
+- **Inter-batch validation gate**: cargo test (1063 pass), cargo clippy -D warnings (clean), tsc --noEmit (clean), biome check (clean)
+- **Batch 2** (1 sub-agent, providers module + catalog.rs + install.rs call site)
+  - Agent D — providers (5 files) + `providers/mod.rs` + `catalog.rs` + `install.rs:619`: F005, F006
+
+## Fixes Applied
+
+| ID   | Severity | File(s)                                                                                                | Status | Notes                                                                                                                                                                                                                                                                                                                       |
+| ---- | -------- | ------------------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| F001 | CRITICAL | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | `validate_install_destination` now re-runs the `compatibilitytools.d` segment check AFTER `path.canonicalize()` and returns `InstallError::InvalidPath` if the resolved path escapes the compat tree. New test `rejects_symlink_redirect_escaping_compat_dir` exercises the symlink-redirect scenario via a tempdir.        |
+| F002 | HIGH     | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | Added `const MAX_CHECKSUM_BYTES: u64 = 1024 * 1024`. Both `fetch_sha512_sidecar` and `fetch_sha256_manifest` now gate on `response.content_length() > MAX_CHECKSUM_BYTES` before `.text().await`, returning `InstallError::ChecksumFailed`.                                                                                 |
+| F003 | HIGH     | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | New `InstallError::UntrustedUrl(String)` variant + `validate_release_url(url)` helper (https + host allowlist: `github.com`, `api.github.com`, `objects.githubusercontent.com`, `github-releases.githubusercontent.com`). Called for `download_url`, sha512 `checksum_url`, and sha256 `manifest_url`. 4 new unit tests.    |
+| F004 | HIGH     | `crosshook-core/src/protonup/install.rs`                                                               | Fixed  | Replaced `ok_or_else` closure in `ChecksumKind::Sha256Manifest` missing-`checksum_url` branch with explicit `match`; on `None`, calls `best_effort_cleanup`, emits `Phase::Failed` via `em`, returns `Err(InstallError::ChecksumMissing(...))` — matches pattern used by the other error branches.                          |
+| F005 | HIGH     | `crosshook-core/src/protonup/providers/{mod,ge_proton,proton_cachyos,proton_em,boxtron,luxtorpeda}.rs` | Fixed  | New `pub(super) async fn fetch_github_releases(client, url)` in `providers/mod.rs` with `const MAX_CATALOG_BYTES: u64 = 10 * 1024 * 1024` byte cap (returns `ProviderError::Parse` on overrun). All 5 provider `fetch()` methods wired through the helper.                                                                  |
+| F006 | HIGH     | `crosshook-core/src/protonup/providers/mod.rs`, `catalog.rs`, `install.rs`                             | Fixed  | Removed `include_prereleases: bool` from `registry()` signature + all call sites (install.rs, catalog.rs × 2, `describe_providers`, 2 test sites). `include_prereleases` is now threaded only where actually consumed (`provider.fetch(client, include_prereleases)`). Removed now-unused param from `persist_catalog`.     |
+| F007 | HIGH     | `src/components/proton-manager/InstallProgressBar.tsx`                                                 | Fixed  | Added `aria-label={`Cancel install ${opId.slice(0, 8)}`}` to the Cancel `<button>`, mirroring the Dismiss button pattern.                                                                                                                                                                                                   |
+| F008 | HIGH     | `src/hooks/useProtonManager.ts`                                                                        | Fixed  | Removed `console.warn` from per-provider catalog fan-out catch; catch param renamed to `_err`. Settled-promise pattern already propagates failure gracefully.                                                                                                                                                               |
+| F009 | HIGH     | `src/types/protonup.ts`, `src/hooks/useProtonManager.ts`                                               | Fixed  | Widened `ProtonUpProvider` union with `'boxtron' \| 'luxtorpeda'`. Added `KNOWN_PROVIDER_IDS: Set<ProtonUpProvider>` + `asProvider(id)` runtime narrower in `useProtonManager.ts`; replaced `(selectedProviderId ?? 'ge-proton') as ProtonUpProvider` with `asProvider(selectedProviderId)`. No downstream consumers broke. |
+
+## Validation Results (final)
+
+| Check                   | Result                                                             |
+| ----------------------- | ------------------------------------------------------------------ |
+| `cargo test`            | Pass (1063 passed, 0 failed — up from 1058 baseline; +5 new tests) |
+| `cargo clippy`          | Pass (`-D warnings` clean)                                         |
+| `tsc --noEmit`          | Pass                                                               |
+| `biome check`           | Pass (258 files)                                                   |
+| `check-host-gateway.sh` | Pass (no direct host-tool bypasses)                                |
+
+## Remaining Open Findings (below severity threshold)
+
+### MEDIUM (11) — `Status: Open` in source review
+
+F010, F011, F012, F013, F014, F015, F016, F017, F018, F019, F020
+
+Notable security-adjacent items intentionally deferred:
+
+- **F012** (install.rs tar symlink targets) — defense-in-depth against archive-time symlink escape; F001 already closes the most obvious vector (pre-extract destination canonicalization).
+- **F013** (archive_filename sanitization) — hardening gap; defused by F001 canonicalization.
+- **F018** (uninstall.rs denylist gap — `/home`, `/root`) — the `PathOutsideKnownRoots` check still refuses, but via the "wrong gate".
+
+### LOW (7) — `Status: Open` in source review
+
+F021, F022, F023, F024, F025, F026, F027
+
+## Next Steps
+
+1. **Re-review** to verify fixes resolved the findings:
+   - `/ycc:code-review 281`
+2. **Commit** the fixes:
+   - `/ycc:git-workflow`
+3. (Optional) **Follow-up pass** on MEDIUM findings:
+   - `/ycc:review-fix 281 --parallel --severity MEDIUM`

--- a/docs/prps/reviews/fixes/pr-281-fixes.md
+++ b/docs/prps/reviews/fixes/pr-281-fixes.md
@@ -3,80 +3,73 @@
 **Source**: `docs/prps/reviews/pr-281-review.md`
 **Applied**: 2026-04-17
 **Mode**: Parallel sub-agents (1 batch, max width 6)
-**Severity threshold**: MEDIUM
+**Severity threshold**: LOW
 
 ## Summary
 
 - **Total findings in source**: 27
 - **Already processed before this run**:
-  - Fixed: 9
-  - Failed: 0
-- **Eligible this run**: 11
+  - Fixed: 19
+  - Failed: 1
+- **Eligible this run**: 7
 - **Applied this run**:
-  - Fixed: 10
+  - Fixed: 6
   - Failed: 1
 - **Skipped this run**:
-  - Below severity threshold: 7
+  - Below severity threshold: 0
   - No suggested fix: 0
   - Missing file: 0
 
 ## Fixes Applied
 
-| ID   | Severity | File                                                                             | Line | Status | Notes                                                                                   |
-| ---- | -------- | -------------------------------------------------------------------------------- | ---- | ------ | --------------------------------------------------------------------------------------- |
-| F010 | MEDIUM   | `docs/architecture/adr-0003-proton-download-manager.md`                          | 67   | Fixed  | ADR now documents Proton-EM as install-capable and `ChecksumKind::None` as a live path. |
-| F011 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`             | 90   | Fixed  | Added `cancelled` error kind across Rust + TS IPC types.                                |
-| F012 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`             | 407  | Fixed  | Link validation now rejects only archive links that escape the install root.            |
-| F013 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`             | 674  | Fixed  | Unsafe derived archive filenames now fail before temp-path creation.                    |
-| F014 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs`            | 39   | Fixed  | Broadcast buffer cap is now explicit and documented as intentional lossy back-pressure. |
-| F015 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs`   | 79   | Fixed  | Removed redundant catalog-only wrapper helpers in Boxtron and Luxtorpeda.               |
-| F016 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs` | 59   | Fixed  | Installable providers now share a single GitHub fetch-and-parse helper.                 |
-| F017 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs`       | 253  | Fixed  | `take(max)` now limits successfully parsed versions, not attempted releases.            |
-| F018 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs`           | 32   | Failed | Suggested `/home`/`/root` denial changes module semantics and misclassifies user paths. |
-| F019 | MEDIUM   | `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs`           | 147  | Fixed  | Added an exact `SystemPathRefused` regression test for explicit Steam system roots.     |
-| F020 | MEDIUM   | `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx`      | 106  | Fixed  | Replaced `window.confirm()` with inline accessible confirmation UI.                     |
+| ID   | Severity | File                                                                              | Line | Status | Notes                                                                                 |
+| ---- | -------- | --------------------------------------------------------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------- |
+| F021 | LOW      | `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs`           | 4    | Failed | Suggested fix explicitly says no action is required for this PR.                      |
+| F022 | LOW      | `src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs` | 1    | Fixed  | Already satisfied in current code; v22 migration already creates the composite index. |
+| F023 | LOW      | `src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs`              | 53   | Fixed  | Replaced manual singleton init with async `tokio::sync::OnceCell`.                    |
+| F024 | LOW      | `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs`              | 564  | Fixed  | Added module-level note documenting extraction cancellation limits.                   |
+| F025 | LOW      | `src/crosshook-native/src-tauri/src/commands/protonup.rs`                         | 18   | Fixed  | Moved `DEFAULT_PROVIDER_ID` below all `use` items.                                    |
+| F026 | LOW      | `src/crosshook-native/src/components/proton-manager/VersionRow.tsx`               | 38   | Fixed  | Documented WCAG AA audit results; no visual change required.                          |
+| F027 | LOW      | `src/crosshook-native/src/hooks/useProtonManager.ts`                              | 85   | Fixed  | Removed the `ALL_MODE_SENTINEL` constant and inlined `null` with comments.            |
 
 ## Files Changed
 
-- `docs/architecture/adr-0003-proton-download-manager.md` (F010)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs` (F011, F012, F013)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs` (F011)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs` (F014)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs` (F016, F017)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs` (F016)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs` (F016)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs` (F016)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs` (F015)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs` (F015)
-- `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs` (F019; F018 attempted and rejected)
-- `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx` (F020)
-- `src/crosshook-native/src/styles/proton-manager.css` (F020)
-- `src/crosshook-native/src/types/protonup.ts` (F011)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs` (Fixed F023)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs` (Fixed F024)
+- `src/crosshook-native/src-tauri/src/commands/protonup.rs` (Fixed F025)
+- `src/crosshook-native/src/hooks/useProtonManager.ts` (Fixed F027)
+- `src/crosshook-native/src/styles/proton-manager.css` (Fixed F026)
 
 ## Failed Fixes
 
-### F018 — `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs:32`
+### F021 — `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs:4`
 
-**Severity**: MEDIUM  
-**Category**: Security  
-**Description**: The suggested fix pushes broad `/home` / `/root` paths through `SystemPathRefused` instead of `PathOutsideKnownRoots`.
-
-**Suggested fix (from review)**: Add `"/home"` and `"/root"` to `SYSTEM_PREFIX_DENYLIST` so broad home-directory paths produce `UninstallError::SystemPathRefused`.
-
-**Blocker**: That change breaks the documented uninstall contract by misclassifying normal user-owned home paths as system paths, and an earlier implementation also blocked valid native Steam uninstall roots under `$HOME/.local/share/Steam/compatibilitytools.d`.
-
-**Recommendation**: Keep the current `PathOutsideKnownRoots` behavior for unmatched home paths unless the product/API contract is deliberately changed. If explicit reclassification is still desired, update the module docs, user-facing copy, and tests first, then revisit the design in a dedicated follow-up.
+**Severity**: LOW
+**Category**: Completeness
+**Description**: `run_migrations` snapshots `user_version` once at start; a mid-run failure leaves the DB at the last committed version. Pre-existing pattern, not introduced by this PR.
+**Suggested fix (from review)**: No action required for this PR. If future migrations add irreversible operations, consider re-reading `user_version` after each migration or wrapping the full sequence in a single transaction.
+**Blocker**: The suggested fix is explicitly non-actionable for this PR, so changing migration behavior here would go beyond the finding's own stated scope.
+**Recommendation**: Leave `run_migrations` unchanged in this PR. If irreversible migrations are added later, open a dedicated follow-up to revisit transaction boundaries or version re-reads.
 
 ## Validation Results
 
-| Check               | Result |
-| ------------------- | ------ |
-| Type check          | Pass   |
-| Frontend type check | Pass   |
-| Tests               | Pass   |
+| Check      | Result                                                                                                                                       |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Type check | Fail (`npx tsc --noEmit -p src/crosshook-native/tsconfig.json` reports existing errors in `src/crosshook-native/src/lib/plugin-stubs/fs.ts`) |
+| Tests      | Pass (`cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core`)                                                        |
+
+## Post-change Review
+
+No findings were reported by the required code-review pass on the local diff.
+
+Residual validation gap:
+
+- There is no focused test that exercises concurrent first-call initialization of `protonup_http_client()`.
+- Frontend-only edits were not covered by browser or component tests because this repo does not ship a frontend test framework.
 
 ## Next Steps
 
-- Re-run `$code-review 281` to verify the remaining open findings and confirm the fixed ones stay resolved.
-- Decide whether `F018` should remain a documentation-level disagreement or become a separate design issue.
-- Run `$git-workflow` when you want to commit the fix batch.
+- Re-run `$code-review 281` to confirm the remaining review state from the updated artifact
+- Address `F021` only if you want to take on migration behavior as a separate follow-up
+- Investigate the existing TypeScript errors in `src/crosshook-native/src/lib/plugin-stubs/fs.ts`
+- Run `$git-workflow` when you are ready to commit the fixes

--- a/docs/prps/reviews/pr-281-review.md
+++ b/docs/prps/reviews/pr-281-review.md
@@ -59,47 +59,47 @@ Ambitious, well-scoped replacement for ProtonUp-Qt orchestration — clean `Prot
 ### MEDIUM
 
 - **[F010]** `docs/architecture/adr-0003-proton-download-manager.md:67` — The ADR treats Proton-EM as a "future" browse-only provider with `supports_install() → false`, but the shipped `proton_em.rs:38` sets `supports_install() → true` with `ChecksumKind::None`. Leaves the `ChecksumKind::None` install pathway undocumented in the authoritative design record. [maintainability]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Maintainability
   - **Suggested fix**: Update ADR-0003 § _Provider trait_ to reflect that Proton-EM ships install-capable with `ChecksumKind::None`, and add a note that `None` is a first-class (flagged) install path rather than a deferred case.
 - **[F011]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:90` — `InstallError::Cancelled` maps to `ProtonUpInstallErrorKind::Unknown` in `to_result()`. Today this is reached only through the legacy `install_version` wrapper (which discards the error variant), but any future caller that inspects `error_kind` will misclassify cancellations. [completeness]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Completeness
   - **Suggested fix**: Add a `Cancelled` variant to `ProtonUpInstallErrorKind` on both the Rust enum and the TS union in `src/types/protonup.ts`, and route `InstallError::Cancelled` to it.
 - **[F012]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:407` — `tar::Archive::unpack_in` (crate 0.4.x) enforces the destination-prefix invariant on regular entries, but does not sanitize symlink _targets_ during extraction. An archive containing `GE-ProtonX/escape -> /etc` followed by `GE-ProtonX/escape/payload` can effect a symlink-chain escape outside `dest_dir`. [security]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Security
   - **Suggested fix**: Either (a) iterate `archive.entries_with_seek()?` first and reject any `Symlink`/`Hardlink` whose `link_name()` resolves (via `dest_dir.join(link).canonicalize()`) outside `dest_dir`, or (b) disable symlink/hardlink extraction for the Proton tarballs (none of GE-Proton / CachyOS / EM require them for operation). Document the choice in a module-level comment.
 - **[F013]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:674` — `archive_filename` derived from the last `/`-segment of `download_url` is not validated for path separators or `..` before being interpolated into `format!(".tmp.{archive_filename}")`. Not directly exploitable (destination is canonicalized under `compatibilitytools.d`), but a hardening gap that depends on F001 being fixed. [security]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Security
   - **Suggested fix**: After deriving `archive_filename`, reject any value that contains `/`, `\\`, NUL, or `..` components: `if archive_filename.is_empty() || archive_filename.contains('/') || archive_filename.contains("..") { return Err(InstallError::InvalidPath(...)); }`.
 - **[F014]** `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs:39` — The 64-slot broadcast channel silently drops progress messages under back-pressure (`let _ = tx.send(...)`). The 256 KiB `EMIT_INTERVAL_BYTES` throttle in the download phase is fine; the non-download phases have no rate limit and, combined with the Tauri event pump at `src-tauri/.../commands/protonup.rs:273`, can flood the webview during fast verify/extract transitions. [performance]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Performance
   - **Suggested fix**: Either (a) document the 64-slot cap as the intentional rate limit, or (b) add a minimum-interval coalescer in the pump task (e.g., 50 ms) so the webview receives at most 20 progress events/second regardless of phase. Verify with a stress-test that an 80 Mbps download does not emit more than 10 events/s.
 - **[F015]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs:79` (and `luxtorpeda.rs:79`) — Both catalog-only providers define an identical `releases_to_versions` function whose body is a single call to `build_versions_from_releases`. The abstraction adds zero value. [maintainability]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Maintainability
   - **Suggested fix**: Inline the three-line call and delete the local `releases_to_versions` functions in both files.
 - **[F016]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs:59` (and `proton_cachyos.rs`, `proton_em.rs`) — All three installable providers have identical `fetch()` bodies (same headers, same `error_for_status`, same deserialize-then-`parse_releases`). The only differences are the URL constant and, in one case, a feature flag. The trait exists to deduplicate this. [maintainability]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Maintainability
   - **Suggested fix**: Extract `async fn fetch_github_releases(client: &reqwest::Client, url: &str) -> Result<Vec<GhRelease>, ProviderError>` as `pub(super)` in `providers/mod.rs` and have the five providers call it, keeping only `parse_releases(...)` in the provider body. (This also gives F005 a single choke point for size limits.)
 - **[F017]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs:253` — `parse_releases` applies `take(max)` before `filter_map(gh_release_to_version)`. If the first `max` GitHub releases are drafts or lack a supported tarball asset, `filter_map` drops them and the final vector is short. Example: a catalog with `max = 30` draft/no-tarball entries followed by 30 valid releases returns 0 entries instead of 30. [correctness]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Correctness
   - **Suggested fix**: Reorder to `.filter(...).filter_map(|r| gh_release_to_version(r, provider_id)).take(max).collect()` so `take` caps successfully parsed versions rather than releases attempted.
 - **[F018]** `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs:32` — `SYSTEM_PREFIX_DENYLIST` covers `/usr`, `/opt`, `/snap`, and the Flatpak runtime tree, but not `/home` or `/root`. The `PathOutsideKnownRoots` check at step 3 still prevents deletion of arbitrary home paths, so the refusal fires via the _wrong_ gate. Defense-in-depth matters here because this module is the last line before `fs::remove_dir_all`. [security]
-  - **Status**: Open
+  - **Status**: Failed
   - **Category**: Security
   - **Suggested fix**: Add `"/home"` and `"/root"` to `SYSTEM_PREFIX_DENYLIST` so broad home-directory paths produce `UninstallError::SystemPathRefused` (the stated property) rather than relying on step 3.
 - **[F019]** `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs:147` — The system-path refusal test accepts either `SystemPathRefused` or `PathOutsideKnownRoots`. There is no isolated test that the canonical `STEAM_SYSTEM_ROOTS` entries are refused specifically via `SystemPathRefused`. A regression that removed the `STEAM_SYSTEM_ROOTS` list would still pass. [completeness]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Completeness
   - **Suggested fix**: Add a test that constructs a tempdir whose canonical path matches one of the `STEAM_SYSTEM_ROOTS` entries (via a bind-style tempdir or by calling `plan_uninstall_core` with a pre-canonicalized path) and asserts `UninstallError::SystemPathRefused` exactly.
 - **[F020]** `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx:106` — Uninstall confirmation uses `window.confirm()`, a synchronous native dialog that bypasses the app's styling, accessibility baseline, and keyboard-trap conventions. [maintainability]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Maintainability
   - **Suggested fix**: Replace with the project's modal/dialog component (consistent with how other destructive actions confirm) or an inline `aria-live`-backed confirmation pattern; preserve the existing "type the version to confirm" affordance if one exists elsewhere in the app.
 

--- a/docs/prps/reviews/pr-281-review.md
+++ b/docs/prps/reviews/pr-281-review.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-Ambitious, well-scoped replacement for ProtonUp-Qt orchestration — clean `ProtonReleaseProvider` trait, streaming install orchestrator with cancel tokens, Flatpak `:ro` resolver, SQLite v22/v23 schema work, and matching TS/React UI. Validation is green (1058 cargo tests, clippy `-D warnings`, rustfmt, biome, tsc, host-gateway). However, the native download-and-extract path — which is supply-chain-adjacent — ships with one CRITICAL symlink-redirect vulnerability in the `compatibilitytools.d` install-root check and three HIGH hardening gaps around URL origin allowlisting and unbounded response bodies. Merge blocked until F001–F004 and F007 are addressed; the remaining findings are strong improvements but not strict blockers.
+Ambitious, well-scoped replacement for ProtonUp-Qt orchestration — clean `ProtonReleaseProvider` trait, streaming install orchestrator with cancel tokens, Flatpak `:ro` resolver, SQLite v22/v23 schema work, and matching TS/React UI. Validation is green (1058 cargo tests, clippy `-D warnings`, rustfmt, biome, tsc, host-gateway). F001–F004 and F007 are now **Fixed** in the findings table. Merge remains blocked on **F018** (High — `SYSTEM_PREFIX_DENYLIST` defense-in-depth for `/home` / `/root` in uninstall); **F021** (Low — pre-existing migration transaction pattern) is documented as out of scope for this PR.
 
 ## Findings
 
@@ -46,7 +46,7 @@ Ambitious, well-scoped replacement for ProtonUp-Qt orchestration — clean `Prot
 - **[F007]** `src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx:91` — The Cancel button (rendered in the non-terminal branch) has no `aria-label`, while the Dismiss button at :82 correctly sets `aria-label="Dismiss install status"`. Screen-reader users tabbing to an active install will hit an unlabeled interactive control. [a11y]
   - **Status**: Fixed
   - **Category**: Maintainability
-  - **Suggested fix**: Add `aria-label={\`Cancel install ${opId.slice(0, 8)}\`}`(or a stable`"Cancel Proton install"`) to the Cancel`<button>`, mirroring the Dismiss button pattern.
+  - **Suggested fix**: Add ``aria-label={`Cancel install ${opId.slice(0, 8)}`}`` (or a stable `"Cancel Proton install"`) to the Cancel `<button>`, mirroring the Dismiss button pattern.
 - **[F008]** `src/crosshook-native/src/hooks/useProtonManager.ts:186` — `console.warn` left in production code inside the per-provider catalog fan-out catch block. Fires on every provider catalog failure in the shipped binary. Per CLAUDE.md, `console.log`/`console.warn` should not be in shipped frontend code. [pattern]
   - **Status**: Fixed
   - **Category**: Pattern Compliance

--- a/docs/prps/reviews/pr-281-review.md
+++ b/docs/prps/reviews/pr-281-review.md
@@ -106,31 +106,31 @@ Ambitious, well-scoped replacement for ProtonUp-Qt orchestration — clean `Prot
 ### LOW
 
 - **[F021]** `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs:4` — `run_migrations` snapshots `user_version` once at start; a mid-run failure leaves the DB at the last committed version. Pre-existing pattern, not introduced by this PR. [completeness]
-  - **Status**: Open
+  - **Status**: Failed
   - **Category**: Completeness
   - **Suggested fix**: No action required for this PR. If future migrations add irreversible operations, consider re-reading `user_version` after each migration or wrapping the full sequence in a single transaction.
 - **[F022]** `src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs:1` — No explicit composite index on `(provider_id, fetched_at)` on `proton_release_catalog`. With 3 providers × ~30 rows each, performance is fine today, but a composite index makes the `ORDER BY fetched_at DESC` query planner-friendly as the cache ages. [performance]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Performance
   - **Suggested fix**: Add `CREATE INDEX IF NOT EXISTS idx_proton_release_catalog_provider_fetched ON proton_release_catalog(provider_id, fetched_at DESC)` to the v22 migration (or a follow-up v24 if v22 is considered frozen).
 - **[F023]** `src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs:53` — Benign `OnceLock` TOCTOU in `protonup_http_client`: two concurrent first-callers can both construct a `reqwest::Client`; the losing one is dropped. Equivalent clients means no correctness hazard. [security]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Performance
   - **Suggested fix**: Use `OnceLock::get_or_try_init` (Rust ≥ 1.80) or `tokio::sync::OnceCell` to make initialization strictly atomic. Cosmetic.
 - **[F024]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:564` — `extract_archive` is offloaded to `spawn_blocking` but has no cancellation check inside the tar loop. For multi-GB archives, the user waits for extraction to complete before cancel takes effect. [correctness]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Correctness
   - **Suggested fix**: Document as a known limitation in a module-level comment. A full fix requires a streaming async tar extractor; consider a periodic `cancel.is_cancelled()` check between archive entries by manually iterating `archive.entries()?` instead of calling `unpack_in` (this also enables F012's per-entry symlink validation).
 - **[F025]** `src/crosshook-native/src-tauri/src/commands/protonup.rs:18` — `const DEFAULT_PROVIDER_ID: &str = "ge-proton";` is declared between two `use` blocks rather than after all `use` items. Minor layout nit. [pattern]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Pattern Compliance
   - **Suggested fix**: Move the constant below all `use` statements, above the first struct/function definition.
 - **[F026]** `src/crosshook-native/src/components/proton-manager/VersionRow.tsx:38` — Status pill (`Installed` / `Available`) conveys state through both text and class-based color. Fine today, but confirm the `--installed` / `--available` colors meet WCAG AA contrast against `var(--crosshook-color-surface)` in both light and dark themes. [a11y]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Maintainability
   - **Suggested fix**: Run a contrast check (or rely on the existing theme-token contrast audit if one exists) and document the results; no runtime change required if ratios pass.
 - **[F027]** `src/crosshook-native/src/hooks/useProtonManager.ts:85` — `ALL_MODE_SENTINEL = null` is a zero-abstraction constant; it does not add beyond an inline comment. [maintainability]
-  - **Status**: Open
+  - **Status**: Fixed
   - **Category**: Maintainability
   - **Suggested fix**: Either inline `null` with a brief comment at each use site, or promote the constant to a discriminated-union type (`type ProviderSelection = { kind: 'all' } | { kind: 'specific'; id: string }`). As-is it adds a name without carrying semantics.
 

--- a/docs/prps/reviews/pr-281-review.md
+++ b/docs/prps/reviews/pr-281-review.md
@@ -1,0 +1,197 @@
+# PR Review #281 — feat(protonup): native Proton download manager with AppImage/Flatpak parity
+
+**Reviewed**: 2026-04-17
+**Mode**: PR
+**Author**: yandy-r
+**Branch**: `feat/native-proton-manager` → `main`
+**Head SHA**: `2f1d812a12b615b955baff9bc778a0d25c66fd90`
+**Closes**: #274
+**Decision**: REQUEST CHANGES
+
+## Summary
+
+Ambitious, well-scoped replacement for ProtonUp-Qt orchestration — clean `ProtonReleaseProvider` trait, streaming install orchestrator with cancel tokens, Flatpak `:ro` resolver, SQLite v22/v23 schema work, and matching TS/React UI. Validation is green (1058 cargo tests, clippy `-D warnings`, rustfmt, biome, tsc, host-gateway). However, the native download-and-extract path — which is supply-chain-adjacent — ships with one CRITICAL symlink-redirect vulnerability in the `compatibilitytools.d` install-root check and three HIGH hardening gaps around URL origin allowlisting and unbounded response bodies. Merge blocked until F001–F004 and F007 are addressed; the remaining findings are strong improvements but not strict blockers.
+
+## Findings
+
+### CRITICAL
+
+- **[F001]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:147` — Symlink-based install-root redirect. `validate_install_destination` checks that the path contains a `compatibilitytools.d` segment **before** calling `path.canonicalize()`. If an attacker (or a misconfigured user install) places a symlink at a `compatibilitytools.d` component that resolves outside the Steam tree (e.g., `~/.local/share/Steam/compatibilitytools.d` → `/`), the pre-canonicalize check passes and the returned canonical `dest_dir` is handed directly to `entry.unpack_in(dest_dir)` at install.rs:432, extracting into the symlink target. [security]
+  - **Status**: Fixed
+  - **Category**: Security
+  - **Suggested fix**: After `path.canonicalize()` at install.rs:147, re-run the `has_compat_segment` check on the canonical result and return `Err(InstallError::InvalidPath(...))` if the resolved path no longer contains a `compatibilitytools.d` component. Add a unit test that creates a tempdir symlink at a `compatibilitytools.d/` path pointing to a sibling directory and asserts the install is refused.
+
+### HIGH
+
+- **[F002]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:304` — Unbounded response body for checksum fetches (`fetch_sha512_sidecar` at :304 and `fetch_sha256_manifest` at :341). Both call `.text().await` with no byte cap. Legitimate sidecars are ~200 B and manifests a few KiB; a hostile or mis-served CDN response would be buffered into RAM for the full 10 s timeout window. [security]
+  - **Status**: Fixed
+  - **Category**: Security
+  - **Suggested fix**: Gate on `response.content_length()` with a hard ceiling (e.g., 1 MiB) before calling `.text()`, or stream via `bytes_stream()` with a running byte counter that errors past 64 KiB.
+- **[F003]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:681` — No URL origin allowlist before download. `download_url` and `checksum_url` originate from the `ProtonUpAvailableVersion` catalog entry (persisted in the SQLite cache from upstream GitHub responses). The `protonup_install_version_async` handler at src-tauri/.../protonup.rs:244 checks for client-vs-server URL mismatch (anti-frontend-tamper), but no code enforces that the host is `github.com` / `objects.githubusercontent.com`. A poisoned cache row or compromised upstream response could point the downloader at an attacker-controlled host. [security]
+  - **Status**: Fixed
+  - **Category**: Security
+  - **Suggested fix**: Add a `validate_release_url(url: &str) -> Result<(), InstallError>` helper in `install.rs` that asserts `https` scheme and host ∈ {`github.com`, `api.github.com`, `objects.githubusercontent.com`}. Call it for `download_url` just after resolution at install.rs:663 and for `checksum_url` before `fetch_sha512_sidecar` / `fetch_sha256_manifest`. Apply the same check in provider-constructed checksum URLs (e.g., boxtron.rs:286).
+- **[F004]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:782` — `Sha256Manifest` missing-`checksum_url` path calls `best_effort_cleanup` inside the `ok_or_else` closure but never emits `Phase::Failed`. Every other error branch in the checksum dispatch (lines 750, 763, 775, 797, 811) emits a terminal `Phase::Failed` event. When a `Sha256Manifest` provider ships a version with no `checksum_url`, the frontend progress bar gets stuck permanently in `Verifying` with no terminal event. [correctness]
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Resolve the `ok_or_else` result into a local, emit `Phase::Failed` via `em` before the `?`, then propagate: `let manifest_url = match version_info.checksum_url.as_deref() { Some(u) => u, None => { best_effort_cleanup(&temp_path, None); if let Some(em) = em { em.emit(Phase::Failed, 0, None, Some(err.to_string())); } return Err(InstallError::ChecksumMissing(...)); } };`.
+- **[F005]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs:69` (and `ge_proton.rs:65`, `proton_cachyos.rs:63`, `proton_em.rs:68`, `luxtorpeda.rs:69`) — Unbounded `response.json::<Vec<GhRelease>>().await` for catalog fetch. The 10 s `protonup_http_client` timeout limits duration but not byte volume; a trickle attack can still buffer a large payload. [security]
+  - **Status**: Fixed
+  - **Category**: Security
+  - **Suggested fix**: Add a shared `fetch_github_releases(client, url)` helper in `providers/mod.rs` that rejects responses with `content_length > MAX_CATALOG_BYTES` (e.g., 10 MiB) or streams via `bytes_stream()` with a running counter. Wire all five providers through it (also addresses F016).
+- **[F006]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs:94` — `registry(include_prereleases: bool)` accepts a parameter it immediately drops with `let _ = include_prereleases`, and `describe_providers()` at :141 calls `registry(false)` — a silent default. The prerelease flag belongs on `fetch()` (where it actually filters), not on registry enumeration, and keeping it here is misleading API surface. [maintainability]
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: Remove `include_prereleases` from the `registry()` and `find_provider_by_id()` signatures and from every call site. Keep the flag only on the `fetch()` path where it is actually consumed.
+- **[F007]** `src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx:91` — The Cancel button (rendered in the non-terminal branch) has no `aria-label`, while the Dismiss button at :82 correctly sets `aria-label="Dismiss install status"`. Screen-reader users tabbing to an active install will hit an unlabeled interactive control. [a11y]
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: Add `aria-label={\`Cancel install ${opId.slice(0, 8)}\`}`(or a stable`"Cancel Proton install"`) to the Cancel`<button>`, mirroring the Dismiss button pattern.
+- **[F008]** `src/crosshook-native/src/hooks/useProtonManager.ts:186` — `console.warn` left in production code inside the per-provider catalog fan-out catch block. Fires on every provider catalog failure in the shipped binary. Per CLAUDE.md, `console.log`/`console.warn` should not be in shipped frontend code. [pattern]
+  - **Status**: Fixed
+  - **Category**: Pattern Compliance
+  - **Suggested fix**: Remove the `console.warn` and propagate the per-provider failure into a `perProviderErrors` map (or the existing `allError` state) so the UI can surface it. If silent fallback is desired, move the diagnostic to `tracing::warn!` on the Rust side.
+- **[F009]** `src/crosshook-native/src/types/protonup.ts:3` — `ProtonUpProvider` is a narrow literal union (`'ge-proton' | 'proton-cachyos' | 'proton-em'`) while `providers/mod.rs` may emit `'boxtron'` or `'luxtorpeda'` under the `experimental-providers` cargo feature. The unsafe cast `(selectedProviderId ?? 'ge-proton') as ProtonUpProvider` at `src/hooks/useProtonManager.ts:119` suppresses the type error instead of handling the widening at runtime. [type-safety]
+  - **Status**: Fixed
+  - **Category**: Type Safety
+  - **Suggested fix**: Widen `ProtonUpProvider` to `string` (and document the canonical IDs) or explicitly add `'boxtron' | 'luxtorpeda'` to the union. Remove the `as ProtonUpProvider` assertion at `useProtonManager.ts:119`; if a narrowing is needed, validate the string against a runtime Set of known IDs.
+
+### MEDIUM
+
+- **[F010]** `docs/architecture/adr-0003-proton-download-manager.md:67` — The ADR treats Proton-EM as a "future" browse-only provider with `supports_install() → false`, but the shipped `proton_em.rs:38` sets `supports_install() → true` with `ChecksumKind::None`. Leaves the `ChecksumKind::None` install pathway undocumented in the authoritative design record. [maintainability]
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Update ADR-0003 § _Provider trait_ to reflect that Proton-EM ships install-capable with `ChecksumKind::None`, and add a note that `None` is a first-class (flagged) install path rather than a deferred case.
+- **[F011]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:90` — `InstallError::Cancelled` maps to `ProtonUpInstallErrorKind::Unknown` in `to_result()`. Today this is reached only through the legacy `install_version` wrapper (which discards the error variant), but any future caller that inspects `error_kind` will misclassify cancellations. [completeness]
+  - **Status**: Open
+  - **Category**: Completeness
+  - **Suggested fix**: Add a `Cancelled` variant to `ProtonUpInstallErrorKind` on both the Rust enum and the TS union in `src/types/protonup.ts`, and route `InstallError::Cancelled` to it.
+- **[F012]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:407` — `tar::Archive::unpack_in` (crate 0.4.x) enforces the destination-prefix invariant on regular entries, but does not sanitize symlink _targets_ during extraction. An archive containing `GE-ProtonX/escape -> /etc` followed by `GE-ProtonX/escape/payload` can effect a symlink-chain escape outside `dest_dir`. [security]
+  - **Status**: Open
+  - **Category**: Security
+  - **Suggested fix**: Either (a) iterate `archive.entries_with_seek()?` first and reject any `Symlink`/`Hardlink` whose `link_name()` resolves (via `dest_dir.join(link).canonicalize()`) outside `dest_dir`, or (b) disable symlink/hardlink extraction for the Proton tarballs (none of GE-Proton / CachyOS / EM require them for operation). Document the choice in a module-level comment.
+- **[F013]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:674` — `archive_filename` derived from the last `/`-segment of `download_url` is not validated for path separators or `..` before being interpolated into `format!(".tmp.{archive_filename}")`. Not directly exploitable (destination is canonicalized under `compatibilitytools.d`), but a hardening gap that depends on F001 being fixed. [security]
+  - **Status**: Open
+  - **Category**: Security
+  - **Suggested fix**: After deriving `archive_filename`, reject any value that contains `/`, `\\`, NUL, or `..` components: `if archive_filename.is_empty() || archive_filename.contains('/') || archive_filename.contains("..") { return Err(InstallError::InvalidPath(...)); }`.
+- **[F014]** `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs:39` — The 64-slot broadcast channel silently drops progress messages under back-pressure (`let _ = tx.send(...)`). The 256 KiB `EMIT_INTERVAL_BYTES` throttle in the download phase is fine; the non-download phases have no rate limit and, combined with the Tauri event pump at `src-tauri/.../commands/protonup.rs:273`, can flood the webview during fast verify/extract transitions. [performance]
+  - **Status**: Open
+  - **Category**: Performance
+  - **Suggested fix**: Either (a) document the 64-slot cap as the intentional rate limit, or (b) add a minimum-interval coalescer in the pump task (e.g., 50 ms) so the webview receives at most 20 progress events/second regardless of phase. Verify with a stress-test that an 80 Mbps download does not emit more than 10 events/s.
+- **[F015]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs:79` (and `luxtorpeda.rs:79`) — Both catalog-only providers define an identical `releases_to_versions` function whose body is a single call to `build_versions_from_releases`. The abstraction adds zero value. [maintainability]
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Inline the three-line call and delete the local `releases_to_versions` functions in both files.
+- **[F016]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs:59` (and `proton_cachyos.rs`, `proton_em.rs`) — All three installable providers have identical `fetch()` bodies (same headers, same `error_for_status`, same deserialize-then-`parse_releases`). The only differences are the URL constant and, in one case, a feature flag. The trait exists to deduplicate this. [maintainability]
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Extract `async fn fetch_github_releases(client: &reqwest::Client, url: &str) -> Result<Vec<GhRelease>, ProviderError>` as `pub(super)` in `providers/mod.rs` and have the five providers call it, keeping only `parse_releases(...)` in the provider body. (This also gives F005 a single choke point for size limits.)
+- **[F017]** `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs:253` — `parse_releases` applies `take(max)` before `filter_map(gh_release_to_version)`. If the first `max` GitHub releases are drafts or lack a supported tarball asset, `filter_map` drops them and the final vector is short. Example: a catalog with `max = 30` draft/no-tarball entries followed by 30 valid releases returns 0 entries instead of 30. [correctness]
+  - **Status**: Open
+  - **Category**: Correctness
+  - **Suggested fix**: Reorder to `.filter(...).filter_map(|r| gh_release_to_version(r, provider_id)).take(max).collect()` so `take` caps successfully parsed versions rather than releases attempted.
+- **[F018]** `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs:32` — `SYSTEM_PREFIX_DENYLIST` covers `/usr`, `/opt`, `/snap`, and the Flatpak runtime tree, but not `/home` or `/root`. The `PathOutsideKnownRoots` check at step 3 still prevents deletion of arbitrary home paths, so the refusal fires via the _wrong_ gate. Defense-in-depth matters here because this module is the last line before `fs::remove_dir_all`. [security]
+  - **Status**: Open
+  - **Category**: Security
+  - **Suggested fix**: Add `"/home"` and `"/root"` to `SYSTEM_PREFIX_DENYLIST` so broad home-directory paths produce `UninstallError::SystemPathRefused` (the stated property) rather than relying on step 3.
+- **[F019]** `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs:147` — The system-path refusal test accepts either `SystemPathRefused` or `PathOutsideKnownRoots`. There is no isolated test that the canonical `STEAM_SYSTEM_ROOTS` entries are refused specifically via `SystemPathRefused`. A regression that removed the `STEAM_SYSTEM_ROOTS` list would still pass. [completeness]
+  - **Status**: Open
+  - **Category**: Completeness
+  - **Suggested fix**: Add a test that constructs a tempdir whose canonical path matches one of the `STEAM_SYSTEM_ROOTS` entries (via a bind-style tempdir or by calling `plan_uninstall_core` with a pre-canonicalized path) and asserts `UninstallError::SystemPathRefused` exactly.
+- **[F020]** `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx:106` — Uninstall confirmation uses `window.confirm()`, a synchronous native dialog that bypasses the app's styling, accessibility baseline, and keyboard-trap conventions. [maintainability]
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Replace with the project's modal/dialog component (consistent with how other destructive actions confirm) or an inline `aria-live`-backed confirmation pattern; preserve the existing "type the version to confirm" affordance if one exists elsewhere in the app.
+
+### LOW
+
+- **[F021]** `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs:4` — `run_migrations` snapshots `user_version` once at start; a mid-run failure leaves the DB at the last committed version. Pre-existing pattern, not introduced by this PR. [completeness]
+  - **Status**: Open
+  - **Category**: Completeness
+  - **Suggested fix**: No action required for this PR. If future migrations add irreversible operations, consider re-reading `user_version` after each migration or wrapping the full sequence in a single transaction.
+- **[F022]** `src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs:1` — No explicit composite index on `(provider_id, fetched_at)` on `proton_release_catalog`. With 3 providers × ~30 rows each, performance is fine today, but a composite index makes the `ORDER BY fetched_at DESC` query planner-friendly as the cache ages. [performance]
+  - **Status**: Open
+  - **Category**: Performance
+  - **Suggested fix**: Add `CREATE INDEX IF NOT EXISTS idx_proton_release_catalog_provider_fetched ON proton_release_catalog(provider_id, fetched_at DESC)` to the v22 migration (or a follow-up v24 if v22 is considered frozen).
+- **[F023]** `src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs:53` — Benign `OnceLock` TOCTOU in `protonup_http_client`: two concurrent first-callers can both construct a `reqwest::Client`; the losing one is dropped. Equivalent clients means no correctness hazard. [security]
+  - **Status**: Open
+  - **Category**: Performance
+  - **Suggested fix**: Use `OnceLock::get_or_try_init` (Rust ≥ 1.80) or `tokio::sync::OnceCell` to make initialization strictly atomic. Cosmetic.
+- **[F024]** `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs:564` — `extract_archive` is offloaded to `spawn_blocking` but has no cancellation check inside the tar loop. For multi-GB archives, the user waits for extraction to complete before cancel takes effect. [correctness]
+  - **Status**: Open
+  - **Category**: Correctness
+  - **Suggested fix**: Document as a known limitation in a module-level comment. A full fix requires a streaming async tar extractor; consider a periodic `cancel.is_cancelled()` check between archive entries by manually iterating `archive.entries()?` instead of calling `unpack_in` (this also enables F012's per-entry symlink validation).
+- **[F025]** `src/crosshook-native/src-tauri/src/commands/protonup.rs:18` — `const DEFAULT_PROVIDER_ID: &str = "ge-proton";` is declared between two `use` blocks rather than after all `use` items. Minor layout nit. [pattern]
+  - **Status**: Open
+  - **Category**: Pattern Compliance
+  - **Suggested fix**: Move the constant below all `use` statements, above the first struct/function definition.
+- **[F026]** `src/crosshook-native/src/components/proton-manager/VersionRow.tsx:38` — Status pill (`Installed` / `Available`) conveys state through both text and class-based color. Fine today, but confirm the `--installed` / `--available` colors meet WCAG AA contrast against `var(--crosshook-color-surface)` in both light and dark themes. [a11y]
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Run a contrast check (or rely on the existing theme-token contrast audit if one exists) and document the results; no runtime change required if ratios pass.
+- **[F027]** `src/crosshook-native/src/hooks/useProtonManager.ts:85` — `ALL_MODE_SENTINEL = null` is a zero-abstraction constant; it does not add beyond an inline comment. [maintainability]
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Either inline `null` with a brief comment at each use site, or promote the constant to a discriminated-union type (`type ProviderSelection = { kind: 'all' } | { kind: 'specific'; id: string }`). As-is it adds a name without carrying semantics.
+
+## Validation Results
+
+| Check        | Result                                       |
+| ------------ | -------------------------------------------- |
+| Type check   | Pass (`tsc --noEmit`)                        |
+| Lint         | Pass (rustfmt, `clippy -D warnings`, biome)  |
+| Tests        | Pass (`cargo test -p crosshook-core` — 1058) |
+| Build        | Skipped (CI `build-native.sh --binary-only`) |
+| Host-gateway | Pass (`scripts/check-host-gateway.sh`)       |
+
+## Files Reviewed
+
+- `AGENTS.md` (Modified)
+- `CHANGELOG.md` (Modified)
+- `CLAUDE.md` (Modified)
+- `docs/architecture/adr-0003-proton-download-manager.md` (Added)
+- `src/crosshook-native/Cargo.lock` (Modified)
+- `src/crosshook-native/crates/crosshook-core/Cargo.toml` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/install.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/install_root.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs` (Modified)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs` (Added)
+- `src/crosshook-native/crates/crosshook-core/src/settings/mod.rs` (Modified)
+- `src/crosshook-native/src-tauri/Cargo.toml` (Modified)
+- `src/crosshook-native/src-tauri/src/commands/protonup.rs` (Modified)
+- `src/crosshook-native/src-tauri/src/commands/settings.rs` (Modified)
+- `src/crosshook-native/src-tauri/src/lib.rs` (Modified)
+- `src/crosshook-native/src/App.tsx` (Modified)
+- `src/crosshook-native/src/components/SettingsPanel.tsx` (Modified)
+- `src/crosshook-native/src/components/icons/SidebarIcons.tsx` (Modified)
+- `src/crosshook-native/src/components/layout/ContentArea.tsx` (Modified)
+- `src/crosshook-native/src/components/layout/PageBanner.tsx` (Modified)
+- `src/crosshook-native/src/components/layout/Sidebar.tsx` (Modified)
+- `src/crosshook-native/src/components/layout/routeMetadata.ts` (Modified)
+- `src/crosshook-native/src/components/pages/ProtonManagerPage.tsx` (Added)
+- `src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx` (Added)
+- `src/crosshook-native/src/components/proton-manager/InstallRootBadge.tsx` (Added)
+- `src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx` (Added)
+- `src/crosshook-native/src/components/proton-manager/ProviderPicker.tsx` (Added)
+- `src/crosshook-native/src/components/proton-manager/VersionRow.tsx` (Added)
+- `src/crosshook-native/src/hooks/useProtonInstallProgress.ts` (Added)
+- `src/crosshook-native/src/hooks/useProtonInstalls.ts` (Modified)
+- `src/crosshook-native/src/hooks/useProtonManager.ts` (Added)
+- `src/crosshook-native/src/hooks/useProtonUp.ts` (Modified)
+- `src/crosshook-native/src/lib/mocks/handlers/protonup.ts` (Modified)
+- `src/crosshook-native/src/lib/protonup/classifyInstall.ts` (Added)
+- `src/crosshook-native/src/lib/protonup/format.ts` (Added)
+- `src/crosshook-native/src/styles/proton-manager.css` (Added)
+- `src/crosshook-native/src/types/protonup.ts` (Modified)
+- `src/crosshook-native/src/types/settings.ts` (Modified)

--- a/src/crosshook-native/Cargo.lock
+++ b/src/crosshook-native/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
 name = "crosshook-core"
 version = "0.2.11"
 dependencies = [
+ "async-trait",
  "chrono",
  "csv",
  "directories",
@@ -667,6 +668,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
@@ -693,6 +695,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
@@ -4887,6 +4890,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/src/crosshook-native/crates/crosshook-core/Cargo.toml
+++ b/src/crosshook-native/crates/crosshook-core/Cargo.toml
@@ -3,6 +3,11 @@ name = "crosshook-core"
 version = "0.2.11"
 edition = "2021"
 
+[features]
+default = []
+# Enable catalog-only Luxtorpeda + Boxtron providers (Batch 3). Disabled in AppImage/Flatpak release builds.
+experimental-providers = []
+
 [dependencies]
 chrono = "0.4"
 csv = "1"
@@ -14,6 +19,7 @@ serde_json = "1"
 toml = "1.1.0"
 tar = "0.4"
 tokio = { version = "1", features = ["fs", "process", "rt", "sync", "time"] }
+tokio-util = { version = "0.7" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",
@@ -22,6 +28,7 @@ tracing-subscriber = { version = "0.3", features = [
 ] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 quick-xml = "0.39.2"
+async-trait = "0.1"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls", "stream"] }
 sha2 = "0.11.0"
@@ -42,5 +49,5 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 wiremock = "0.6"

--- a/src/crosshook-native/crates/crosshook-core/Cargo.toml
+++ b/src/crosshook-native/crates/crosshook-core/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1.0"
 tar = "0.4"
-tokio = { version = "1", features = ["fs", "process", "rt", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "macros", "process", "rt", "sync", "time"] }
 tokio-util = { version = "0.7" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/migrations.rs
@@ -198,6 +198,24 @@ pub fn run_migrations(conn: &Connection) -> Result<(), MetadataStoreError> {
             })?;
     }
 
+    if version < 22 {
+        migrate_21_to_22(conn)?;
+        conn.pragma_update(None, "user_version", 22_u32)
+            .map_err(|source| MetadataStoreError::Database {
+                action: "set user_version to 22",
+                source,
+            })?;
+    }
+
+    if version < 23 {
+        migrate_22_to_23(conn)?;
+        conn.pragma_update(None, "user_version", 23_u32)
+            .map_err(|source| MetadataStoreError::Database {
+                action: "set user_version to 23",
+                source,
+            })?;
+    }
+
     Ok(())
 }
 
@@ -953,6 +971,55 @@ fn migrate_20_to_21(conn: &Connection) -> Result<(), MetadataStoreError> {
     Ok(())
 }
 
+/// Dedicated Proton release catalog table (issue #274).
+///
+/// `external_cache_entries` caps payloads at 512 KiB and blends all provider data into a single
+/// opaque JSON blob; the new typed table allows partial catalog refreshes and per-provider
+/// queries. The DELETE evicts legacy `protonup:catalog:*` entries; they are regenerated on next
+/// fetch, so removing them here is safe.
+fn migrate_21_to_22(conn: &Connection) -> Result<(), MetadataStoreError> {
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS proton_release_catalog (
+            provider_id     TEXT NOT NULL,
+            version_tag     TEXT NOT NULL,
+            payload_json    TEXT NOT NULL,
+            release_url     TEXT,
+            download_url    TEXT,
+            checksum_url    TEXT,
+            checksum_kind   TEXT,
+            asset_size      INTEGER,
+            fetched_at      TEXT NOT NULL,
+            expires_at      TEXT,
+            PRIMARY KEY (provider_id, version_tag)
+        );
+        CREATE INDEX IF NOT EXISTS idx_proton_catalog_provider_fetched
+            ON proton_release_catalog(provider_id, fetched_at);
+
+        DELETE FROM external_cache_entries WHERE cache_key LIKE 'protonup:catalog:%';
+        ",
+    )
+    .map_err(|source| MetadataStoreError::Database {
+        action: "run metadata migration 21 to 22",
+        source,
+    })?;
+
+    Ok(())
+}
+
+/// v23 — evict cached Proton release payloads so newly-added DTO fields
+/// (notably `published_at`) repopulate on next fetch. The cache is runtime
+/// metadata, not user data; the next catalog call rebuilds it from GitHub.
+fn migrate_22_to_23(conn: &Connection) -> Result<(), MetadataStoreError> {
+    conn.execute_batch("DELETE FROM proton_release_catalog;")
+        .map_err(|source| MetadataStoreError::Database {
+            action: "run metadata migration 22 to 23",
+            source,
+        })?;
+
+    Ok(())
+}
+
 fn migrate_16_to_17(conn: &Connection) -> Result<(), MetadataStoreError> {
     conn.execute_batch(
         "
@@ -1414,6 +1481,131 @@ mod tests {
         assert!(
             idx_exists,
             "unique index idx_readiness_nag_dismissals_tool_id should exist"
+        );
+    }
+
+    #[test]
+    fn migration_21_to_22_creates_proton_release_catalog_table() {
+        let conn = db::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let version: u32 = conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert!(
+            version >= 22,
+            "schema version should be at least 22 after migration 21→22, got {version}"
+        );
+
+        // Table exists.
+        let table_exists: bool = conn
+            .prepare(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='proton_release_catalog'",
+            )
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(table_exists, "proton_release_catalog table should exist");
+
+        // Index exists.
+        let idx_exists: bool = conn
+            .prepare(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_proton_catalog_provider_fetched'",
+            )
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(
+            idx_exists,
+            "index idx_proton_catalog_provider_fetched should exist"
+        );
+    }
+
+    #[test]
+    fn migration_21_to_22_evicts_legacy_protonup_cache_entries() {
+        // Run up to version 21 so external_cache_entries exists.
+        let conn = db::open_in_memory().unwrap();
+        // Run all migrations up to 21 manually (stop before 22) by running the full set;
+        // at schema v21 the external_cache_entries table already exists (added in v3→v4).
+        run_migrations(&conn).unwrap();
+
+        // Reset to v21 and re-insert the legacy row to simulate a pre-migration state.
+        // Because run_migrations is idempotent (CREATE TABLE IF NOT EXISTS), we simulate the
+        // v21 steady state by inserting a legacy cache row, dropping down to v21, re-running
+        // only migrate_21_to_22, and asserting it's gone.
+        //
+        // Simpler approach: insert a legacy row now (post-full-migration, table still exists),
+        // verify it is deleted by checking current count.
+        conn.execute(
+            "INSERT INTO external_cache_entries
+             (cache_id, source_url, cache_key, payload_json, payload_size, fetched_at, expires_at, created_at, updated_at)
+             VALUES ('test-id', 'https://example.com', 'protonup:catalog:ge-proton', '{}', 2,
+                     datetime('now'), datetime('now', '+1 hour'), datetime('now'), datetime('now'))",
+            [],
+        )
+        .unwrap();
+
+        // Confirm the row is visible before the migration evicts it.
+        let before: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM external_cache_entries WHERE cache_key LIKE 'protonup:catalog:%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(before, 1, "legacy row should be present before eviction");
+
+        // Run the migration directly (simulating what run_migrations does at v21→v22).
+        migrate_21_to_22(&conn).unwrap();
+
+        // Assert the legacy row is gone.
+        let after: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM external_cache_entries WHERE cache_key LIKE 'protonup:catalog:%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            after, 0,
+            "legacy protonup:catalog:* entries should be evicted by the migration"
+        );
+    }
+
+    #[test]
+    fn migration_22_to_23_evicts_stale_proton_release_catalog_rows() {
+        // Run migrations so proton_release_catalog exists at v22.
+        let conn = db::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+
+        // Seed a row as if written by v22 code (no published_at in payload_json).
+        conn.execute(
+            "INSERT INTO proton_release_catalog
+             (provider_id, version_tag, payload_json, fetched_at)
+             VALUES ('ge-proton', 'GE-Proton9-21',
+                     '{\"provider\":\"ge-proton\",\"version\":\"GE-Proton9-21\"}',
+                     datetime('now'))",
+            [],
+        )
+        .unwrap();
+
+        let before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proton_release_catalog", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(before, 1, "seeded row must exist before eviction");
+
+        migrate_22_to_23(&conn).unwrap();
+
+        let after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proton_release_catalog", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            after, 0,
+            "v22→v23 migration must evict proton_release_catalog rows so published_at repopulates"
         );
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs
@@ -1457,6 +1457,17 @@ impl MetadataStore {
         })
     }
 
+    /// Atomically replace all cached rows for a provider.
+    pub fn replace_proton_catalog(
+        &self,
+        provider_id: &str,
+        rows: &[ProtonCatalogRow],
+    ) -> Result<(), MetadataStoreError> {
+        self.with_conn_mut("replace proton catalog", |conn| {
+            proton_catalog_store::replace_proton_catalog_impl(conn, provider_id, rows)
+        })
+    }
+
     // -------------------------------------------------------------------------
     // Prefix dependency state persistence
     // -------------------------------------------------------------------------

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/mod.rs
@@ -15,6 +15,7 @@ mod prefix_deps_store;
 mod prefix_storage_store;
 mod preset_store;
 pub mod profile_sync;
+mod proton_catalog_store;
 mod readiness_catalog_store;
 mod readiness_dismissal_store;
 mod readiness_snapshot_store;
@@ -34,6 +35,7 @@ pub use models::{
 };
 pub use offline_store::{CommunityTapOfflineRow, OfflineReadinessRow, TrainerHashCacheRow};
 pub use profile_sync::sha256_hex;
+pub use proton_catalog_store::ProtonCatalogRow;
 pub use readiness_snapshot_store::HostReadinessSnapshotRow;
 pub use version_store::{compute_correlation_status, hash_trainer_file};
 
@@ -1424,6 +1426,34 @@ impl MetadataStore {
     ) -> Result<Option<HostReadinessSnapshotRow>, MetadataStoreError> {
         self.with_conn("get host readiness snapshot", |conn| {
             readiness_snapshot_store::get_host_readiness_snapshot_impl(conn)
+        })
+    }
+
+    // -------------------------------------------------------------------------
+    // Proton release catalog persistence (issue #274)
+    // -------------------------------------------------------------------------
+
+    /// Batch-upsert rows into `proton_release_catalog`.
+    pub fn put_proton_catalog(&self, rows: &[ProtonCatalogRow]) -> Result<(), MetadataStoreError> {
+        self.with_conn_mut("put proton catalog", |conn| {
+            proton_catalog_store::put_proton_catalog_impl(conn, rows)
+        })
+    }
+
+    /// Return all cached rows for `provider_id`, ordered by `fetched_at` descending.
+    pub fn get_proton_catalog(
+        &self,
+        provider_id: &str,
+    ) -> Result<Vec<ProtonCatalogRow>, MetadataStoreError> {
+        self.with_conn("get proton catalog", |conn| {
+            proton_catalog_store::get_proton_catalog_impl(conn, provider_id)
+        })
+    }
+
+    /// Delete all cached rows for `provider_id` (evict stale entries before a refresh).
+    pub fn clear_proton_catalog(&self, provider_id: &str) -> Result<(), MetadataStoreError> {
+        self.with_conn_mut("clear proton catalog", |conn| {
+            proton_catalog_store::clear_proton_catalog_impl(conn, provider_id)
         })
     }
 

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs
@@ -1,0 +1,258 @@
+use rusqlite::Connection;
+
+use crate::metadata::MetadataStoreError;
+
+/// A single row from the `proton_release_catalog` table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtonCatalogRow {
+    pub provider_id: String,
+    pub version_tag: String,
+    pub payload_json: String,
+    pub release_url: Option<String>,
+    pub download_url: Option<String>,
+    pub checksum_url: Option<String>,
+    pub checksum_kind: Option<String>,
+    pub asset_size: Option<i64>,
+    /// ISO-8601 timestamp.
+    pub fetched_at: String,
+    pub expires_at: Option<String>,
+}
+
+/// Batch-upsert rows into `proton_release_catalog`.
+///
+/// Uses `INSERT OR REPLACE` so repeated fetches for the same `(provider_id, version_tag)` key
+/// update the cached payload in place.
+pub fn put_proton_catalog_impl(
+    conn: &mut Connection,
+    rows: &[ProtonCatalogRow],
+) -> Result<(), MetadataStoreError> {
+    let tx = conn
+        .transaction()
+        .map_err(|source| MetadataStoreError::Database {
+            action: "begin proton catalog upsert transaction",
+            source,
+        })?;
+
+    for row in rows {
+        tx.execute(
+            "INSERT OR REPLACE INTO proton_release_catalog (
+                provider_id, version_tag, payload_json, release_url, download_url,
+                checksum_url, checksum_kind, asset_size, fetched_at, expires_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            rusqlite::params![
+                row.provider_id,
+                row.version_tag,
+                row.payload_json,
+                row.release_url,
+                row.download_url,
+                row.checksum_url,
+                row.checksum_kind,
+                row.asset_size,
+                row.fetched_at,
+                row.expires_at,
+            ],
+        )
+        .map_err(|source| MetadataStoreError::Database {
+            action: "upsert proton catalog row",
+            source,
+        })?;
+    }
+
+    tx.commit().map_err(|source| MetadataStoreError::Database {
+        action: "commit proton catalog upsert transaction",
+        source,
+    })?;
+
+    Ok(())
+}
+
+/// Return all cached rows for `provider_id`, ordered by `fetched_at` descending.
+pub fn get_proton_catalog_impl(
+    conn: &Connection,
+    provider_id: &str,
+) -> Result<Vec<ProtonCatalogRow>, MetadataStoreError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT provider_id, version_tag, payload_json, release_url, download_url,
+                    checksum_url, checksum_kind, asset_size, fetched_at, expires_at
+             FROM proton_release_catalog
+             WHERE provider_id = ?1
+             ORDER BY fetched_at DESC",
+        )
+        .map_err(|source| MetadataStoreError::Database {
+            action: "prepare get proton catalog query",
+            source,
+        })?;
+
+    let rows = stmt
+        .query_map([provider_id], |row| {
+            Ok(ProtonCatalogRow {
+                provider_id: row.get(0)?,
+                version_tag: row.get(1)?,
+                payload_json: row.get(2)?,
+                release_url: row.get(3)?,
+                download_url: row.get(4)?,
+                checksum_url: row.get(5)?,
+                checksum_kind: row.get(6)?,
+                asset_size: row.get(7)?,
+                fetched_at: row.get(8)?,
+                expires_at: row.get(9)?,
+            })
+        })
+        .map_err(|source| MetadataStoreError::Database {
+            action: "query proton catalog rows",
+            source,
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| MetadataStoreError::Database {
+            action: "decode proton catalog row",
+            source,
+        })?;
+
+    Ok(rows)
+}
+
+/// Delete all cached rows for `provider_id` (used to evict stale entries before a refresh).
+pub fn clear_proton_catalog_impl(
+    conn: &mut Connection,
+    provider_id: &str,
+) -> Result<(), MetadataStoreError> {
+    conn.execute(
+        "DELETE FROM proton_release_catalog WHERE provider_id = ?1",
+        [provider_id],
+    )
+    .map_err(|source| MetadataStoreError::Database {
+        action: "clear proton catalog for provider",
+        source,
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::db;
+    use crate::metadata::migrations::run_migrations;
+
+    fn open_v22() -> Connection {
+        let conn = db::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn proton_catalog_round_trip() {
+        let mut conn = open_v22();
+
+        let rows = vec![
+            ProtonCatalogRow {
+                provider_id: "ge-proton".to_string(),
+                version_tag: "GE-Proton9-1".to_string(),
+                payload_json: r#"{"tag":"GE-Proton9-1"}"#.to_string(),
+                release_url: Some("https://example.com/release/9-1".to_string()),
+                download_url: Some("https://example.com/GE-Proton9-1.tar.gz".to_string()),
+                checksum_url: Some("https://example.com/GE-Proton9-1.sha512sum".to_string()),
+                checksum_kind: Some("sha512".to_string()),
+                asset_size: Some(512_000_000),
+                fetched_at: "2026-04-17T00:00:00Z".to_string(),
+                expires_at: Some("2026-04-18T00:00:00Z".to_string()),
+            },
+            ProtonCatalogRow {
+                provider_id: "ge-proton".to_string(),
+                version_tag: "GE-Proton9-2".to_string(),
+                payload_json: r#"{"tag":"GE-Proton9-2"}"#.to_string(),
+                release_url: None,
+                download_url: None,
+                checksum_url: None,
+                checksum_kind: None,
+                asset_size: None,
+                fetched_at: "2026-04-17T01:00:00Z".to_string(),
+                expires_at: None,
+            },
+        ];
+
+        put_proton_catalog_impl(&mut conn, &rows).unwrap();
+
+        let fetched = get_proton_catalog_impl(&conn, "ge-proton").unwrap();
+        assert_eq!(fetched.len(), 2);
+
+        // Ordered by fetched_at DESC — GE-Proton9-2 comes first.
+        assert_eq!(fetched[0].version_tag, "GE-Proton9-2");
+        assert_eq!(fetched[1].version_tag, "GE-Proton9-1");
+        assert_eq!(fetched[1].asset_size, Some(512_000_000));
+        assert_eq!(fetched[0].download_url, None);
+
+        // Unknown provider returns empty.
+        let empty = get_proton_catalog_impl(&conn, "unknown-provider").unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn proton_catalog_clear_evicts_provider() {
+        let mut conn = open_v22();
+
+        let row = ProtonCatalogRow {
+            provider_id: "proton-tkg".to_string(),
+            version_tag: "proton-tkg-1".to_string(),
+            payload_json: "{}".to_string(),
+            release_url: None,
+            download_url: None,
+            checksum_url: None,
+            checksum_kind: None,
+            asset_size: None,
+            fetched_at: "2026-04-17T00:00:00Z".to_string(),
+            expires_at: None,
+        };
+        put_proton_catalog_impl(&mut conn, &[row]).unwrap();
+
+        let before = get_proton_catalog_impl(&conn, "proton-tkg").unwrap();
+        assert_eq!(before.len(), 1);
+
+        clear_proton_catalog_impl(&mut conn, "proton-tkg").unwrap();
+
+        let after = get_proton_catalog_impl(&conn, "proton-tkg").unwrap();
+        assert!(
+            after.is_empty(),
+            "clear should evict all rows for the provider"
+        );
+    }
+
+    #[test]
+    fn proton_catalog_upsert_replaces_existing() {
+        let mut conn = open_v22();
+
+        let original = ProtonCatalogRow {
+            provider_id: "ge-proton".to_string(),
+            version_tag: "GE-Proton9-1".to_string(),
+            payload_json: r#"{"original":true}"#.to_string(),
+            release_url: None,
+            download_url: None,
+            checksum_url: None,
+            checksum_kind: None,
+            asset_size: None,
+            fetched_at: "2026-04-17T00:00:00Z".to_string(),
+            expires_at: None,
+        };
+        put_proton_catalog_impl(&mut conn, &[original]).unwrap();
+
+        let updated = ProtonCatalogRow {
+            provider_id: "ge-proton".to_string(),
+            version_tag: "GE-Proton9-1".to_string(),
+            payload_json: r#"{"updated":true}"#.to_string(),
+            release_url: Some("https://example.com".to_string()),
+            download_url: None,
+            checksum_url: None,
+            checksum_kind: None,
+            asset_size: Some(1),
+            fetched_at: "2026-04-17T02:00:00Z".to_string(),
+            expires_at: None,
+        };
+        put_proton_catalog_impl(&mut conn, &[updated]).unwrap();
+
+        let rows = get_proton_catalog_impl(&conn, "ge-proton").unwrap();
+        assert_eq!(rows.len(), 1, "upsert must not duplicate the row");
+        assert_eq!(rows[0].payload_json, r#"{"updated":true}"#);
+        assert_eq!(rows[0].asset_size, Some(1));
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/proton_catalog_store.rs
@@ -33,6 +33,59 @@ pub fn put_proton_catalog_impl(
             source,
         })?;
 
+    upsert_proton_catalog_rows(&tx, rows)?;
+
+    tx.commit().map_err(|source| MetadataStoreError::Database {
+        action: "commit proton catalog upsert transaction",
+        source,
+    })?;
+
+    Ok(())
+}
+
+/// Replace one provider snapshot atomically inside a single transaction.
+///
+/// Deletes all rows for `provider_id` first, then inserts `rows`.
+pub fn replace_proton_catalog_impl(
+    conn: &mut Connection,
+    provider_id: &str,
+    rows: &[ProtonCatalogRow],
+) -> Result<(), MetadataStoreError> {
+    let tx = conn
+        .transaction()
+        .map_err(|source| MetadataStoreError::Database {
+            action: "begin proton catalog replace transaction",
+            source,
+        })?;
+
+    tx.execute(
+        "DELETE FROM proton_release_catalog WHERE provider_id = ?1",
+        [provider_id],
+    )
+    .map_err(|source| MetadataStoreError::Database {
+        action: "clear proton catalog for provider",
+        source,
+    })?;
+
+    if rows.iter().any(|row| row.provider_id != provider_id) {
+        return Err(MetadataStoreError::Validation(format!(
+            "replace_proton_catalog rows contain provider ids that do not match target provider '{provider_id}'"
+        )));
+    }
+    upsert_proton_catalog_rows(&tx, rows)?;
+
+    tx.commit().map_err(|source| MetadataStoreError::Database {
+        action: "commit proton catalog replace transaction",
+        source,
+    })?;
+
+    Ok(())
+}
+
+fn upsert_proton_catalog_rows(
+    tx: &rusqlite::Transaction<'_>,
+    rows: &[ProtonCatalogRow],
+) -> Result<(), MetadataStoreError> {
     for row in rows {
         tx.execute(
             "INSERT OR REPLACE INTO proton_release_catalog (
@@ -57,12 +110,6 @@ pub fn put_proton_catalog_impl(
             source,
         })?;
     }
-
-    tx.commit().map_err(|source| MetadataStoreError::Database {
-        action: "commit proton catalog upsert transaction",
-        source,
-    })?;
-
     Ok(())
 }
 
@@ -254,5 +301,79 @@ mod tests {
         assert_eq!(rows.len(), 1, "upsert must not duplicate the row");
         assert_eq!(rows[0].payload_json, r#"{"updated":true}"#);
         assert_eq!(rows[0].asset_size, Some(1));
+    }
+
+    #[test]
+    fn replace_proton_catalog_replaces_provider_snapshot_atomically() {
+        let mut conn = open_v22();
+
+        let existing_rows = vec![
+            ProtonCatalogRow {
+                provider_id: "ge-proton".to_string(),
+                version_tag: "GE-Proton9-1".to_string(),
+                payload_json: r#"{"v":"old-1"}"#.to_string(),
+                release_url: None,
+                download_url: None,
+                checksum_url: None,
+                checksum_kind: None,
+                asset_size: None,
+                fetched_at: "2026-04-17T00:00:00Z".to_string(),
+                expires_at: None,
+            },
+            ProtonCatalogRow {
+                provider_id: "ge-proton".to_string(),
+                version_tag: "GE-Proton9-2".to_string(),
+                payload_json: r#"{"v":"old-2"}"#.to_string(),
+                release_url: None,
+                download_url: None,
+                checksum_url: None,
+                checksum_kind: None,
+                asset_size: None,
+                fetched_at: "2026-04-17T00:00:00Z".to_string(),
+                expires_at: None,
+            },
+        ];
+        put_proton_catalog_impl(&mut conn, &existing_rows).unwrap();
+
+        let replacement_rows = vec![ProtonCatalogRow {
+            provider_id: "ge-proton".to_string(),
+            version_tag: "GE-Proton9-9".to_string(),
+            payload_json: r#"{"v":"new"}"#.to_string(),
+            release_url: None,
+            download_url: None,
+            checksum_url: None,
+            checksum_kind: None,
+            asset_size: None,
+            fetched_at: "2026-04-18T00:00:00Z".to_string(),
+            expires_at: None,
+        }];
+        replace_proton_catalog_impl(&mut conn, "ge-proton", &replacement_rows).unwrap();
+
+        let rows = get_proton_catalog_impl(&conn, "ge-proton").unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].version_tag, "GE-Proton9-9");
+    }
+
+    #[test]
+    fn replace_proton_catalog_can_clear_provider_when_rows_empty() {
+        let mut conn = open_v22();
+        let row = ProtonCatalogRow {
+            provider_id: "ge-proton".to_string(),
+            version_tag: "GE-Proton9-1".to_string(),
+            payload_json: "{}".to_string(),
+            release_url: None,
+            download_url: None,
+            checksum_url: None,
+            checksum_kind: None,
+            asset_size: None,
+            fetched_at: "2026-04-17T00:00:00Z".to_string(),
+            expires_at: None,
+        };
+        put_proton_catalog_impl(&mut conn, &[row]).unwrap();
+
+        replace_proton_catalog_impl(&mut conn, "ge-proton", &[]).unwrap();
+
+        let rows = get_proton_catalog_impl(&conn, "ge-proton").unwrap();
+        assert!(rows.is_empty());
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
@@ -105,7 +105,6 @@ pub async fn list_available_versions_by_id(
                 &versions,
                 &fetched_at,
                 &expires_at,
-                include_prereleases,
             );
 
             ProtonUpCatalogResponse {
@@ -168,7 +167,7 @@ async fn fetch_live_catalog_by_id(
     let client = protonup_http_client().map_err(providers::ProviderError::Http)?;
 
     // Resolve the matching provider implementation from the registry.
-    let registry = providers::registry(include_prereleases);
+    let registry = providers::registry();
     match registry.iter().find(|p| p.id() == provider_id).cloned() {
         Some(provider_impl) => provider_impl.fetch(client, include_prereleases).await,
         None => {
@@ -303,11 +302,10 @@ fn persist_catalog(
     versions: &[ProtonUpAvailableVersion],
     fetched_at: &str,
     expires_at: &str,
-    include_prereleases: bool,
 ) {
     // Derive the provider's ChecksumKind from the registry for the checksum_kind column.
     let registry_checksum_kind: Option<String> = {
-        let registry = providers::registry(include_prereleases);
+        let registry = providers::registry();
         registry.iter().find(|p| p.id() == provider_id).map(|p| {
             serde_json::to_string(&p.checksum_kind())
                 .unwrap_or_default()

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
@@ -40,6 +40,11 @@ pub fn catalog_config(provider: ProtonUpProvider) -> CatalogProviderConfig {
             gh_releases_url: providers::proton_cachyos::gh_releases_url(),
             provider_id: "proton-cachyos",
         },
+        ProtonUpProvider::ProtonEm => CatalogProviderConfig {
+            cache_key: providers::proton_em::cache_key(),
+            gh_releases_url: providers::proton_em::gh_releases_url(),
+            provider_id: "proton-em",
+        },
     }
 }
 
@@ -78,6 +83,7 @@ pub async fn list_available_versions_by_id(
     metadata_store: &MetadataStore,
     force_refresh: bool,
     provider_id: &str,
+    include_prereleases: bool,
 ) -> ProtonUpCatalogResponse {
     // Step 1: cache-first (skip on force_refresh)
     if !force_refresh {
@@ -88,7 +94,7 @@ pub async fn list_available_versions_by_id(
     }
 
     // Step 2: live fetch via the provider trait
-    match fetch_live_catalog_by_id(provider_id).await {
+    match fetch_live_catalog_by_id(provider_id, include_prereleases).await {
         Ok(versions) => {
             let fetched_at = Utc::now().to_rfc3339();
             let expires_at = (Utc::now() + ChronoDuration::hours(CACHE_TTL_HOURS)).to_rfc3339();
@@ -99,6 +105,7 @@ pub async fn list_available_versions_by_id(
                 &versions,
                 &fetched_at,
                 &expires_at,
+                include_prereleases,
             );
 
             ProtonUpCatalogResponse {
@@ -141,21 +148,29 @@ pub async fn list_available_versions(
     metadata_store: &MetadataStore,
     force_refresh: bool,
     provider: ProtonUpProvider,
+    include_prereleases: bool,
 ) -> ProtonUpCatalogResponse {
-    list_available_versions_by_id(metadata_store, force_refresh, &provider.to_string()).await
+    list_available_versions_by_id(
+        metadata_store,
+        force_refresh,
+        &provider.to_string(),
+        include_prereleases,
+    )
+    .await
 }
 
 // ----- Live fetch -----
 
 async fn fetch_live_catalog_by_id(
     provider_id: &str,
+    include_prereleases: bool,
 ) -> Result<Vec<ProtonUpAvailableVersion>, providers::ProviderError> {
     let client = protonup_http_client().map_err(providers::ProviderError::Http)?;
 
     // Resolve the matching provider implementation from the registry.
-    let registry = providers::registry(false);
+    let registry = providers::registry(include_prereleases);
     match registry.iter().find(|p| p.id() == provider_id).cloned() {
-        Some(provider_impl) => provider_impl.fetch(client, false).await,
+        Some(provider_impl) => provider_impl.fetch(client, include_prereleases).await,
         None => {
             tracing::warn!(
                 provider_id,
@@ -288,10 +303,11 @@ fn persist_catalog(
     versions: &[ProtonUpAvailableVersion],
     fetched_at: &str,
     expires_at: &str,
+    include_prereleases: bool,
 ) {
     // Derive the provider's ChecksumKind from the registry for the checksum_kind column.
     let registry_checksum_kind: Option<String> = {
-        let registry = providers::registry(false);
+        let registry = providers::registry(include_prereleases);
         registry.iter().find(|p| p.id() == provider_id).map(|p| {
             serde_json::to_string(&p.checksum_kind())
                 .unwrap_or_default()
@@ -336,12 +352,12 @@ fn persist_catalog(
         })
         .collect();
 
-    if rows.is_empty() {
-        return;
-    }
-
-    if let Err(error) = metadata_store.put_proton_catalog(&rows) {
-        tracing::warn!(provider_id, %error, "failed to persist ProtonUp catalog to DB");
+    if let Err(error) = metadata_store.replace_proton_catalog(provider_id, &rows) {
+        tracing::warn!(
+            provider_id,
+            %error,
+            "failed to atomically replace ProtonUp catalog snapshot in DB"
+        );
     }
 }
 
@@ -355,11 +371,19 @@ mod tests {
     fn catalog_configs_have_distinct_cache_keys_and_urls() {
         let ge = catalog_config(ProtonUpProvider::GeProton);
         let cachy = catalog_config(ProtonUpProvider::ProtonCachyos);
+        let em = catalog_config(ProtonUpProvider::ProtonEm);
         assert_ne!(ge.cache_key, cachy.cache_key);
+        assert_ne!(ge.cache_key, em.cache_key);
+        assert_ne!(cachy.cache_key, em.cache_key);
         assert_ne!(ge.gh_releases_url, cachy.gh_releases_url);
+        assert_ne!(ge.gh_releases_url, em.gh_releases_url);
+        assert_ne!(cachy.gh_releases_url, em.gh_releases_url);
         assert_ne!(ge.provider_id, cachy.provider_id);
+        assert_ne!(ge.provider_id, em.provider_id);
+        assert_ne!(cachy.provider_id, em.provider_id);
         assert!(ge.gh_releases_url.contains("GloriousEggroll"));
         assert!(cachy.gh_releases_url.contains("CachyOS/proton-cachyos"));
+        assert!(em.gh_releases_url.contains("Etaash-mathamsetty/Proton"));
     }
 
     // ── Integration: v22 DB + catalog read/write path ─────────────────────────

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
@@ -63,37 +63,39 @@ fn protonup_http_client() -> Result<&'static reqwest::Client, reqwest::Error> {
 
 // ----- Public entry point -----
 
-/// Fetch available versions for `provider` with cache-live-stale fallback.
+/// Fetch available versions by provider id with cache-live-stale fallback.
+///
+/// Dispatch goes through the [`providers::registry`], so any provider id the
+/// registry knows about (including `proton-em` and experimental providers)
+/// works. Unknown ids yield an empty catalog rather than silently falling
+/// back to GE-Proton.
 ///
 /// 1. If `force_refresh` is false, return a valid (non-expired) cache hit immediately.
-/// 2. Attempt a live fetch from GitHub Releases.
+/// 2. Attempt a live fetch via the provider trait.
 /// 3. On network failure, fall back to a stale cache entry.
 /// 4. If no cache exists at all, return an empty offline response.
-pub async fn list_available_versions(
+pub async fn list_available_versions_by_id(
     metadata_store: &MetadataStore,
     force_refresh: bool,
-    provider: ProtonUpProvider,
+    provider_id: &str,
 ) -> ProtonUpCatalogResponse {
-    let cfg = catalog_config(provider.clone());
-
     // Step 1: cache-first (skip on force_refresh)
     if !force_refresh {
-        let rows = load_catalog_rows(metadata_store, cfg.provider_id);
+        let rows = load_catalog_rows(metadata_store, provider_id);
         if let Some(response) = build_response_from_rows(&rows, false) {
             return response;
         }
     }
 
     // Step 2: live fetch via the provider trait
-    match fetch_live_catalog(&cfg, provider).await {
+    match fetch_live_catalog_by_id(provider_id).await {
         Ok(versions) => {
             let fetched_at = Utc::now().to_rfc3339();
             let expires_at = (Utc::now() + ChronoDuration::hours(CACHE_TTL_HOURS)).to_rfc3339();
 
-            // Use v22 proton_release_catalog table — one row per (provider_id, version_tag).
             persist_catalog(
                 metadata_store,
-                cfg.provider_id,
+                provider_id,
                 &versions,
                 &fetched_at,
                 &expires_at,
@@ -111,10 +113,10 @@ pub async fn list_available_versions(
         }
 
         Err(error) => {
-            tracing::warn!(%error, provider_id = cfg.provider_id, "ProtonUp live catalog fetch failed — trying stale cache");
+            tracing::warn!(%error, provider_id, "ProtonUp live catalog fetch failed — trying stale cache");
 
             // Step 3: stale fallback
-            let stale_rows = load_catalog_rows(metadata_store, cfg.provider_id);
+            let stale_rows = load_catalog_rows(metadata_store, provider_id);
             if let Some(response) = build_response_from_rows(&stale_rows, true) {
                 return response;
             }
@@ -133,44 +135,35 @@ pub async fn list_available_versions(
     }
 }
 
+/// Back-compat shim: dispatches the legacy [`ProtonUpProvider`] enum via its
+/// kebab-case id. Prefer [`list_available_versions_by_id`] for new callers.
+pub async fn list_available_versions(
+    metadata_store: &MetadataStore,
+    force_refresh: bool,
+    provider: ProtonUpProvider,
+) -> ProtonUpCatalogResponse {
+    list_available_versions_by_id(metadata_store, force_refresh, &provider.to_string()).await
+}
+
 // ----- Live fetch -----
 
-async fn fetch_live_catalog(
-    cfg: &CatalogProviderConfig,
-    provider: ProtonUpProvider,
+async fn fetch_live_catalog_by_id(
+    provider_id: &str,
 ) -> Result<Vec<ProtonUpAvailableVersion>, providers::ProviderError> {
     let client = protonup_http_client().map_err(providers::ProviderError::Http)?;
 
     // Resolve the matching provider implementation from the registry.
     let registry = providers::registry(false);
-    let impl_ = registry.iter().find(|p| p.id() == cfg.provider_id).cloned();
-
-    if let Some(provider_impl) = impl_ {
-        return provider_impl.fetch(client, false).await;
+    match registry.iter().find(|p| p.id() == provider_id).cloned() {
+        Some(provider_impl) => provider_impl.fetch(client, false).await,
+        None => {
+            tracing::warn!(
+                provider_id,
+                "Unknown Proton provider id — returning empty catalog"
+            );
+            Ok(Vec::new())
+        }
     }
-
-    // Fallback: plain HTTP request using the configured URL (covers any provider
-    // not yet in the registry — should not happen in practice).
-    use reqwest::StatusCode;
-
-    let response = client
-        .get(cfg.gh_releases_url)
-        .header("Accept", "application/vnd.github+json")
-        .header("X-GitHub-Api-Version", "2022-11-28")
-        .send()
-        .await?;
-
-    if response.status() == StatusCode::NOT_FOUND {
-        return Ok(Vec::new());
-    }
-
-    let _ = provider; // used only for the fallback path signature
-    let releases = response
-        .error_for_status()?
-        .json::<Vec<providers::GhRelease>>()
-        .await?;
-
-    Ok(providers::parse_releases(releases, cfg.provider_id, 30))
 }
 
 // ----- Cache helpers -----

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
@@ -61,18 +61,42 @@ async fn protonup_http_client() -> Result<&'static reqwest::Client, reqwest::Err
         .await
 }
 
+// ----- Cache key (stable vs prerelease snapshots) -----
+
+/// SQLite `provider_id` column stores this scoped key so stable and prerelease
+/// catalog snapshots do not overwrite each other.
+fn scoped_cache_key(logical_provider_id: &str, include_prereleases: bool) -> String {
+    format!(
+        "{}:{}",
+        logical_provider_id,
+        if include_prereleases {
+            "prereleases"
+        } else {
+            "stable"
+        }
+    )
+}
+
+/// Strip `:stable` / `:prereleases` for [`providers::registry`] lookup (checksum kind, etc.).
+fn logical_provider_id_for_registry(scoped_provider_id: &str) -> &str {
+    scoped_provider_id
+        .strip_suffix(":stable")
+        .or_else(|| scoped_provider_id.strip_suffix(":prereleases"))
+        .unwrap_or(scoped_provider_id)
+}
+
 // ----- Public entry point -----
 
 /// Fetch available versions by provider id with cache-live-stale fallback.
 ///
 /// Dispatch goes through the [`providers::registry`], so any provider id the
 /// registry knows about (including `proton-em` and experimental providers)
-/// works. Unknown ids yield an empty catalog rather than silently falling
-/// back to GE-Proton.
+/// works. Unknown ids surface stale cache when possible; otherwise an empty
+/// offline response.
 ///
 /// 1. If `force_refresh` is false, return a valid (non-expired) cache hit immediately.
 /// 2. Attempt a live fetch via the provider trait.
-/// 3. On network failure, fall back to a stale cache entry.
+/// 3. On network failure **or** empty/unknown live results, fall back to a stale cache entry.
 /// 4. If no cache exists at all, return an empty offline response.
 pub async fn list_available_versions_by_id(
     metadata_store: &MetadataStore,
@@ -80,9 +104,11 @@ pub async fn list_available_versions_by_id(
     provider_id: &str,
     include_prereleases: bool,
 ) -> ProtonUpCatalogResponse {
+    let cache_key = scoped_cache_key(provider_id, include_prereleases);
+
     // Step 1: cache-first (skip on force_refresh)
     if !force_refresh {
-        let rows = load_catalog_rows(metadata_store, provider_id);
+        let rows = load_catalog_rows(metadata_store, &cache_key);
         if let Some(response) = build_response_from_rows(&rows, false) {
             return response;
         }
@@ -90,13 +116,13 @@ pub async fn list_available_versions_by_id(
 
     // Step 2: live fetch via the provider trait
     match fetch_live_catalog_by_id(provider_id, include_prereleases).await {
-        Ok(versions) => {
+        Ok(versions) if !versions.is_empty() => {
             let fetched_at = Utc::now().to_rfc3339();
             let expires_at = (Utc::now() + ChronoDuration::hours(CACHE_TTL_HOURS)).to_rfc3339();
 
             persist_catalog(
                 metadata_store,
-                provider_id,
+                &cache_key,
                 &versions,
                 &fetched_at,
                 &expires_at,
@@ -113,26 +139,38 @@ pub async fn list_available_versions_by_id(
             }
         }
 
+        Ok(_) => {
+            tracing::warn!(
+                provider_id,
+                "ProtonUp live catalog returned empty — trying stale cache"
+            );
+            stale_fallback_or_offline(metadata_store, &cache_key)
+        }
+
         Err(error) => {
             tracing::warn!(%error, provider_id, "ProtonUp live catalog fetch failed — trying stale cache");
-
-            // Step 3: stale fallback
-            let stale_rows = load_catalog_rows(metadata_store, provider_id);
-            if let Some(response) = build_response_from_rows(&stale_rows, true) {
-                return response;
-            }
-
-            // Step 4: completely offline, no cache
-            ProtonUpCatalogResponse {
-                versions: Vec::new(),
-                cache: ProtonUpCacheMeta {
-                    stale: false,
-                    offline: true,
-                    fetched_at: None,
-                    expires_at: None,
-                },
-            }
+            stale_fallback_or_offline(metadata_store, &cache_key)
         }
+    }
+}
+
+fn stale_fallback_or_offline(
+    metadata_store: &MetadataStore,
+    cache_key: &str,
+) -> ProtonUpCatalogResponse {
+    let stale_rows = load_catalog_rows(metadata_store, cache_key);
+    if let Some(response) = build_response_from_rows(&stale_rows, true) {
+        return response;
+    }
+
+    ProtonUpCatalogResponse {
+        versions: Vec::new(),
+        cache: ProtonUpCacheMeta {
+            stale: false,
+            offline: true,
+            fetched_at: None,
+            expires_at: None,
+        },
     }
 }
 
@@ -170,27 +208,31 @@ async fn fetch_live_catalog_by_id(
         None => {
             tracing::warn!(
                 provider_id,
-                "Unknown Proton provider id — returning empty catalog"
+                "Unknown Proton provider id — treating as failed live fetch so stale cache is preserved"
             );
-            Ok(Vec::new())
+            Err(providers::ProviderError::Parse(format!(
+                "unknown provider id: {provider_id}"
+            )))
         }
     }
 }
 
 // ----- Cache helpers -----
 
-/// Load all rows for `provider_id` from the v22 `proton_release_catalog` table.
+/// Load all rows for `cache_key` from the v22 `proton_release_catalog` table.
 ///
-/// Returns an empty vec when the store is unavailable or has no rows for this provider.
-fn load_catalog_rows(metadata_store: &MetadataStore, provider_id: &str) -> Vec<ProtonCatalogRow> {
+/// `cache_key` is the scoped id from [`scoped_cache_key`].
+///
+/// Returns an empty vec when the store is unavailable or has no rows for this key.
+fn load_catalog_rows(metadata_store: &MetadataStore, cache_key: &str) -> Vec<ProtonCatalogRow> {
     if !metadata_store.is_available() {
         return Vec::new();
     }
 
-    match metadata_store.get_proton_catalog(provider_id) {
+    match metadata_store.get_proton_catalog(cache_key) {
         Ok(rows) => rows,
         Err(error) => {
-            tracing::warn!(%error, provider_id, "failed to load ProtonUp catalog rows from DB");
+            tracing::warn!(%error, cache_key, "failed to load ProtonUp catalog rows from DB");
             Vec::new()
         }
     }
@@ -290,20 +332,24 @@ fn build_response_from_rows(
 
 /// Persist fetched versions into the v22 `proton_release_catalog` table.
 ///
-/// Each `ProtonUpAvailableVersion` becomes one row keyed on `(provider_id, version_tag)`.
+/// Each `ProtonUpAvailableVersion` becomes one row keyed on `(scoped_cache_key, version_tag)`.
 /// The provider-level `ChecksumKind` from the registry is serialized into `checksum_kind`
 /// so the install path can choose the right verification strategy without re-fetching.
+///
+/// `scoped_provider_id` is the result of [`scoped_cache_key`]; row `provider_id` matches it.
 fn persist_catalog(
     metadata_store: &MetadataStore,
-    provider_id: &str,
+    scoped_provider_id: &str,
     versions: &[ProtonUpAvailableVersion],
     fetched_at: &str,
     expires_at: &str,
 ) {
+    let logical = logical_provider_id_for_registry(scoped_provider_id);
+
     // Derive the provider's ChecksumKind from the registry for the checksum_kind column.
     let registry_checksum_kind: Option<String> = {
         let registry = providers::registry();
-        registry.iter().find(|p| p.id() == provider_id).map(|p| {
+        registry.iter().find(|p| p.id() == logical).map(|p| {
             serde_json::to_string(&p.checksum_kind())
                 .unwrap_or_default()
                 .trim_matches('"')
@@ -318,7 +364,7 @@ fn persist_catalog(
                 Ok(s) => s,
                 Err(err) => {
                     tracing::warn!(
-                        provider_id,
+                        scoped_provider_id,
                         version = %v.version,
                         %err,
                         "failed to serialize ProtonUp version for catalog row — skipping"
@@ -328,7 +374,7 @@ fn persist_catalog(
             };
 
             Some(ProtonCatalogRow {
-                provider_id: provider_id.to_owned(),
+                provider_id: scoped_provider_id.to_owned(),
                 version_tag: v.version.clone(),
                 payload_json,
                 release_url: v.release_url.clone(),
@@ -347,9 +393,9 @@ fn persist_catalog(
         })
         .collect();
 
-    if let Err(error) = metadata_store.replace_proton_catalog(provider_id, &rows) {
+    if let Err(error) = metadata_store.replace_proton_catalog(scoped_provider_id, &rows) {
         tracing::warn!(
-            provider_id,
+            scoped_provider_id,
             %error,
             "failed to atomically replace ProtonUp catalog snapshot in DB"
         );
@@ -379,6 +425,24 @@ mod tests {
         assert!(ge.gh_releases_url.contains("GloriousEggroll"));
         assert!(cachy.gh_releases_url.contains("CachyOS/proton-cachyos"));
         assert!(em.gh_releases_url.contains("Etaash-mathamsetty/Proton"));
+    }
+
+    #[test]
+    fn scoped_cache_key_parts() {
+        assert_eq!(scoped_cache_key("ge-proton", false), "ge-proton:stable");
+        assert_eq!(scoped_cache_key("ge-proton", true), "ge-proton:prereleases");
+    }
+
+    #[test]
+    fn logical_provider_id_for_registry_strips_suffix() {
+        assert_eq!(
+            logical_provider_id_for_registry("ge-proton:stable"),
+            "ge-proton"
+        );
+        assert_eq!(
+            logical_provider_id_for_registry("proton-cachyos:prereleases"),
+            "proton-cachyos"
+        );
     }
 
     // ── Integration: v22 DB + catalog read/write path ─────────────────────────
@@ -425,7 +489,7 @@ mod tests {
     #[test]
     fn empty_store_returns_no_response() {
         let store = open_store();
-        let rows = load_catalog_rows(&store, "ge-proton");
+        let rows = load_catalog_rows(&store, "ge-proton:stable");
         assert!(rows.is_empty());
         let resp = build_response_from_rows(&rows, false);
         assert!(resp.is_none(), "empty store should produce no response");
@@ -441,14 +505,15 @@ mod tests {
 
         let v1 = make_version("GE-Proton9-1");
         let v2 = make_version("GE-Proton9-2");
+        let scoped = "ge-proton:stable";
         let rows = vec![
-            make_row("ge-proton", "GE-Proton9-1", &fetched, Some(&future), &v1),
-            make_row("ge-proton", "GE-Proton9-2", &fetched, Some(&future), &v2),
+            make_row(scoped, "GE-Proton9-1", &fetched, Some(&future), &v1),
+            make_row(scoped, "GE-Proton9-2", &fetched, Some(&future), &v2),
         ];
 
         store.put_proton_catalog(&rows).expect("put rows");
 
-        let loaded = load_catalog_rows(&store, "ge-proton");
+        let loaded = load_catalog_rows(&store, scoped);
         assert_eq!(loaded.len(), 2);
 
         let resp = build_response_from_rows(&loaded, false)
@@ -457,6 +522,41 @@ mod tests {
         assert!(!resp.cache.stale, "fresh rows should not be stale");
         assert!(!resp.cache.offline);
         assert!(resp.cache.fetched_at.is_some());
+    }
+
+    #[test]
+    fn stable_and_prerelease_snapshots_coexist() {
+        let store = open_store();
+        let future = (Utc::now() + ChronoDuration::hours(5)).to_rfc3339();
+        let fetched = Utc::now().to_rfc3339();
+
+        let v_stable = make_version("GE-Proton9-1");
+        let v_pre = make_version("GE-Proton9-0-rc1");
+
+        store
+            .put_proton_catalog(&[make_row(
+                "ge-proton:stable",
+                "GE-Proton9-1",
+                &fetched,
+                Some(&future),
+                &v_stable,
+            )])
+            .expect("put stable");
+        store
+            .put_proton_catalog(&[make_row(
+                "ge-proton:prereleases",
+                "GE-Proton9-0-rc1",
+                &fetched,
+                Some(&future),
+                &v_pre,
+            )])
+            .expect("put prerelease");
+
+        let stable_loaded = load_catalog_rows(&store, "ge-proton:stable");
+        let pre_loaded = load_catalog_rows(&store, "ge-proton:prereleases");
+        assert_eq!(stable_loaded.len(), 1);
+        assert_eq!(pre_loaded.len(), 1);
+        assert_ne!(stable_loaded[0].version_tag, pre_loaded[0].version_tag);
     }
 
     #[test]
@@ -470,22 +570,17 @@ mod tests {
 
         let v1 = make_version("GE-Proton9-1");
         let v2 = make_version("GE-Proton9-2");
+        let scoped = "ge-proton:stable";
         let rows = vec![
             // Stale row: no expires_at, fetched_at older than TTL.
-            make_row("ge-proton", "GE-Proton9-1", &stale_fetched, None, &v1),
+            make_row(scoped, "GE-Proton9-1", &stale_fetched, None, &v1),
             // Fresh row: expires in future.
-            make_row(
-                "ge-proton",
-                "GE-Proton9-2",
-                &fresh_fetched,
-                Some(&future),
-                &v2,
-            ),
+            make_row(scoped, "GE-Proton9-2", &fresh_fetched, Some(&future), &v2),
         ];
 
         store.put_proton_catalog(&rows).expect("put rows");
 
-        let loaded = load_catalog_rows(&store, "ge-proton");
+        let loaded = load_catalog_rows(&store, scoped);
         assert_eq!(loaded.len(), 2);
 
         // Calling build_response_from_rows with is_stale=false:
@@ -511,14 +606,15 @@ mod tests {
 
         let v1 = make_version("GE-Proton9-1");
         let v2 = make_version("GE-Proton9-2");
+        let scoped = "ge-proton:stable";
         let rows = vec![
-            make_row("ge-proton", "GE-Proton9-1", &fetched, Some(&past), &v1),
-            make_row("ge-proton", "GE-Proton9-2", &fetched, Some(&past), &v2),
+            make_row(scoped, "GE-Proton9-1", &fetched, Some(&past), &v1),
+            make_row(scoped, "GE-Proton9-2", &fetched, Some(&past), &v2),
         ];
 
         store.put_proton_catalog(&rows).expect("put rows");
 
-        let loaded = load_catalog_rows(&store, "ge-proton");
+        let loaded = load_catalog_rows(&store, scoped);
         let resp = build_response_from_rows(&loaded, false);
         assert!(
             resp.is_none(),
@@ -537,11 +633,26 @@ mod tests {
     fn no_network_offline_path_returns_empty_not_error() {
         // A disabled store (no DB) should yield empty rows → no panic.
         let store = MetadataStore::disabled();
-        let rows = load_catalog_rows(&store, "ge-proton");
+        let rows = load_catalog_rows(&store, "ge-proton:stable");
         assert!(rows.is_empty());
 
         // build_response_from_rows on empty gives None, which maps to offline empty.
         let resp = build_response_from_rows(&rows, false);
         assert!(resp.is_none());
+    }
+
+    #[tokio::test]
+    async fn unknown_provider_force_refresh_falls_back_to_stale_scoped_cache() {
+        let store = open_store();
+        let future = (Utc::now() + ChronoDuration::hours(5)).to_rfc3339();
+        let fetched = Utc::now().to_rfc3339();
+        let v1 = make_version("GE-Proton9-1");
+        let key = scoped_cache_key("totally-unknown-xyz", false);
+        let row = make_row(&key, "GE-Proton9-1", &fetched, Some(&future), &v1);
+        store.put_proton_catalog(&[row]).expect("seed cache");
+
+        let resp = list_available_versions_by_id(&store, true, "totally-unknown-xyz", false).await;
+        assert_eq!(resp.versions.len(), 1);
+        assert_eq!(resp.versions[0].version, "GE-Proton9-1");
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
@@ -1,10 +1,10 @@
 //! Catalog retrieval for Proton compatibility-tool releases (GE-Proton, Proton-CachyOS, …)
 //! with cache-first / live-refresh / stale-fallback.
 
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use tokio::sync::OnceCell;
 
 use crate::metadata::{MetadataStore, ProtonCatalogRow};
 use crate::protonup::{
@@ -15,7 +15,7 @@ use crate::protonup::{
 const CACHE_TTL_HOURS: i64 = 6;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
 
-static PROTONUP_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+static PROTONUP_HTTP_CLIENT: OnceCell<reqwest::Client> = OnceCell::const_new();
 
 /// Per-provider GitHub Releases API URL and `provider_id` string on rows.
 ///
@@ -50,20 +50,15 @@ pub fn catalog_config(provider: ProtonUpProvider) -> CatalogProviderConfig {
 
 // ----- HTTP client -----
 
-fn protonup_http_client() -> Result<&'static reqwest::Client, reqwest::Error> {
-    if let Some(client) = PROTONUP_HTTP_CLIENT.get() {
-        return Ok(client);
-    }
-
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
-        .user_agent(format!("CrossHook/{}", env!("CARGO_PKG_VERSION")))
-        .build()?;
-
-    let _ = PROTONUP_HTTP_CLIENT.set(client);
-    Ok(PROTONUP_HTTP_CLIENT
-        .get()
-        .expect("ProtonUp HTTP client should be initialized before use"))
+async fn protonup_http_client() -> Result<&'static reqwest::Client, reqwest::Error> {
+    PROTONUP_HTTP_CLIENT
+        .get_or_try_init(|| async {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+                .user_agent(format!("CrossHook/{}", env!("CARGO_PKG_VERSION")))
+                .build()
+        })
+        .await
 }
 
 // ----- Public entry point -----
@@ -164,7 +159,9 @@ async fn fetch_live_catalog_by_id(
     provider_id: &str,
     include_prereleases: bool,
 ) -> Result<Vec<ProtonUpAvailableVersion>, providers::ProviderError> {
-    let client = protonup_http_client().map_err(providers::ProviderError::Http)?;
+    let client = protonup_http_client()
+        .await
+        .map_err(providers::ProviderError::Http)?;
 
     // Resolve the matching provider implementation from the registry.
     let registry = providers::registry();

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/catalog.rs
@@ -4,23 +4,23 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use chrono::{Duration as ChronoDuration, Utc};
-use reqwest::StatusCode;
-use rusqlite::{params, OptionalExtension};
-use serde::Deserialize;
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 
-use crate::metadata::{MetadataStore, MetadataStoreError};
+use crate::metadata::{MetadataStore, ProtonCatalogRow};
 use crate::protonup::{
-    ProtonUpAvailableVersion, ProtonUpCacheMeta, ProtonUpCatalogResponse, ProtonUpProvider,
+    providers, ProtonUpAvailableVersion, ProtonUpCacheMeta, ProtonUpCatalogResponse,
+    ProtonUpProvider,
 };
 
 const CACHE_TTL_HOURS: i64 = 6;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
-const MAX_RELEASES: usize = 30;
 
 static PROTONUP_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
-/// Per-provider GitHub Releases API URL, SQLite cache key, and `provider` string on rows.
+/// Per-provider GitHub Releases API URL and `provider_id` string on rows.
+///
+/// Retained for use by `fetch_live_catalog`'s fallback HTTP path and the
+/// existing `catalog_configs_have_distinct_cache_keys_and_urls` test.
 #[derive(Debug, Clone, Copy)]
 pub struct CatalogProviderConfig {
     pub cache_key: &'static str,
@@ -31,47 +31,16 @@ pub struct CatalogProviderConfig {
 pub fn catalog_config(provider: ProtonUpProvider) -> CatalogProviderConfig {
     match provider {
         ProtonUpProvider::GeProton => CatalogProviderConfig {
-            cache_key: "protonup:catalog:ge-proton",
-            gh_releases_url:
-                "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases",
+            cache_key: providers::ge_proton::cache_key(),
+            gh_releases_url: providers::ge_proton::gh_releases_url(),
             provider_id: "ge-proton",
         },
         ProtonUpProvider::ProtonCachyos => CatalogProviderConfig {
-            cache_key: "protonup:catalog:proton-cachyos",
-            gh_releases_url: "https://api.github.com/repos/CachyOS/proton-cachyos/releases",
+            cache_key: providers::proton_cachyos::cache_key(),
+            gh_releases_url: providers::proton_cachyos::gh_releases_url(),
             provider_id: "proton-cachyos",
         },
     }
-}
-
-// ----- GitHub Release API response types (private) -----
-
-#[derive(Debug, Deserialize)]
-struct GhRelease {
-    tag_name: String,
-    html_url: String,
-    #[serde(default)]
-    draft: bool,
-    #[serde(default)]
-    prerelease: bool,
-    #[serde(default)]
-    assets: Vec<GhAsset>,
-}
-
-#[derive(Debug, Deserialize)]
-struct GhAsset {
-    name: String,
-    browser_download_url: String,
-    size: u64,
-}
-
-// ----- Internal cache row -----
-
-#[derive(Debug)]
-struct CachedCatalogRow {
-    payload_json: String,
-    fetched_at: String,
-    expires_at: Option<String>,
 }
 
 // ----- HTTP client -----
@@ -105,45 +74,49 @@ pub async fn list_available_versions(
     force_refresh: bool,
     provider: ProtonUpProvider,
 ) -> ProtonUpCatalogResponse {
-    let cfg = catalog_config(provider);
+    let cfg = catalog_config(provider.clone());
 
     // Step 1: cache-first (skip on force_refresh)
     if !force_refresh {
-        if let Some(cached) = load_cached_row(metadata_store, false, cfg.cache_key) {
-            if let Some(response) = parse_cached_row(cached, false) {
-                return response;
-            }
+        let rows = load_catalog_rows(metadata_store, cfg.provider_id);
+        if let Some(response) = build_response_from_rows(&rows, false) {
+            return response;
         }
     }
 
-    // Step 2: live fetch
-    match fetch_live_catalog(&cfg).await {
+    // Step 2: live fetch via the provider trait
+    match fetch_live_catalog(&cfg, provider).await {
         Ok(versions) => {
             let fetched_at = Utc::now().to_rfc3339();
             let expires_at = (Utc::now() + ChronoDuration::hours(CACHE_TTL_HOURS)).to_rfc3339();
 
-            let response = ProtonUpCatalogResponse {
+            // Use v22 proton_release_catalog table — one row per (provider_id, version_tag).
+            persist_catalog(
+                metadata_store,
+                cfg.provider_id,
+                &versions,
+                &fetched_at,
+                &expires_at,
+            );
+
+            ProtonUpCatalogResponse {
                 versions,
                 cache: ProtonUpCacheMeta {
                     stale: false,
                     offline: false,
                     fetched_at: Some(fetched_at),
-                    expires_at: Some(expires_at.clone()),
+                    expires_at: Some(expires_at),
                 },
-            };
-
-            persist_catalog(metadata_store, &response, &expires_at, &cfg);
-            response
+            }
         }
 
         Err(error) => {
-            tracing::warn!(%error, cache_key = cfg.cache_key, "ProtonUp live catalog fetch failed — trying stale cache");
+            tracing::warn!(%error, provider_id = cfg.provider_id, "ProtonUp live catalog fetch failed — trying stale cache");
 
             // Step 3: stale fallback
-            if let Some(stale) = load_cached_row(metadata_store, true, cfg.cache_key) {
-                if let Some(response) = parse_cached_row(stale, true) {
-                    return response;
-                }
+            let stale_rows = load_catalog_rows(metadata_store, cfg.provider_id);
+            if let Some(response) = build_response_from_rows(&stale_rows, true) {
+                return response;
             }
 
             // Step 4: completely offline, no cache
@@ -164,8 +137,21 @@ pub async fn list_available_versions(
 
 async fn fetch_live_catalog(
     cfg: &CatalogProviderConfig,
-) -> Result<Vec<ProtonUpAvailableVersion>, reqwest::Error> {
-    let client = protonup_http_client()?;
+    provider: ProtonUpProvider,
+) -> Result<Vec<ProtonUpAvailableVersion>, providers::ProviderError> {
+    let client = protonup_http_client().map_err(providers::ProviderError::Http)?;
+
+    // Resolve the matching provider implementation from the registry.
+    let registry = providers::registry(false);
+    let impl_ = registry.iter().find(|p| p.id() == cfg.provider_id).cloned();
+
+    if let Some(provider_impl) = impl_ {
+        return provider_impl.fetch(client, false).await;
+    }
+
+    // Fallback: plain HTTP request using the configured URL (covers any provider
+    // not yet in the registry — should not happen in practice).
+    use reqwest::StatusCode;
 
     let response = client
         .get(cfg.gh_releases_url)
@@ -178,178 +164,191 @@ async fn fetch_live_catalog(
         return Ok(Vec::new());
     }
 
+    let _ = provider; // used only for the fallback path signature
     let releases = response
         .error_for_status()?
-        .json::<Vec<GhRelease>>()
+        .json::<Vec<providers::GhRelease>>()
         .await?;
 
-    Ok(parse_releases(releases, cfg.provider_id))
-}
-
-/// Strip `.tar.gz` / `.tar.xz` from an asset filename for matching sidecar `.sha512sum` files.
-fn tarball_stem(name: &str) -> Option<&str> {
-    name.strip_suffix(".tar.gz")
-        .or_else(|| name.strip_suffix(".tar.xz"))
-}
-
-/// Pick the primary downloadable archive for a release.
-///
-/// GE-Proton publishes `.tar.gz`. Proton-CachyOS publishes `.tar.xz` for several
-/// architectures; we prefer Linux x86_64 baseline, then x86_64_v3, then any non-ARM `.tar.xz`.
-fn pick_tarball_asset<'a>(assets: &'a [GhAsset], provider_id: &str) -> Option<&'a GhAsset> {
-    if provider_id == "proton-cachyos" {
-        let xz: Vec<&GhAsset> = assets
-            .iter()
-            .filter(|a| a.name.ends_with(".tar.xz"))
-            .collect();
-
-        let baseline_x86 = xz.iter().find(|a| {
-            let n = a.name.as_str();
-            n.contains("x86_64") && !n.contains("x86_64_v3")
-        });
-        let v3 = xz.iter().find(|a| a.name.contains("x86_64_v3"));
-        let non_arm = xz.iter().find(|a| !a.name.to_lowercase().contains("arm"));
-
-        baseline_x86
-            .or(v3)
-            .or(non_arm)
-            .copied()
-            .or_else(|| xz.first().copied())
-    } else {
-        assets.iter().find(|a| a.name.ends_with(".tar.gz"))
-    }
-}
-
-fn find_matching_sha512sum<'a>(assets: &'a [GhAsset], tarball_name: &str) -> Option<&'a GhAsset> {
-    let stem = tarball_stem(tarball_name)?;
-    let expected = format!("{stem}.sha512sum");
-    assets.iter().find(|a| a.name == expected)
-}
-
-fn gh_release_to_version(
-    release: GhRelease,
-    provider_id: &str,
-) -> Option<ProtonUpAvailableVersion> {
-    let tarball = pick_tarball_asset(&release.assets, provider_id)?;
-
-    let checksum = find_matching_sha512sum(&release.assets, &tarball.name);
-
-    Some(ProtonUpAvailableVersion {
-        provider: provider_id.to_string(),
-        version: release.tag_name,
-        release_url: Some(release.html_url),
-        download_url: Some(tarball.browser_download_url.clone()),
-        asset_size: Some(tarball.size),
-        checksum_url: checksum.map(|a| a.browser_download_url.clone()),
-        checksum_kind: checksum.map(|_| "sha512".to_string()),
-    })
+    Ok(providers::parse_releases(releases, cfg.provider_id, 30))
 }
 
 // ----- Cache helpers -----
 
-fn load_cached_row(
-    metadata_store: &MetadataStore,
-    allow_expired: bool,
-    cache_key: &str,
-) -> Option<CachedCatalogRow> {
-    if !metadata_store.is_available() {
-        return None;
-    }
-
-    let now = Utc::now().to_rfc3339();
-    let action = if allow_expired {
-        "load a cached ProtonUp catalog row"
-    } else {
-        "load a valid cached ProtonUp catalog row"
-    };
-
-    metadata_store
-        .with_sqlite_conn(action, |conn| {
-            let sql = if allow_expired {
-                "SELECT payload_json, fetched_at, expires_at \
-                 FROM external_cache_entries WHERE cache_key = ?1 LIMIT 1"
-            } else {
-                "SELECT payload_json, fetched_at, expires_at \
-                 FROM external_cache_entries \
-                 WHERE cache_key = ?1 AND (expires_at IS NULL OR expires_at > ?2) LIMIT 1"
-            };
-
-            let row_params = if allow_expired {
-                params![cache_key]
-            } else {
-                params![cache_key, now]
-            };
-
-            conn.query_row(sql, row_params, |row| {
-                Ok(CachedCatalogRow {
-                    payload_json: row.get::<_, Option<String>>(0)?.unwrap_or_default(),
-                    fetched_at: row.get::<_, String>(1)?,
-                    expires_at: row.get::<_, Option<String>>(2)?,
-                })
-            })
-            .optional()
-            .map_err(|source| MetadataStoreError::Database {
-                action: "query a ProtonUp catalog cache row",
-                source,
-            })
-        })
-        .ok()
-        .flatten()
-}
-
-fn parse_cached_row(row: CachedCatalogRow, is_stale: bool) -> Option<ProtonUpCatalogResponse> {
-    if row.payload_json.trim().is_empty() {
-        return None;
-    }
-
-    let mut response = serde_json::from_str::<ProtonUpCatalogResponse>(&row.payload_json).ok()?;
-
-    response.cache = ProtonUpCacheMeta {
-        stale: is_stale,
-        offline: is_stale,
-        fetched_at: Some(row.fetched_at),
-        expires_at: row.expires_at,
-    };
-
-    Some(response)
-}
-
-/// Convert a list of GitHub releases into `ProtonUpAvailableVersion` entries,
-/// applying the same filtering rules used during live fetches: skip drafts,
-/// pre-releases, and releases without a supported tarball (`.tar.gz` for GE-Proton,
-/// `.tar.xz` for Proton-CachyOS). Cap at `MAX_RELEASES`.
+/// Load all rows for `provider_id` from the v22 `proton_release_catalog` table.
 ///
-/// Extracted to allow unit-testing without network I/O.
-fn parse_releases(releases: Vec<GhRelease>, provider_id: &str) -> Vec<ProtonUpAvailableVersion> {
-    releases
-        .into_iter()
-        .filter(|r| !r.draft && !r.prerelease)
-        .take(MAX_RELEASES)
-        .filter_map(|r| gh_release_to_version(r, provider_id))
-        .collect()
+/// Returns an empty vec when the store is unavailable or has no rows for this provider.
+fn load_catalog_rows(metadata_store: &MetadataStore, provider_id: &str) -> Vec<ProtonCatalogRow> {
+    if !metadata_store.is_available() {
+        return Vec::new();
+    }
+
+    match metadata_store.get_proton_catalog(provider_id) {
+        Ok(rows) => rows,
+        Err(error) => {
+            tracing::warn!(%error, provider_id, "failed to load ProtonUp catalog rows from DB");
+            Vec::new()
+        }
+    }
 }
 
+/// Convert a set of `ProtonCatalogRow`s into a `ProtonUpCatalogResponse`.
+///
+/// When `is_stale` is false the caller should only pass rows whose `expires_at`
+/// has not yet elapsed — this function treats whatever is given as authoritative.
+/// When `is_stale` is true the rows may be expired; mark the response accordingly.
+///
+/// Returns `None` when `rows` is empty or every row fails to deserialize.
+fn build_response_from_rows(
+    rows: &[ProtonCatalogRow],
+    is_stale: bool,
+) -> Option<ProtonUpCatalogResponse> {
+    if rows.is_empty() {
+        return None;
+    }
+
+    let now = Utc::now();
+    let ttl_cutoff = now - ChronoDuration::hours(CACHE_TTL_HOURS);
+
+    // When not forcing stale, skip if all rows are expired.
+    if !is_stale {
+        let all_expired = rows.iter().all(|r| {
+            // Prefer expires_at if present; fall back to fetched_at + TTL.
+            if let Some(ref exp) = r.expires_at {
+                DateTime::parse_from_rfc3339(exp)
+                    .map(|dt| dt.with_timezone(&Utc) <= now)
+                    .unwrap_or(true)
+            } else {
+                DateTime::parse_from_rfc3339(&r.fetched_at)
+                    .map(|dt| dt.with_timezone(&Utc) <= ttl_cutoff)
+                    .unwrap_or(true)
+            }
+        });
+        if all_expired {
+            return None;
+        }
+    }
+
+    // Deserialize each row's payload_json into a ProtonUpAvailableVersion.
+    let versions: Vec<ProtonUpAvailableVersion> = rows
+        .iter()
+        .filter_map(|r| match serde_json::from_str(&r.payload_json) {
+            Ok(v) => Some(v),
+            Err(err) => {
+                tracing::warn!(
+                    provider_id = %r.provider_id,
+                    version_tag = %r.version_tag,
+                    %err,
+                    "failed to parse ProtonUp catalog row payload — treating as missing"
+                );
+                None
+            }
+        })
+        .collect();
+
+    if versions.is_empty() {
+        return None;
+    }
+
+    // cache_meta.fetched_at: the oldest fetched_at across all rows defines the age of cached data.
+    let oldest_fetched_at = rows
+        .iter()
+        .map(|r| r.fetched_at.as_str())
+        .min()
+        .map(str::to_owned);
+
+    // Determine staleness from the oldest row's age when not already forced stale.
+    let actually_stale = is_stale || {
+        oldest_fetched_at
+            .as_deref()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&Utc) <= ttl_cutoff)
+            .unwrap_or(false)
+    };
+
+    // expires_at for the response: use the minimum expires_at across rows that have one.
+    let min_expires_at = rows
+        .iter()
+        .filter_map(|r| r.expires_at.as_deref())
+        .min()
+        .map(str::to_owned);
+
+    Some(ProtonUpCatalogResponse {
+        versions,
+        cache: ProtonUpCacheMeta {
+            stale: actually_stale,
+            offline: is_stale,
+            fetched_at: oldest_fetched_at,
+            expires_at: min_expires_at,
+        },
+    })
+}
+
+/// Persist fetched versions into the v22 `proton_release_catalog` table.
+///
+/// Each `ProtonUpAvailableVersion` becomes one row keyed on `(provider_id, version_tag)`.
+/// The provider-level `ChecksumKind` from the registry is serialized into `checksum_kind`
+/// so the install path can choose the right verification strategy without re-fetching.
 fn persist_catalog(
     metadata_store: &MetadataStore,
-    response: &ProtonUpCatalogResponse,
+    provider_id: &str,
+    versions: &[ProtonUpAvailableVersion],
+    fetched_at: &str,
     expires_at: &str,
-    cfg: &CatalogProviderConfig,
 ) {
-    let Ok(payload) = serde_json::to_string(response) else {
-        tracing::warn!(
-            cache_key = cfg.cache_key,
-            "failed to serialize ProtonUp catalog payload"
-        );
-        return;
+    // Derive the provider's ChecksumKind from the registry for the checksum_kind column.
+    let registry_checksum_kind: Option<String> = {
+        let registry = providers::registry(false);
+        registry.iter().find(|p| p.id() == provider_id).map(|p| {
+            serde_json::to_string(&p.checksum_kind())
+                .unwrap_or_default()
+                .trim_matches('"')
+                .to_owned()
+        })
     };
 
-    if let Err(error) = metadata_store.put_cache_entry(
-        cfg.gh_releases_url,
-        cfg.cache_key,
-        &payload,
-        Some(expires_at),
-    ) {
-        tracing::warn!(cache_key = cfg.cache_key, %error, "failed to persist ProtonUp catalog cache");
+    let rows: Vec<ProtonCatalogRow> = versions
+        .iter()
+        .filter_map(|v| {
+            let payload_json = match serde_json::to_string(v) {
+                Ok(s) => s,
+                Err(err) => {
+                    tracing::warn!(
+                        provider_id,
+                        version = %v.version,
+                        %err,
+                        "failed to serialize ProtonUp version for catalog row — skipping"
+                    );
+                    return None;
+                }
+            };
+
+            Some(ProtonCatalogRow {
+                provider_id: provider_id.to_owned(),
+                version_tag: v.version.clone(),
+                payload_json,
+                release_url: v.release_url.clone(),
+                download_url: v.download_url.clone(),
+                checksum_url: v.checksum_url.clone(),
+                // Use the row's own checksum_kind when present; otherwise fall back to
+                // the provider-level registry value.
+                checksum_kind: v
+                    .checksum_kind
+                    .clone()
+                    .or_else(|| registry_checksum_kind.clone()),
+                asset_size: v.asset_size.map(|s| s as i64),
+                fetched_at: fetched_at.to_owned(),
+                expires_at: Some(expires_at.to_owned()),
+            })
+        })
+        .collect();
+
+    if rows.is_empty() {
+        return;
+    }
+
+    if let Err(error) = metadata_store.put_proton_catalog(&rows) {
+        tracing::warn!(provider_id, %error, "failed to persist ProtonUp catalog to DB");
     }
 }
 
@@ -358,58 +357,6 @@ fn persist_catalog(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Build a minimal `GhRelease` for testing.
-    fn make_release(
-        tag_name: &str,
-        draft: bool,
-        prerelease: bool,
-        assets: Vec<GhAsset>,
-    ) -> GhRelease {
-        GhRelease {
-            tag_name: tag_name.to_string(),
-            html_url: format!("https://github.com/example/releases/tag/{tag_name}"),
-            draft,
-            prerelease,
-            assets,
-        }
-    }
-
-    fn tar_gz_asset(tag_name: &str) -> GhAsset {
-        GhAsset {
-            name: format!("{tag_name}.tar.gz"),
-            browser_download_url: format!(
-                "https://github.com/releases/download/{tag_name}/{tag_name}.tar.gz"
-            ),
-            size: 1_234_567,
-        }
-    }
-
-    fn sha512_asset(tag_name: &str) -> GhAsset {
-        GhAsset {
-            name: format!("{tag_name}.sha512sum"),
-            browser_download_url: format!(
-                "https://github.com/releases/download/{tag_name}/{tag_name}.sha512sum"
-            ),
-            size: 128,
-        }
-    }
-
-    fn tar_xz_named(name: &str) -> GhAsset {
-        GhAsset {
-            name: name.to_string(),
-            browser_download_url: format!("https://github.com/releases/download/x/{name}"),
-            size: 300_000_000,
-        }
-    }
-
-    fn sha512_named(name: &str) -> GhAsset {
-        GhAsset {
-            name: name.to_string(),
-            browser_download_url: format!("https://github.com/releases/download/x/{name}"),
-            size: 128,
-        }
-    }
 
     #[test]
     fn catalog_configs_have_distinct_cache_keys_and_urls() {
@@ -422,186 +369,167 @@ mod tests {
         assert!(cachy.gh_releases_url.contains("CachyOS/proton-cachyos"));
     }
 
-    #[test]
-    fn parse_gh_release_extracts_version_and_urls() {
-        let releases = vec![make_release(
-            "GE-Proton9-21",
-            false,
-            false,
-            vec![tar_gz_asset("GE-Proton9-21"), sha512_asset("GE-Proton9-21")],
-        )];
+    // ── Integration: v22 DB + catalog read/write path ─────────────────────────
 
-        let versions = parse_releases(releases, "ge-proton");
-        assert_eq!(versions.len(), 1);
-        let v = &versions[0];
-        assert_eq!(v.version, "GE-Proton9-21");
-        assert_eq!(v.provider, "ge-proton");
-        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.gz"));
-        assert!(v.release_url.as_deref().unwrap().contains("GE-Proton9-21"));
-        assert!(v.checksum_url.is_some());
-        assert_eq!(v.checksum_kind.as_deref(), Some("sha512"));
-        assert_eq!(v.asset_size, Some(1_234_567));
+    fn make_version(version: &str) -> ProtonUpAvailableVersion {
+        ProtonUpAvailableVersion {
+            provider: "ge-proton".to_string(),
+            version: version.to_string(),
+            release_url: Some(format!("https://example.com/release/{version}")),
+            download_url: Some(format!("https://example.com/{version}.tar.gz")),
+            checksum_url: Some(format!("https://example.com/{version}.sha512sum")),
+            checksum_kind: Some("sha512".to_string()),
+            asset_size: Some(500_000_000),
+            published_at: Some("2024-06-01T00:00:00Z".to_string()),
+        }
+    }
+
+    fn make_row(
+        provider_id: &str,
+        version_tag: &str,
+        fetched_at: &str,
+        expires_at: Option<&str>,
+        version: &ProtonUpAvailableVersion,
+    ) -> ProtonCatalogRow {
+        ProtonCatalogRow {
+            provider_id: provider_id.to_string(),
+            version_tag: version_tag.to_string(),
+            payload_json: serde_json::to_string(version).unwrap(),
+            release_url: version.release_url.clone(),
+            download_url: version.download_url.clone(),
+            checksum_url: version.checksum_url.clone(),
+            checksum_kind: version.checksum_kind.clone(),
+            asset_size: version.asset_size.map(|s| s as i64),
+            fetched_at: fetched_at.to_string(),
+            expires_at: expires_at.map(str::to_owned),
+        }
+    }
+
+    /// Fresh v22 in-memory store (runs all migrations including 21→22).
+    fn open_store() -> MetadataStore {
+        MetadataStore::open_in_memory().expect("open in-memory metadata store")
     }
 
     #[test]
-    fn parse_releases_stamps_proton_cachyos_provider() {
-        let tb = "proton-cachyos-10.0-20260330-slr-x86_64.tar.xz";
-        let releases = vec![make_release(
-            "cachyos-10.0-20260330-slr",
-            false,
-            false,
-            vec![
-                tar_xz_named(tb),
-                sha512_named("proton-cachyos-10.0-20260330-slr-x86_64.sha512sum"),
-            ],
-        )];
-
-        let versions = parse_releases(releases, "proton-cachyos");
-        assert_eq!(versions.len(), 1);
-        assert_eq!(versions[0].provider, "proton-cachyos");
-        assert_eq!(versions[0].version, "cachyos-10.0-20260330-slr");
-        assert!(versions[0]
-            .download_url
-            .as_deref()
-            .unwrap()
-            .ends_with(".tar.xz"));
-        assert!(versions[0]
-            .checksum_url
-            .as_deref()
-            .unwrap()
-            .contains("x86_64.sha512sum"));
+    fn empty_store_returns_no_response() {
+        let store = open_store();
+        let rows = load_catalog_rows(&store, "ge-proton");
+        assert!(rows.is_empty());
+        let resp = build_response_from_rows(&rows, false);
+        assert!(resp.is_none(), "empty store should produce no response");
     }
 
     #[test]
-    fn proton_cachyos_prefers_baseline_x86_64_over_v3_and_arm() {
-        let releases = vec![make_release(
-            "cachyos-test",
-            false,
-            false,
-            vec![
-                tar_xz_named("proton-cachyos-test-arm64.tar.xz"),
-                tar_xz_named("proton-cachyos-test-x86_64_v3.tar.xz"),
-                tar_xz_named("proton-cachyos-test-x86_64.tar.xz"),
-                sha512_named("proton-cachyos-test-x86_64.sha512sum"),
-                sha512_named("proton-cachyos-test-x86_64_v3.sha512sum"),
-            ],
-        )];
+    fn fresh_rows_return_non_stale_response() {
+        let store = open_store();
 
-        let versions = parse_releases(releases, "proton-cachyos");
-        assert_eq!(versions.len(), 1);
-        let url = versions[0].download_url.as_deref().unwrap();
+        // Both rows fetched recently (well within TTL) and not yet expired.
+        let future = (Utc::now() + ChronoDuration::hours(5)).to_rfc3339();
+        let fetched = Utc::now().to_rfc3339();
+
+        let v1 = make_version("GE-Proton9-1");
+        let v2 = make_version("GE-Proton9-2");
+        let rows = vec![
+            make_row("ge-proton", "GE-Proton9-1", &fetched, Some(&future), &v1),
+            make_row("ge-proton", "GE-Proton9-2", &fetched, Some(&future), &v2),
+        ];
+
+        store.put_proton_catalog(&rows).expect("put rows");
+
+        let loaded = load_catalog_rows(&store, "ge-proton");
+        assert_eq!(loaded.len(), 2);
+
+        let resp = build_response_from_rows(&loaded, false)
+            .expect("should produce a response from fresh rows");
+        assert_eq!(resp.versions.len(), 2);
+        assert!(!resp.cache.stale, "fresh rows should not be stale");
+        assert!(!resp.cache.offline);
+        assert!(resp.cache.fetched_at.is_some());
+    }
+
+    #[test]
+    fn stale_oldest_row_makes_response_stale() {
+        let store = open_store();
+
+        // One row older than 6 h (stale), one fresh.
+        let stale_fetched = (Utc::now() - ChronoDuration::hours(7)).to_rfc3339();
+        let fresh_fetched = Utc::now().to_rfc3339();
+        let future = (Utc::now() + ChronoDuration::hours(5)).to_rfc3339();
+
+        let v1 = make_version("GE-Proton9-1");
+        let v2 = make_version("GE-Proton9-2");
+        let rows = vec![
+            // Stale row: no expires_at, fetched_at older than TTL.
+            make_row("ge-proton", "GE-Proton9-1", &stale_fetched, None, &v1),
+            // Fresh row: expires in future.
+            make_row(
+                "ge-proton",
+                "GE-Proton9-2",
+                &fresh_fetched,
+                Some(&future),
+                &v2,
+            ),
+        ];
+
+        store.put_proton_catalog(&rows).expect("put rows");
+
+        let loaded = load_catalog_rows(&store, "ge-proton");
+        assert_eq!(loaded.len(), 2);
+
+        // Calling build_response_from_rows with is_stale=false:
+        // all_expired check: v1 has no expires_at → uses fetched_at + TTL → expired;
+        // v2 has a future expires_at → not expired. So not all_expired → proceeds.
+        // Staleness check: oldest fetched_at (stale_fetched, 7h ago) < ttl_cutoff → stale=true.
+        let resp = build_response_from_rows(&loaded, false)
+            .expect("should produce a response even with one stale row");
+        assert_eq!(resp.versions.len(), 2);
         assert!(
-            url.contains("x86_64.tar.xz") && !url.contains("x86_64_v3"),
-            "expected baseline x86_64, got {url}"
+            resp.cache.stale,
+            "oldest row older than TTL should mark response as stale"
         );
     }
 
     #[test]
-    fn skips_draft_releases() {
-        let releases = vec![
-            make_release(
-                "GE-Proton9-21",
-                true,
-                false,
-                vec![tar_gz_asset("GE-Proton9-21")],
-            ),
-            make_release(
-                "GE-Proton9-20",
-                false,
-                false,
-                vec![tar_gz_asset("GE-Proton9-20")],
-            ),
+    fn all_expired_rows_return_none_for_fresh_check() {
+        let store = open_store();
+
+        // Both rows have expires_at in the past.
+        let past = (Utc::now() - ChronoDuration::hours(1)).to_rfc3339();
+        let fetched = (Utc::now() - ChronoDuration::hours(7)).to_rfc3339();
+
+        let v1 = make_version("GE-Proton9-1");
+        let v2 = make_version("GE-Proton9-2");
+        let rows = vec![
+            make_row("ge-proton", "GE-Proton9-1", &fetched, Some(&past), &v1),
+            make_row("ge-proton", "GE-Proton9-2", &fetched, Some(&past), &v2),
         ];
 
-        let versions = parse_releases(releases, "ge-proton");
-        assert_eq!(versions.len(), 1);
-        assert_eq!(versions[0].version, "GE-Proton9-20");
+        store.put_proton_catalog(&rows).expect("put rows");
+
+        let loaded = load_catalog_rows(&store, "ge-proton");
+        let resp = build_response_from_rows(&loaded, false);
+        assert!(
+            resp.is_none(),
+            "all-expired rows should return None for a non-stale (fresh-only) check"
+        );
+
+        // But stale check should still return them.
+        let stale_resp = build_response_from_rows(&loaded, true);
+        assert!(
+            stale_resp.is_some(),
+            "stale=true should return expired rows as fallback"
+        );
     }
 
     #[test]
-    fn skips_prerelease_releases() {
-        let releases = vec![
-            make_release(
-                "GE-Proton9-21-rc1",
-                false,
-                true,
-                vec![tar_gz_asset("GE-Proton9-21-rc1")],
-            ),
-            make_release(
-                "GE-Proton9-20",
-                false,
-                false,
-                vec![tar_gz_asset("GE-Proton9-20")],
-            ),
-        ];
+    fn no_network_offline_path_returns_empty_not_error() {
+        // A disabled store (no DB) should yield empty rows → no panic.
+        let store = MetadataStore::disabled();
+        let rows = load_catalog_rows(&store, "ge-proton");
+        assert!(rows.is_empty());
 
-        let versions = parse_releases(releases, "ge-proton");
-        assert_eq!(versions.len(), 1);
-        assert_eq!(versions[0].version, "GE-Proton9-20");
-    }
-
-    #[test]
-    fn skips_releases_without_tar_gz() {
-        let releases = vec![make_release(
-            "GE-Proton9-21",
-            false,
-            false,
-            // Only a checksum — no .tar.gz present.
-            vec![sha512_asset("GE-Proton9-21")],
-        )];
-
-        let versions = parse_releases(releases, "ge-proton");
-        assert!(versions.is_empty());
-    }
-
-    #[test]
-    fn extracts_checksum_url_when_present() {
-        let releases = vec![make_release(
-            "GE-Proton9-21",
-            false,
-            false,
-            vec![tar_gz_asset("GE-Proton9-21"), sha512_asset("GE-Proton9-21")],
-        )];
-
-        let versions = parse_releases(releases, "ge-proton");
-        let v = &versions[0];
-        assert!(v.checksum_url.is_some());
-        assert!(v.checksum_url.as_deref().unwrap().ends_with(".sha512sum"));
-        assert_eq!(v.checksum_kind.as_deref(), Some("sha512"));
-    }
-
-    #[test]
-    fn checksum_url_is_none_when_no_sha512sum_asset() {
-        let releases = vec![make_release(
-            "GE-Proton9-21",
-            false,
-            false,
-            vec![tar_gz_asset("GE-Proton9-21")],
-        )];
-
-        let versions = parse_releases(releases, "ge-proton");
-        let v = &versions[0];
-        assert!(v.checksum_url.is_none());
-        assert!(v.checksum_kind.is_none());
-    }
-
-    #[test]
-    fn caps_at_max_releases() {
-        // Generate MAX_RELEASES + 5 valid releases.
-        let releases: Vec<GhRelease> = (0..MAX_RELEASES + 5)
-            .map(|i| {
-                let tag = format!("GE-Proton9-{i}");
-                make_release(&tag, false, false, vec![tar_gz_asset(&tag)])
-            })
-            .collect();
-
-        let versions = parse_releases(releases, "ge-proton");
-        assert_eq!(versions.len(), MAX_RELEASES);
-    }
-
-    #[test]
-    fn empty_release_list_returns_empty() {
-        let versions = parse_releases(vec![], "ge-proton");
-        assert!(versions.is_empty());
+        // build_response_from_rows on empty gives None, which maps to offline empty.
+        let resp = build_response_from_rows(&rows, false);
+        assert!(resp.is_none());
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
@@ -89,7 +89,7 @@ impl InstallError {
                 "no writable Proton install root found; install Steam first",
                 ProtonUpInstallErrorKind::InvalidPath,
             ),
-            Self::Cancelled => err("install cancelled", ProtonUpInstallErrorKind::Unknown),
+            Self::Cancelled => err("install cancelled", ProtonUpInstallErrorKind::Cancelled),
             Self::UntrustedUrl(m) => err(m, ProtonUpInstallErrorKind::NetworkError),
             Self::Unknown(m) => err(m, ProtonUpInstallErrorKind::Unknown),
         }
@@ -183,6 +183,21 @@ fn err(message: impl Into<String>, kind: ProtonUpInstallErrorKind) -> ProtonUpIn
 
 fn network_err(message: impl std::fmt::Display) -> InstallError {
     InstallError::NetworkError(message.to_string())
+}
+
+fn validate_archive_filename(archive_filename: &str) -> Result<(), InstallError> {
+    if archive_filename.is_empty()
+        || archive_filename.contains('/')
+        || archive_filename.contains('\\')
+        || archive_filename.contains('\0')
+        || archive_filename.contains("..")
+    {
+        return Err(InstallError::InvalidPath(
+            "download URL resolved to an unsafe archive filename".into(),
+        ));
+    }
+
+    Ok(())
 }
 
 fn map_io_err(io_err: std::io::Error, context: &str) -> InstallError {
@@ -496,6 +511,90 @@ fn first_normal_path_component(path: &Path) -> Option<String> {
     None
 }
 
+fn normalize_archive_relative_path(path: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => continue,
+            Component::Normal(segment) => normalized.push(segment),
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+
+    Some(normalized)
+}
+
+fn validate_link_entry(
+    entry_path: &Path,
+    entry_type: tar::EntryType,
+    link_target: &Path,
+) -> Result<(), InstallError> {
+    let Some(top_level) = first_normal_path_component(entry_path) else {
+        return Err(InstallError::InvalidPath(format!(
+            "archive link entry '{}' has no valid top-level directory",
+            entry_path.display()
+        )));
+    };
+
+    let top_level = Path::new(&top_level);
+    let invalid_target = || {
+        InstallError::InvalidPath(format!(
+            "archive link '{}' points outside the install root via '{}'",
+            entry_path.display(),
+            link_target.display()
+        ))
+    };
+
+    if link_target.is_absolute() {
+        return Err(invalid_target());
+    }
+
+    let entry_parent = entry_path.parent().unwrap_or_else(|| Path::new(""));
+    let symlink_target = normalize_archive_relative_path(&entry_parent.join(link_target));
+    if entry_type.is_symlink() {
+        let Some(symlink_target) = symlink_target else {
+            return Err(invalid_target());
+        };
+        if !symlink_target.starts_with(top_level) {
+            return Err(invalid_target());
+        }
+        return Ok(());
+    }
+
+    if entry_type.is_hard_link() {
+        let direct_target = normalize_archive_relative_path(link_target);
+        let is_safe_direct = direct_target
+            .as_ref()
+            .is_some_and(|candidate| candidate.starts_with(top_level));
+        let is_safe_parent_relative = symlink_target
+            .as_ref()
+            .is_some_and(|candidate| candidate.starts_with(top_level));
+        if !(is_safe_direct || is_safe_parent_relative) {
+            return Err(invalid_target());
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_unpack_result(entry_path: &Path, unpacked: bool) -> Result<(), InstallError> {
+    if unpacked {
+        Ok(())
+    } else {
+        Err(InstallError::InvalidPath(format!(
+            "archive entry '{}' escapes the install root",
+            entry_path.display()
+        )))
+    }
+}
+
 fn extract_tar_read_sync<R: std::io::Read>(
     read: R,
     dest_dir: &Path,
@@ -515,13 +614,29 @@ fn extract_tar_read_sync<R: std::io::Read>(
 
         let entry_path = entry
             .path()
-            .map_err(|e| InstallError::Unknown(format!("invalid path in archive entry: {e}")))?;
+            .map_err(|e| InstallError::Unknown(format!("invalid path in archive entry: {e}")))?
+            .into_owned();
 
         if top_level_dir.is_none() {
             top_level_dir = first_normal_path_component(&entry_path);
         }
 
-        entry.unpack_in(dest_dir).map_err(|e| {
+        if entry.header().entry_type().is_symlink() || entry.header().entry_type().is_hard_link() {
+            let link_target = entry
+                .link_name()
+                .map_err(|e| {
+                    InstallError::Unknown(format!("invalid link target in archive entry: {e}"))
+                })?
+                .ok_or_else(|| {
+                    InstallError::InvalidPath(format!(
+                        "archive link entry '{}' is missing a link target",
+                        entry_path.display()
+                    ))
+                })?;
+            validate_link_entry(&entry_path, entry.header().entry_type(), &link_target)?;
+        }
+
+        let unpacked = entry.unpack_in(dest_dir).map_err(|e| {
             if e.kind() == std::io::ErrorKind::PermissionDenied {
                 InstallError::PermissionDenied(format!(
                     "permission denied extracting to {}: {e}",
@@ -531,6 +646,7 @@ fn extract_tar_read_sync<R: std::io::Read>(
                 InstallError::Unknown(format!("extraction error: {e}"))
             }
         })?;
+        validate_unpack_result(&entry_path, unpacked)?;
     }
 
     top_level_dir.ok_or_else(|| InstallError::Unknown("archive appears to be empty".into()))
@@ -771,6 +887,7 @@ pub async fn install_version_with_progress(
         .next()
         .unwrap_or("proton-archive.tar.gz")
         .to_string();
+    validate_archive_filename(&archive_filename)?;
     let temp_path = dest_dir.join(format!(".tmp.{archive_filename}"));
 
     let client = reqwest::Client::new();
@@ -1245,6 +1362,13 @@ mod tests {
     }
 
     #[test]
+    fn cancelled_maps_to_cancelled_error_kind() {
+        let result = InstallError::Cancelled.to_result();
+        assert_eq!(result.error_kind, Some(ProtonUpInstallErrorKind::Cancelled));
+        assert_eq!(result.error_message.as_deref(), Some("install cancelled"));
+    }
+
+    #[test]
     fn rejects_path_with_parent_dir_component() {
         let result = validate_install_destination(
             "/home/user/.steam/../../../etc/passwd/compatibilitytools.d",
@@ -1273,6 +1397,28 @@ mod tests {
         assert!(result.is_dir());
     }
 
+    #[test]
+    fn validate_archive_filename_accepts_safe_name() {
+        assert!(validate_archive_filename("GE-Proton9-21.tar.gz").is_ok());
+    }
+
+    #[test]
+    fn validate_archive_filename_rejects_unsafe_names() {
+        for filename in [
+            "",
+            "../evil.tar.gz",
+            "bad\\name.tar.gz",
+            "bad/name.tar.gz",
+            "bad\0name.tar.gz",
+        ] {
+            let result = validate_archive_filename(filename);
+            assert!(
+                matches!(result, Err(InstallError::InvalidPath(_))),
+                "expected InvalidPath for {filename:?}, got {result:?}"
+            );
+        }
+    }
+
     /// F001: A symlink at the `compatibilitytools.d` component that resolves to
     /// a sibling directory (i.e., the canonical path has no
     /// `compatibilitytools.d` segment) must be refused with
@@ -1293,6 +1439,114 @@ mod tests {
         assert!(
             matches!(result, InstallError::InvalidPath(_)),
             "expected InvalidPath for symlink-redirected compat dir, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn extract_tar_rejects_link_entries_that_escape_install_root() {
+        for (entry_type, path, target) in [
+            (tar::EntryType::Symlink, "GE-Proton9-21/escape", "/etc"),
+            (
+                tar::EntryType::Symlink,
+                "GE-Proton9-21/escape",
+                "../../../etc",
+            ),
+            (
+                tar::EntryType::Link,
+                "GE-Proton9-21/hardlink",
+                "../outside/proton",
+            ),
+        ] {
+            let temp = tempfile::tempdir().expect("temp dir");
+            let mut buf = Vec::new();
+            {
+                let mut builder = tar::Builder::new(&mut buf);
+                let mut header = tar::Header::new_gnu();
+                header.set_entry_type(entry_type);
+                header.set_path(path).expect("link path");
+                header.set_link_name(target).expect("link target");
+                header.set_size(0);
+                header.set_mode(0o777);
+                header.set_cksum();
+                builder
+                    .append(&header, std::io::empty())
+                    .expect("append link entry");
+                builder.finish().expect("finish tar");
+            }
+
+            let result = extract_tar_read_sync(buf.as_slice(), temp.path());
+            assert!(
+                matches!(result, Err(InstallError::InvalidPath(_))),
+                "expected InvalidPath for tar link entry {path}, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn extract_tar_allows_safe_symlink_entries_within_archive_root() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+
+            let mut dir_header = tar::Header::new_gnu();
+            dir_header.set_entry_type(tar::EntryType::Directory);
+            dir_header
+                .set_path("GE-Proton9-21/usr/bin")
+                .expect("dir path");
+            dir_header.set_size(0);
+            dir_header.set_mode(0o755);
+            dir_header.set_cksum();
+            builder
+                .append(&dir_header, std::io::empty())
+                .expect("append directory");
+
+            let mut symlink_header = tar::Header::new_gnu();
+            symlink_header.set_entry_type(tar::EntryType::Symlink);
+            symlink_header
+                .set_path("GE-Proton9-21/bin")
+                .expect("symlink path");
+            symlink_header
+                .set_link_name("usr/bin")
+                .expect("symlink target");
+            symlink_header.set_size(0);
+            symlink_header.set_mode(0o777);
+            symlink_header.set_cksum();
+            builder
+                .append(&symlink_header, std::io::empty())
+                .expect("append symlink");
+
+            let payload = b"proton-binary";
+            let mut file_header = tar::Header::new_gnu();
+            file_header.set_entry_type(tar::EntryType::Regular);
+            file_header
+                .set_path("GE-Proton9-21/bin/proton")
+                .expect("file path");
+            file_header.set_size(payload.len() as u64);
+            file_header.set_mode(0o755);
+            file_header.set_cksum();
+            builder
+                .append(&file_header, payload.as_slice())
+                .expect("append payload");
+
+            builder.finish().expect("finish tar");
+        }
+
+        let extracted = extract_tar_read_sync(buf.as_slice(), temp.path()).expect("extract tar");
+        assert_eq!(extracted, "GE-Proton9-21");
+        assert_eq!(
+            std::fs::read(temp.path().join("GE-Proton9-21/usr/bin/proton"))
+                .expect("read extracted payload"),
+            b"proton-binary"
+        );
+    }
+
+    #[test]
+    fn validate_unpack_result_rejects_skipped_entries() {
+        let result = validate_unpack_result(Path::new("GE-Proton9-21/../../escape"), false);
+        assert!(
+            matches!(result, Err(InstallError::InvalidPath(_))),
+            "expected InvalidPath for skipped traversal entry, got {result:?}"
         );
     }
 

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
@@ -38,6 +38,7 @@ pub enum InstallError {
     DependencyMissing { reason: String },
     NoWritableInstallRoot,
     Cancelled,
+    UntrustedUrl(String),
     Unknown(String),
 }
 
@@ -60,6 +61,7 @@ impl std::fmt::Display for InstallError {
                 )
             }
             Self::Cancelled => write!(f, "install cancelled"),
+            Self::UntrustedUrl(m) => write!(f, "untrusted URL: {m}"),
             Self::Unknown(m) => write!(f, "unknown error: {m}"),
         }
     }
@@ -88,6 +90,7 @@ impl InstallError {
                 ProtonUpInstallErrorKind::InvalidPath,
             ),
             Self::Cancelled => err("install cancelled", ProtonUpInstallErrorKind::Unknown),
+            Self::UntrustedUrl(m) => err(m, ProtonUpInstallErrorKind::NetworkError),
             Self::Unknown(m) => err(m, ProtonUpInstallErrorKind::Unknown),
         }
     }
@@ -148,6 +151,22 @@ fn validate_install_destination(target_root: &str) -> Result<PathBuf, InstallErr
         InstallError::InvalidPath(format!("failed to resolve {}: {io_err}", path.display()))
     })?;
 
+    // Re-run the compatibilitytools.d check on the *canonical* path so that a
+    // symlink whose component spells "compatibilitytools.d" but resolves to an
+    // unrelated directory (e.g., `/`) does not bypass the guard.
+    let canonical_has_compat_segment = canonical.components().any(|c| {
+        c.as_os_str()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("compatibilitytools.d")
+    });
+    if !canonical_has_compat_segment {
+        return Err(InstallError::InvalidPath(format!(
+            "install destination '{}' resolved to '{}' which is not under a 'compatibilitytools.d' directory",
+            path.display(),
+            canonical.display()
+        )));
+    }
+
     Ok(canonical)
 }
 
@@ -174,12 +193,66 @@ fn map_io_err(io_err: std::io::Error, context: &str) -> InstallError {
     }
 }
 
+/// Assert that `url` is an `https` URL whose host is one of the known-good
+/// GitHub origins. Returns `InstallError::UntrustedUrl` if any check fails.
+///
+/// Allowed hosts:
+///   - `github.com`               — release API / raw URLs
+///   - `api.github.com`           — REST API
+///   - `objects.githubusercontent.com`         — uploaded release assets
+///   - `github-releases.githubusercontent.com` — CDN redirect target for assets
+///
+/// In test builds, `http://127.0.0.1` and `http://localhost` are also accepted
+/// so that wiremock-backed unit tests can exercise the install flow end-to-end
+/// without standing up a TLS server.
+fn validate_release_url(url: &str) -> Result<(), InstallError> {
+    const ALLOWED_HOSTS: &[&str] = &[
+        "github.com",
+        "api.github.com",
+        "objects.githubusercontent.com",
+        "github-releases.githubusercontent.com",
+    ];
+
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| InstallError::UntrustedUrl(format!("failed to parse URL '{url}': {e}")))?;
+
+    let host = parsed.host_str().unwrap_or("");
+
+    // In test builds allow plain-http loopback so wiremock tests can run.
+    #[cfg(test)]
+    if parsed.scheme() == "http" && (host == "127.0.0.1" || host == "localhost") {
+        return Ok(());
+    }
+
+    if parsed.scheme() != "https" {
+        return Err(InstallError::UntrustedUrl(format!(
+            "URL '{url}' uses scheme '{}'; only https is allowed",
+            parsed.scheme()
+        )));
+    }
+
+    if !ALLOWED_HOSTS.contains(&host) {
+        return Err(InstallError::UntrustedUrl(format!(
+            "URL '{url}' has untrusted host '{host}'; allowed: {}",
+            ALLOWED_HOSTS.join(", ")
+        )));
+    }
+
+    Ok(())
+}
+
 // ── download helpers ──────────────────────────────────────────────────────────
 
 /// Stream the URL into `dest_path`, returning the SHA-512 digest. Emits
 /// `Phase::Downloading` progress every `EMIT_INTERVAL_BYTES`. Checks `cancel`
 /// before each chunk; returns `InstallError::Cancelled` if triggered.
 const EMIT_INTERVAL_BYTES: u64 = 256 * 1024;
+
+/// Hard ceiling for checksum sidecar / manifest response bodies (1 MiB).
+/// Legitimate `.sha512sum` files are ~200 B and SHA256SUMS manifests are a few
+/// KiB; this cap prevents a hostile or mis-served CDN response from being
+/// buffered into RAM unboundedly.
+const MAX_CHECKSUM_BYTES: u64 = 1024 * 1024;
 
 async fn download_to_file(
     client: &reqwest::Client,
@@ -306,11 +379,21 @@ async fn fetch_sha512_sidecar(
     client: &reqwest::Client,
     checksum_url: &str,
 ) -> Result<String, InstallError> {
-    let body = client
+    let response = client
         .get(checksum_url)
         .send()
         .await
-        .map_err(|e| network_err(format!("checksum request failed for {checksum_url}: {e}")))?
+        .map_err(|e| network_err(format!("checksum request failed for {checksum_url}: {e}")))?;
+
+    if let Some(len) = response.content_length() {
+        if len > MAX_CHECKSUM_BYTES {
+            return Err(InstallError::ChecksumFailed(format!(
+                "checksum response for {checksum_url} is too large ({len} bytes, limit {MAX_CHECKSUM_BYTES})"
+            )));
+        }
+    }
+
+    let body = response
         .text()
         .await
         .map_err(|e| network_err(format!("failed to read checksum body: {e}")))?;
@@ -343,11 +426,20 @@ async fn fetch_sha256_manifest(
     manifest_url: &str,
     asset_filename: &str,
 ) -> Result<String, InstallError> {
-    let body = client
-        .get(manifest_url)
-        .send()
-        .await
-        .map_err(|e| network_err(format!("SHA256SUMS request failed for {manifest_url}: {e}")))?
+    let response =
+        client.get(manifest_url).send().await.map_err(|e| {
+            network_err(format!("SHA256SUMS request failed for {manifest_url}: {e}"))
+        })?;
+
+    if let Some(len) = response.content_length() {
+        if len > MAX_CHECKSUM_BYTES {
+            return Err(InstallError::ChecksumFailed(format!(
+                "SHA256SUMS response for {manifest_url} is too large ({len} bytes, limit {MAX_CHECKSUM_BYTES})"
+            )));
+        }
+    }
+
+    let body = response
         .text()
         .await
         .map_err(|e| network_err(format!("failed to read SHA256SUMS body: {e}")))?;
@@ -616,7 +708,7 @@ pub async fn install_version_with_progress(
         em.emit(Phase::Resolving, 0, None, None);
     }
 
-    let registry = providers::registry(false);
+    let registry = providers::registry();
     let provider = registry
         .iter()
         .find(|p| p.id() == request.provider.as_str());
@@ -670,6 +762,9 @@ pub async fn install_version_with_progress(
                     version_info.version
                 ),
             })?;
+
+    // F003: Validate download URL origin before use.
+    validate_release_url(download_url)?;
 
     let archive_filename = download_url
         .rsplit('/')
@@ -742,6 +837,14 @@ pub async fn install_version_with_progress(
     match checksum_kind {
         ChecksumKind::Sha512Sidecar => {
             if let Some(checksum_url) = &version_info.checksum_url {
+                // F003: Validate checksum URL origin before fetching.
+                if let Err(e) = validate_release_url(checksum_url) {
+                    best_effort_cleanup(&temp_path, None);
+                    if let Some(em) = em {
+                        em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+                    }
+                    return Err(e);
+                }
                 let expected_hex = match fetch_sha512_sidecar(&client, checksum_url).await {
                     Ok(h) => h,
                     Err(e) => {
@@ -779,14 +882,32 @@ pub async fn install_version_with_progress(
         }
 
         ChecksumKind::Sha256Manifest => {
-            let manifest_url = version_info.checksum_url.as_deref().ok_or_else(|| {
-                let e = InstallError::ChecksumMissing(format!(
-                    "provider requires SHA256SUMS manifest but none is available for version {}",
-                    version_info.version
-                ));
+            // F004: Expand ok_or_else to a match so Phase::Failed is emitted
+            // before returning, preventing the frontend progress bar from
+            // getting stuck in `Verifying` when checksum_url is absent.
+            let manifest_url = match version_info.checksum_url.as_deref() {
+                Some(u) => u,
+                None => {
+                    best_effort_cleanup(&temp_path, None);
+                    let err = InstallError::ChecksumMissing(format!(
+                        "provider requires SHA256SUMS manifest but none is available for version {}",
+                        version_info.version
+                    ));
+                    if let Some(em) = em {
+                        em.emit(Phase::Failed, 0, None, Some(err.to_string()));
+                    }
+                    return Err(err);
+                }
+            };
+
+            // F003: Validate checksum URL origin before fetching.
+            if let Err(e) = validate_release_url(manifest_url) {
                 best_effort_cleanup(&temp_path, None);
-                e
-            })?;
+                if let Some(em) = em {
+                    em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+                }
+                return Err(e);
+            }
 
             let expected_hex =
                 match fetch_sha256_manifest(&client, manifest_url, &archive_filename).await {
@@ -1152,6 +1273,29 @@ mod tests {
         assert!(result.is_dir());
     }
 
+    /// F001: A symlink at the `compatibilitytools.d` component that resolves to
+    /// a sibling directory (i.e., the canonical path has no
+    /// `compatibilitytools.d` segment) must be refused with
+    /// `InstallError::InvalidPath`.
+    #[test]
+    fn rejects_symlink_redirect_escaping_compat_dir() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        // Create a sibling directory that the symlink will point to.
+        let real_target = temp.path().join("not_compat");
+        std::fs::create_dir_all(&real_target).expect("real target dir");
+
+        // Create a symlink named `compatibilitytools.d` pointing to the sibling.
+        let symlink_path = temp.path().join("compatibilitytools.d");
+        std::os::unix::fs::symlink(&real_target, &symlink_path).expect("create symlink");
+
+        let dest = symlink_path.to_string_lossy().to_string();
+        let result = validate_install_destination(&dest).unwrap_err();
+        assert!(
+            matches!(result, InstallError::InvalidPath(_)),
+            "expected InvalidPath for symlink-redirected compat dir, got: {result:?}"
+        );
+    }
+
     // ── hex_encode ────────────────────────────────────────────────────────────
 
     #[test]
@@ -1263,6 +1407,40 @@ mod tests {
             Some(ProtonUpInstallErrorKind::DependencyMissing),
             "with force=true the already-installed guard must be skipped"
         );
+    }
+
+    // ── validate_release_url ─────────────────────────────────────────────────
+
+    #[test]
+    fn validate_release_url_accepts_known_github_hosts() {
+        assert!(validate_release_url("https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-21/GE-Proton9-21.tar.gz").is_ok());
+        assert!(validate_release_url(
+            "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases"
+        )
+        .is_ok());
+        assert!(validate_release_url("https://objects.githubusercontent.com/github-production-release-asset-2e65be/GE-Proton9-21.tar.gz").is_ok());
+        assert!(validate_release_url(
+            "https://github-releases.githubusercontent.com/GE-Proton9-21.tar.gz"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn validate_release_url_rejects_http_scheme() {
+        let result = validate_release_url("http://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-21/GE-Proton9-21.tar.gz");
+        assert!(matches!(result, Err(InstallError::UntrustedUrl(_))));
+    }
+
+    #[test]
+    fn validate_release_url_rejects_untrusted_host() {
+        let result = validate_release_url("https://evil.example.com/GE-Proton9-21.tar.gz");
+        assert!(matches!(result, Err(InstallError::UntrustedUrl(_))));
+    }
+
+    #[test]
+    fn validate_release_url_rejects_malformed_url() {
+        let result = validate_release_url("not a url at all");
+        assert!(matches!(result, Err(InstallError::UntrustedUrl(_))));
     }
 
     // ── error helper ──────────────────────────────────────────────────────────

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
@@ -221,17 +221,29 @@ async fn download_to_file(
 
     use futures_util::StreamExt;
     loop {
-        // Check cancellation before each chunk.
-        if let Some(tok) = cancel {
+        // Race the next chunk against cancellation so a stalled / slow
+        // stream doesn't hold the user's Cancel click hostage — a plain
+        // `stream.next().await` only yields control when the next chunk
+        // arrives, which on a stuck connection could be never.
+        let chunk = if let Some(tok) = cancel {
             if tok.is_cancelled() {
                 return Err(InstallError::Cancelled);
             }
-        }
-
-        let chunk = match stream.next().await {
-            Some(Ok(b)) => b,
-            Some(Err(e)) => return Err(network_err(format!("download interrupted: {e}"))),
-            None => break,
+            tokio::select! {
+                biased;
+                _ = tok.cancelled() => return Err(InstallError::Cancelled),
+                next = stream.next() => match next {
+                    Some(Ok(b)) => b,
+                    Some(Err(e)) => return Err(network_err(format!("download interrupted: {e}"))),
+                    None => break,
+                },
+            }
+        } else {
+            match stream.next().await {
+                Some(Ok(b)) => b,
+                Some(Err(e)) => return Err(network_err(format!("download interrupted: {e}"))),
+                None => break,
+            }
         };
 
         sha512.update(&chunk);
@@ -254,6 +266,32 @@ async fn download_to_file(
     file.flush()
         .await
         .map_err(|e| map_io_err(e, &format!("flush failed for {}", dest_path.display())))?;
+
+    // Drop the tokio fs::File handle before the caller re-opens the path for
+    // peek/extract. tokio::fs close is async-lazy; holding it across the
+    // subsequent synchronous open can race on some kernels.
+    drop(file);
+
+    // Fail fast if the stream closed without delivering any bytes. Without
+    // this, a silent short-circuit (e.g. an unexpected redirect body with
+    // Content-Length: 0) propagates as an opaque "archive appears to be
+    // empty" error from the tar peek step.
+    if bytes_done == 0 {
+        return Err(network_err(format!(
+            "download produced 0 bytes for {url} — server may have redirected to an empty response"
+        )));
+    }
+
+    // If the upstream advertised a size, require the transfer to match. A
+    // silent truncation here shows up much later as a confusing extraction
+    // error, so surface it right at the source.
+    if let Some(expected) = bytes_total {
+        if expected > 0 && bytes_done != expected {
+            return Err(network_err(format!(
+                "download truncated for {url}: got {bytes_done} bytes, expected {expected}"
+            )));
+        }
+    }
 
     // Emit a final downloading event with the full byte count.
     if let Some(em) = emitter {
@@ -342,6 +380,30 @@ async fn fetch_sha256_manifest(
 
 // ── extract helpers ───────────────────────────────────────────────────────────
 
+/// Return the first non-`.` normal path segment, or `None` if the path has
+/// no usable top-level name. Archives produced by GNU tar frequently prefix
+/// every entry with `./` (POSIX "current directory" marker) — taking the
+/// raw first component would misclassify every entry as `.` and leak through
+/// as an empty-archive error.
+fn first_normal_path_component(path: &Path) -> Option<String> {
+    use std::path::Component;
+    for component in path.components() {
+        match component {
+            Component::Normal(s) => {
+                let name = s.to_string_lossy().to_string();
+                if !name.is_empty() {
+                    return Some(name);
+                }
+            }
+            Component::CurDir => continue,
+            // Anything else (RootDir / ParentDir / Prefix) means the path
+            // escapes the archive root — treat as no usable top-level.
+            _ => return None,
+        }
+    }
+    None
+}
+
 fn extract_tar_read_sync<R: std::io::Read>(
     read: R,
     dest_dir: &Path,
@@ -364,12 +426,7 @@ fn extract_tar_read_sync<R: std::io::Read>(
             .map_err(|e| InstallError::Unknown(format!("invalid path in archive entry: {e}")))?;
 
         if top_level_dir.is_none() {
-            if let Some(first) = entry_path.components().next() {
-                let name = first.as_os_str().to_string_lossy().to_string();
-                if !name.is_empty() && name != "." {
-                    top_level_dir = Some(name);
-                }
-            }
+            top_level_dir = first_normal_path_component(&entry_path);
         }
 
         entry.unpack_in(dest_dir).map_err(|e| {
@@ -422,14 +479,26 @@ fn peek_tar_read_top_level_sync<R: std::io::Read>(read: R) -> Result<String, Ins
         let entry_path = entry
             .path()
             .map_err(|e| InstallError::Unknown(format!("invalid path in archive entry: {e}")))?;
-        if let Some(first) = entry_path.components().next() {
-            let name = first.as_os_str().to_string_lossy().to_string();
-            if !name.is_empty() && name != "." {
-                return Ok(name);
-            }
+        if let Some(name) = first_normal_path_component(&entry_path) {
+            return Ok(name);
         }
     }
     Err(InstallError::Unknown("archive appears to be empty".into()))
+}
+
+/// Attach the archive path + on-disk file size to a peek error so the
+/// caller can distinguish "truncated download" from "corrupt stream".
+fn enrich_peek_err(archive_path: &Path, err: InstallError) -> InstallError {
+    let size = std::fs::metadata(archive_path)
+        .map(|m| m.len())
+        .unwrap_or(0);
+    match err {
+        InstallError::Unknown(msg) => InstallError::Unknown(format!(
+            "{msg} (archive: {} — on-disk size {size} bytes)",
+            archive_path.display()
+        )),
+        other => other,
+    }
 }
 
 fn peek_tar_gz_top_level_sync(archive_path: &Path) -> Result<String, InstallError> {
@@ -440,7 +509,7 @@ fn peek_tar_gz_top_level_sync(archive_path: &Path) -> Result<String, InstallErro
             &format!("failed to open archive {}", archive_path.display()),
         )
     })?;
-    peek_tar_read_top_level_sync(GzDecoder::new(file))
+    peek_tar_read_top_level_sync(GzDecoder::new(file)).map_err(|e| enrich_peek_err(archive_path, e))
 }
 
 fn peek_tar_xz_top_level_sync(archive_path: &Path) -> Result<String, InstallError> {
@@ -451,7 +520,7 @@ fn peek_tar_xz_top_level_sync(archive_path: &Path) -> Result<String, InstallErro
             &format!("failed to open archive {}", archive_path.display()),
         )
     })?;
-    peek_tar_read_top_level_sync(XzDecoder::new(file))
+    peek_tar_read_top_level_sync(XzDecoder::new(file)).map_err(|e| enrich_peek_err(archive_path, e))
 }
 
 fn archive_peek_sync(archive_path: &Path) -> Result<String, InstallError> {
@@ -782,9 +851,14 @@ pub async fn install_version_with_progress(
         }
     };
 
-    // GE-Proton archives use the release tag as the root folder.
-    // Proton-CachyOS archives use a different name (tag vs. folder name).
-    if version_info.provider != "proton-cachyos" && top_level_dir != version_info.version {
+    // Only GE-Proton guarantees `archive top-level dir == release tag`.
+    // Proton-CachyOS (`proton-cachyos-<tag>-x86_64/`) and Proton-EM
+    // (`proton-<tag>/`) use distinct naming schemes; the matching
+    // TS-side `normalizeInstallToTag` helper knows how to recover the
+    // tag from those directory names. For any non-GE provider we trust
+    // the archive's declared top-level — `unpack_in(dest_dir)` still
+    // prevents the archive from escaping the compat-tools root.
+    if version_info.provider == "ge-proton" && top_level_dir != version_info.version {
         let msg = format!(
             "archive top-level directory '{top_level_dir}' does not match expected version '{}'",
             version_info.version
@@ -910,6 +984,62 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // ── shared fixtures ───────────────────────────────────────────────────────
+
+    // ── first_normal_path_component ──────────────────────────────────────────
+
+    #[test]
+    fn first_normal_component_returns_plain_dir_name() {
+        let p = std::path::Path::new("GE-Proton9-21/proton");
+        assert_eq!(
+            first_normal_path_component(p),
+            Some("GE-Proton9-21".to_string())
+        );
+    }
+
+    /// GNU tar commonly prefixes entries with `./` (POSIX current-directory
+    /// marker). Proton-EM ships archives like this. The first raw component
+    /// is `CurDir` (`.`); we must look past it to reach the real top-level
+    /// directory name — otherwise peek returns 0 usable entries and the
+    /// install fails with "archive appears to be empty".
+    #[test]
+    fn first_normal_component_skips_leading_current_dir_marker() {
+        let p = std::path::Path::new("./proton-EM-10.0-37-HDR/proton");
+        assert_eq!(
+            first_normal_path_component(p),
+            Some("proton-EM-10.0-37-HDR".to_string())
+        );
+    }
+
+    #[test]
+    fn first_normal_component_rejects_absolute_paths() {
+        let p = std::path::Path::new("/etc/passwd");
+        assert_eq!(first_normal_path_component(p), None);
+    }
+
+    #[test]
+    fn first_normal_component_rejects_parent_traversal() {
+        let p = std::path::Path::new("../escape/me");
+        assert_eq!(first_normal_path_component(p), None);
+    }
+
+    /// End-to-end: a tar built with leading `./` entries (Proton-EM's shape)
+    /// must peek to the actual dir name, not be treated as empty.
+    #[test]
+    fn peek_tar_with_dot_slash_prefix_returns_real_top_level() {
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_path("./proton-EM-10.0-37-HDR/proton").unwrap();
+            header.set_size(0);
+            header.set_cksum();
+            builder.append(&header, std::io::empty()).unwrap();
+            builder.finish().unwrap();
+        }
+
+        let top = peek_tar_read_top_level_sync(buf.as_slice()).expect("peek must succeed");
+        assert_eq!(top, "proton-EM-10.0-37-HDR");
+    }
 
     fn minimal_ge_proton_tar_gz(tool_dir_name: &str) -> Vec<u8> {
         let mut buf = Vec::new();

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
@@ -6,6 +6,13 @@
 //!
 //! All host-tool execution is in-process (tar/flate2/xz2); no `Command::new` calls
 //! for blocked tools appear here (ADR-0001 compliance).
+//!
+//! Known limitation: archive extraction is offloaded to `spawn_blocking`, but the
+//! synchronous tar loop does not observe cancellation mid-extract. For large
+//! archives, cancellation is only seen before or after extraction completes. A
+//! full fix requires a streaming async tar extractor; manually iterating
+//! `archive.entries()?` and checking `cancel.is_cancelled()` between entries
+//! would also enable per-entry symlink validation.
 
 use std::path::{Component, Path, PathBuf};
 

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
@@ -766,10 +766,15 @@ pub async fn install_version_with_progress(
                 }
                 tracing::info!(version = %version_info.version, "SHA-512 checksum verified");
             } else {
-                tracing::warn!(
-                    version = %version_info.version,
-                    "no checksum URL available; skipping checksum verification"
+                let msg = format!(
+                    "provider requires SHA-512 sidecar checksum but no checksum URL is available for version {}",
+                    version_info.version
                 );
+                best_effort_cleanup(&temp_path, None);
+                if let Some(em) = em {
+                    em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+                }
+                return Err(InstallError::ChecksumMissing(msg));
             }
         }
 
@@ -871,11 +876,29 @@ pub async fn install_version_with_progress(
     }
 
     let installed_dir = dest_dir.join(&top_level_dir);
-    if !request.force && installed_dir.exists() {
-        best_effort_cleanup(&temp_path, None);
-        return Err(InstallError::AlreadyInstalled {
-            path: installed_dir,
-        });
+    if installed_dir.exists() {
+        if !request.force {
+            best_effort_cleanup(&temp_path, None);
+            return Err(InstallError::AlreadyInstalled {
+                path: installed_dir,
+            });
+        }
+        if let Err(err) = fs::remove_dir_all(&installed_dir).await {
+            best_effort_cleanup(&temp_path, None);
+            let msg = format!(
+                "failed to remove existing install directory '{}' before forced reinstall: {err}",
+                installed_dir.display()
+            );
+            if let Some(em) = em {
+                em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+            }
+            let is_permission = matches!(err.kind(), std::io::ErrorKind::PermissionDenied);
+            return if is_permission {
+                Err(InstallError::PermissionDenied(msg))
+            } else {
+                Err(InstallError::Unknown(msg))
+            };
+        }
     }
 
     // ── 11. Extract archive ───────────────────────────────────────────────────
@@ -905,6 +928,21 @@ pub async fn install_version_with_progress(
             return Err(e);
         }
     };
+
+    if let Some(tok) = &cancel {
+        if tok.is_cancelled() {
+            best_effort_cleanup(&temp_path, Some(&installed_dir));
+            if let Some(em) = em {
+                em.emit(
+                    Phase::Cancelled,
+                    0,
+                    None,
+                    Some("cancelled during extraction".to_string()),
+                );
+            }
+            return Err(InstallError::Cancelled);
+        }
+    }
 
     if extracted_top != top_level_dir {
         let msg = format!(
@@ -1139,13 +1177,22 @@ mod tests {
     async fn returns_already_installed_when_tool_dir_exists_and_force_false() {
         let mock_server = MockServer::start().await;
         let archive = minimal_ge_proton_tar_gz("GE-Proton9-21");
+        let digest = hex_encode(&Sha512::digest(&archive));
         Mock::given(method("GET"))
             .and(path("/archive.tar.gz"))
             .respond_with(ResponseTemplate::new(200).set_body_bytes(archive))
             .mount(&mock_server)
             .await;
+        Mock::given(method("GET"))
+            .and(path("/archive.tar.gz.sha512sum"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string(format!("{digest}  archive.tar.gz")),
+            )
+            .mount(&mock_server)
+            .await;
 
         let download_url = format!("{}/archive.tar.gz", mock_server.uri());
+        let checksum_url = format!("{}/archive.tar.gz.sha512sum", mock_server.uri());
 
         let temp = tempfile::tempdir().expect("temp dir");
         let compat_dir = temp.path().join("compatibilitytools.d");
@@ -1158,7 +1205,7 @@ mod tests {
             target_root: compat_dir.to_string_lossy().to_string(),
             force: false,
         };
-        let version_info = make_version("GE-Proton9-21", Some(&download_url), None);
+        let version_info = make_version("GE-Proton9-21", Some(&download_url), Some(&checksum_url));
 
         let result = install_version(&request, &version_info).await;
         assert!(!result.success);
@@ -1289,9 +1336,18 @@ mod tests {
         let mock_server = MockServer::start().await;
         // Serve a valid archive so all phases complete.
         let archive = minimal_ge_proton_tar_gz("GE-Proton9-22");
+        let digest = hex_encode(&Sha512::digest(&archive));
         Mock::given(method("GET"))
             .and(path("/GE-Proton9-22.tar.gz"))
             .respond_with(ResponseTemplate::new(200).set_body_bytes(archive))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/GE-Proton9-22.tar.gz.sha512sum"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(format!("{digest}  GE-Proton9-22.tar.gz")),
+            )
             .mount(&mock_server)
             .await;
 
@@ -1306,7 +1362,8 @@ mod tests {
             target_root: compat_dir.to_string_lossy().to_string(),
             force: false,
         };
-        let version_info = make_version("GE-Proton9-22", Some(&download_url), None);
+        let checksum_url = format!("{}/GE-Proton9-22.tar.gz.sha512sum", mock_server.uri());
+        let version_info = make_version("GE-Proton9-22", Some(&download_url), Some(&checksum_url));
 
         let (emitter, mut rx) = ProgressEmitter::new("test-op-1");
 

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install.rs
@@ -1,99 +1,151 @@
-//! ProtonUp install orchestration with security guardrails.
+//! ProtonUp install orchestration with progress, cancellation, and checksum dispatch.
 //!
-//! Handles archive download, SHA-512 checksum verification, and extraction to
-//! the Steam compatibility tools directory. All paths are validated to prevent
-//! writes outside the allowed destinations before any I/O begins.
+//! The public surface is:
+//!   - [`install_version`] — backward-compatible entry point (no progress/cancel).
+//!   - [`install_version_with_progress`] — full-featured orchestrator.
+//!
+//! All host-tool execution is in-process (tar/flate2/xz2); no `Command::new` calls
+//! for blocked tools appear here (ADR-0001 compliance).
 
 use std::path::{Component, Path, PathBuf};
 
-use sha2::{Digest, Sha512};
+use sha2::{Digest, Sha256, Sha512};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
+use tokio_util::sync::CancellationToken;
 
+use crate::protonup::install_root::{pick_default_install_root, resolve_install_root_candidates};
+use crate::protonup::progress::{Phase, ProgressEmitter};
+use crate::protonup::providers::{self, ChecksumKind};
 use crate::protonup::{
     ProtonUpAvailableVersion, ProtonUpInstallErrorKind, ProtonUpInstallRequest,
     ProtonUpInstallResult,
 };
 use crate::settings::expand_path_with_tilde;
 
+// ── internal error type ───────────────────────────────────────────────────────
+
+/// Internal install error — richer than `ProtonUpInstallResult` for use inside
+/// the orchestrator. Converted to `ProtonUpInstallResult` at the public boundary.
+#[derive(Debug)]
+pub enum InstallError {
+    InvalidPath(String),
+    PermissionDenied(String),
+    NetworkError(String),
+    ChecksumMissing(String),
+    ChecksumFailed(String),
+    AlreadyInstalled { path: PathBuf },
+    DependencyMissing { reason: String },
+    NoWritableInstallRoot,
+    Cancelled,
+    Unknown(String),
+}
+
+impl std::fmt::Display for InstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPath(m) => write!(f, "invalid path: {m}"),
+            Self::PermissionDenied(m) => write!(f, "permission denied: {m}"),
+            Self::NetworkError(m) => write!(f, "network error: {m}"),
+            Self::ChecksumMissing(m) => write!(f, "checksum missing: {m}"),
+            Self::ChecksumFailed(m) => write!(f, "checksum failed: {m}"),
+            Self::AlreadyInstalled { path } => {
+                write!(f, "already installed at {}", path.display())
+            }
+            Self::DependencyMissing { reason } => write!(f, "dependency missing: {reason}"),
+            Self::NoWritableInstallRoot => {
+                write!(
+                    f,
+                    "no writable Proton install root found; install Steam first"
+                )
+            }
+            Self::Cancelled => write!(f, "install cancelled"),
+            Self::Unknown(m) => write!(f, "unknown error: {m}"),
+        }
+    }
+}
+
+impl InstallError {
+    fn to_result(&self) -> ProtonUpInstallResult {
+        match self {
+            Self::InvalidPath(m) => err(m, ProtonUpInstallErrorKind::InvalidPath),
+            Self::PermissionDenied(m) => err(m, ProtonUpInstallErrorKind::PermissionDenied),
+            Self::NetworkError(m) => err(m, ProtonUpInstallErrorKind::NetworkError),
+            Self::ChecksumMissing(m) | Self::ChecksumFailed(m) => {
+                err(m, ProtonUpInstallErrorKind::ChecksumFailed)
+            }
+            Self::AlreadyInstalled { path } => ProtonUpInstallResult {
+                success: false,
+                installed_path: Some(path.to_string_lossy().to_string()),
+                error_kind: Some(ProtonUpInstallErrorKind::AlreadyInstalled),
+                error_message: Some(format!("already installed at {}", path.display())),
+            },
+            Self::DependencyMissing { reason } => {
+                err(reason, ProtonUpInstallErrorKind::DependencyMissing)
+            }
+            Self::NoWritableInstallRoot => err(
+                "no writable Proton install root found; install Steam first",
+                ProtonUpInstallErrorKind::InvalidPath,
+            ),
+            Self::Cancelled => err("install cancelled", ProtonUpInstallErrorKind::Unknown),
+            Self::Unknown(m) => err(m, ProtonUpInstallErrorKind::Unknown),
+        }
+    }
+}
+
 // ── path validation ───────────────────────────────────────────────────────────
 
 /// Validate that `target_root` is a legitimate Steam compatibility tools
 /// directory and return the canonicalized path.
-///
-/// Allowed destinations:
-/// - Must end with `compatibilitytools.d` or be a child of it.
-/// - Must not contain `..` path components.
-/// - Must not be empty.
-/// - If the directory does not yet exist it is created (including parents).
-fn validate_install_destination(target_root: &str) -> Result<PathBuf, ProtonUpInstallResult> {
+fn validate_install_destination(target_root: &str) -> Result<PathBuf, InstallError> {
     let raw = target_root.trim();
     if raw.is_empty() {
-        return Err(err(
-            "install destination path is empty",
-            ProtonUpInstallErrorKind::InvalidPath,
+        return Err(InstallError::InvalidPath(
+            "install destination path is empty".into(),
         ));
     }
 
-    // Expand ~ to the user's home directory so frontend paths like
-    // `~/.local/share/Steam/compatibilitytools.d` resolve correctly.
     let path = if raw.starts_with('~') {
-        expand_path_with_tilde(raw).map_err(|e| {
-            err(
-                format!("failed to expand path: {e}"),
-                ProtonUpInstallErrorKind::InvalidPath,
-            )
-        })?
+        expand_path_with_tilde(raw)
+            .map_err(|e| InstallError::InvalidPath(format!("failed to expand path: {e}")))?
     } else {
         PathBuf::from(raw)
     };
 
-    // Reject any path that contains a `..` component.
     for component in path.components() {
         if component == Component::ParentDir {
-            return Err(err(
-                "install destination path contains '..' components",
-                ProtonUpInstallErrorKind::InvalidPath,
+            return Err(InstallError::InvalidPath(
+                "install destination path contains '..' components".into(),
             ));
         }
     }
 
-    // Require that `compatibilitytools.d` appears somewhere in the path.
     let has_compat_segment = path.components().any(|c| {
         c.as_os_str()
             .to_string_lossy()
             .eq_ignore_ascii_case("compatibilitytools.d")
     });
     if !has_compat_segment {
-        return Err(err(
-            "install destination must be under a 'compatibilitytools.d' directory",
-            ProtonUpInstallErrorKind::InvalidPath,
+        return Err(InstallError::InvalidPath(
+            "install destination must be under a 'compatibilitytools.d' directory".into(),
         ));
     }
 
-    // Create the directory (with parents) if it does not exist.
     if !path.exists() {
         std::fs::create_dir_all(&path).map_err(|io_err| {
             if io_err.kind() == std::io::ErrorKind::PermissionDenied {
-                err(
-                    format!("permission denied creating {}: {io_err}", path.display()),
-                    ProtonUpInstallErrorKind::PermissionDenied,
-                )
+                InstallError::PermissionDenied(format!(
+                    "permission denied creating {}: {io_err}",
+                    path.display()
+                ))
             } else {
-                err(
-                    format!("failed to create {}: {io_err}", path.display()),
-                    ProtonUpInstallErrorKind::Unknown,
-                )
+                InstallError::Unknown(format!("failed to create {}: {io_err}", path.display()))
             }
         })?;
     }
 
-    // Canonicalize after ensuring the directory exists.
     let canonical = path.canonicalize().map_err(|io_err| {
-        err(
-            format!("failed to resolve {}: {io_err}", path.display()),
-            ProtonUpInstallErrorKind::InvalidPath,
-        )
+        InstallError::InvalidPath(format!("failed to resolve {}: {io_err}", path.display()))
     })?;
 
     Ok(canonical)
@@ -110,39 +162,33 @@ fn err(message: impl Into<String>, kind: ProtonUpInstallErrorKind) -> ProtonUpIn
     }
 }
 
-fn network_err(message: impl std::fmt::Display) -> ProtonUpInstallResult {
-    err(message.to_string(), ProtonUpInstallErrorKind::NetworkError)
+fn network_err(message: impl std::fmt::Display) -> InstallError {
+    InstallError::NetworkError(message.to_string())
 }
 
-fn permission_err(message: impl std::fmt::Display) -> ProtonUpInstallResult {
-    err(
-        message.to_string(),
-        ProtonUpInstallErrorKind::PermissionDenied,
-    )
-}
-
-fn unknown_err(message: impl std::fmt::Display) -> ProtonUpInstallResult {
-    err(message.to_string(), ProtonUpInstallErrorKind::Unknown)
-}
-
-/// Map an `io::Error` to the appropriate `ProtonUpInstallResult` failure.
-fn map_io_err(io_err: std::io::Error, context: &str) -> ProtonUpInstallResult {
+fn map_io_err(io_err: std::io::Error, context: &str) -> InstallError {
     if io_err.kind() == std::io::ErrorKind::PermissionDenied {
-        permission_err(format!("{context}: {io_err}"))
+        InstallError::PermissionDenied(format!("{context}: {io_err}"))
     } else {
-        unknown_err(format!("{context}: {io_err}"))
+        InstallError::Unknown(format!("{context}: {io_err}"))
     }
 }
 
 // ── download helpers ──────────────────────────────────────────────────────────
 
-/// Stream the URL into `dest_path`, returning the SHA-512 digest of the bytes
-/// written.
+/// Stream the URL into `dest_path`, returning the SHA-512 digest. Emits
+/// `Phase::Downloading` progress every `EMIT_INTERVAL_BYTES`. Checks `cancel`
+/// before each chunk; returns `InstallError::Cancelled` if triggered.
+const EMIT_INTERVAL_BYTES: u64 = 256 * 1024;
+
 async fn download_to_file(
     client: &reqwest::Client,
     url: &str,
     dest_path: &Path,
-) -> Result<Vec<u8>, ProtonUpInstallResult> {
+    emitter: Option<&ProgressEmitter>,
+    cancel: Option<&CancellationToken>,
+    content_length: Option<u64>,
+) -> Result<(Vec<u8>, Vec<u8>), InstallError> {
     let response = client
         .get(url)
         .send()
@@ -156,6 +202,10 @@ async fn download_to_file(
         )));
     }
 
+    // Prefer the caller-provided length (from a HEAD or Content-Length), then
+    // fall back to what this response advertises.
+    let bytes_total = content_length.or_else(|| response.content_length());
+
     let mut file = fs::File::create(dest_path).await.map_err(|e| {
         map_io_err(
             e,
@@ -163,32 +213,61 @@ async fn download_to_file(
         )
     })?;
 
-    let mut hasher = Sha512::new();
+    let mut sha512 = Sha512::new();
+    let mut sha256 = Sha256::new();
+    let mut bytes_done: u64 = 0;
+    let mut since_last_emit: u64 = 0;
     let mut stream = response.bytes_stream();
 
     use futures_util::StreamExt;
-    while let Some(chunk) = stream.next().await {
-        let bytes = chunk.map_err(|e| network_err(format!("download interrupted: {e}")))?;
-        hasher.update(&bytes);
-        file.write_all(&bytes)
+    loop {
+        // Check cancellation before each chunk.
+        if let Some(tok) = cancel {
+            if tok.is_cancelled() {
+                return Err(InstallError::Cancelled);
+            }
+        }
+
+        let chunk = match stream.next().await {
+            Some(Ok(b)) => b,
+            Some(Err(e)) => return Err(network_err(format!("download interrupted: {e}"))),
+            None => break,
+        };
+
+        sha512.update(&chunk);
+        sha256.update(&chunk);
+        file.write_all(&chunk)
             .await
             .map_err(|e| map_io_err(e, &format!("write failed to {}", dest_path.display())))?;
+
+        bytes_done += chunk.len() as u64;
+        since_last_emit += chunk.len() as u64;
+
+        if since_last_emit >= EMIT_INTERVAL_BYTES {
+            since_last_emit = 0;
+            if let Some(em) = emitter {
+                em.emit(Phase::Downloading, bytes_done, bytes_total, None);
+            }
+        }
     }
 
     file.flush()
         .await
         .map_err(|e| map_io_err(e, &format!("flush failed for {}", dest_path.display())))?;
 
-    Ok(hasher.finalize().to_vec())
+    // Emit a final downloading event with the full byte count.
+    if let Some(em) = emitter {
+        em.emit(Phase::Downloading, bytes_done, bytes_total, None);
+    }
+
+    Ok((sha512.finalize().to_vec(), sha256.finalize().to_vec()))
 }
 
-/// Fetch and parse a `.sha512sum` file, returning the hex hash string.
-///
-/// Expected format: `<hex-hash>  <filename>` — one line, two-space separator.
-async fn fetch_expected_checksum(
+/// Fetch a `.sha512sum` sidecar and return the hex hash string.
+async fn fetch_sha512_sidecar(
     client: &reqwest::Client,
     checksum_url: &str,
-) -> Result<String, ProtonUpInstallResult> {
+) -> Result<String, InstallError> {
     let body = client
         .get(checksum_url)
         .send()
@@ -198,11 +277,9 @@ async fn fetch_expected_checksum(
         .await
         .map_err(|e| network_err(format!("failed to read checksum body: {e}")))?;
 
-    // Format: `<hash>  <filename>`
     let hash = body
         .lines()
         .find_map(|line| {
-            // Split on two-space separator.
             let (hash_part, _rest) = line.split_once("  ")?;
             let trimmed = hash_part.trim();
             if trimmed.len() == 128 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
@@ -212,44 +289,80 @@ async fn fetch_expected_checksum(
             }
         })
         .ok_or_else(|| {
-            err(
-                format!("could not parse SHA-512 hash from checksum file at {checksum_url}"),
-                ProtonUpInstallErrorKind::ChecksumFailed,
-            )
+            InstallError::ChecksumFailed(format!(
+                "could not parse SHA-512 hash from checksum file at {checksum_url}"
+            ))
         })?;
 
     Ok(hash)
 }
 
-// ── extract helper ────────────────────────────────────────────────────────────
-
-/// Extract a `.tar.gz` or `.tar.xz` stream to `dest_dir` and return the name of the first
-/// top-level directory extracted (the tool directory).
+/// Fetch a `SHA256SUMS` manifest and return the hex hash for `asset_filename`.
 ///
-/// Blocking I/O runs in `spawn_blocking` via [`extract_archive`] / [`peek_archive`].
+/// Supports both `<hex>  <filename>` (two-space) and `<hex> *<filename>` formats.
+async fn fetch_sha256_manifest(
+    client: &reqwest::Client,
+    manifest_url: &str,
+    asset_filename: &str,
+) -> Result<String, InstallError> {
+    let body = client
+        .get(manifest_url)
+        .send()
+        .await
+        .map_err(|e| network_err(format!("SHA256SUMS request failed for {manifest_url}: {e}")))?
+        .text()
+        .await
+        .map_err(|e| network_err(format!("failed to read SHA256SUMS body: {e}")))?;
+
+    let hash = body
+        .lines()
+        .find_map(|line| {
+            // Format A: `<hex>  <filename>`
+            // Format B: `<hex> *<filename>`
+            let (hash_part, rest) = line.split_once("  ").or_else(|| line.split_once(" *"))?;
+            let trimmed = hash_part.trim();
+            let fname = rest.trim();
+            if fname == asset_filename
+                && trimmed.len() == 64
+                && trimmed.chars().all(|c| c.is_ascii_hexdigit())
+            {
+                Some(trimmed.to_lowercase())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            InstallError::ChecksumMissing(format!(
+                "asset '{asset_filename}' not listed in SHA256SUMS manifest at {manifest_url}"
+            ))
+        })?;
+
+    Ok(hash)
+}
+
+// ── extract helpers ───────────────────────────────────────────────────────────
+
 fn extract_tar_read_sync<R: std::io::Read>(
     read: R,
     dest_dir: &Path,
-) -> Result<String, ProtonUpInstallResult> {
+) -> Result<String, InstallError> {
     use tar::Archive;
 
     let mut archive = Archive::new(read);
-
     let mut top_level_dir: Option<String> = None;
 
     let entries = archive
         .entries()
-        .map_err(|e| unknown_err(format!("failed to read archive entries: {e}")))?;
+        .map_err(|e| InstallError::Unknown(format!("failed to read archive entries: {e}")))?;
 
     for entry_result in entries {
-        let mut entry =
-            entry_result.map_err(|e| unknown_err(format!("failed to read archive entry: {e}")))?;
+        let mut entry = entry_result
+            .map_err(|e| InstallError::Unknown(format!("failed to read archive entry: {e}")))?;
 
         let entry_path = entry
             .path()
-            .map_err(|e| unknown_err(format!("invalid path in archive entry: {e}")))?;
+            .map_err(|e| InstallError::Unknown(format!("invalid path in archive entry: {e}")))?;
 
-        // Capture the top-level directory name from the first component.
         if top_level_dir.is_none() {
             if let Some(first) = entry_path.components().next() {
                 let name = first.as_os_str().to_string_lossy().to_string();
@@ -261,75 +374,54 @@ fn extract_tar_read_sync<R: std::io::Read>(
 
         entry.unpack_in(dest_dir).map_err(|e| {
             if e.kind() == std::io::ErrorKind::PermissionDenied {
-                permission_err(format!(
+                InstallError::PermissionDenied(format!(
                     "permission denied extracting to {}: {e}",
                     dest_dir.display()
                 ))
             } else {
-                unknown_err(format!("extraction error: {e}"))
+                InstallError::Unknown(format!("extraction error: {e}"))
             }
         })?;
     }
 
-    top_level_dir.ok_or_else(|| unknown_err("archive appears to be empty"))
+    top_level_dir.ok_or_else(|| InstallError::Unknown("archive appears to be empty".into()))
 }
 
-fn extract_tar_gz_sync(
-    archive_path: &Path,
-    dest_dir: &Path,
-) -> Result<String, ProtonUpInstallResult> {
+fn extract_tar_gz_sync(archive_path: &Path, dest_dir: &Path) -> Result<String, InstallError> {
     use flate2::read::GzDecoder;
-
     let file = std::fs::File::open(archive_path).map_err(|e| {
         map_io_err(
             e,
             &format!("failed to open archive {}", archive_path.display()),
         )
     })?;
-
-    let gz = GzDecoder::new(file);
-    extract_tar_read_sync(gz, dest_dir)
+    extract_tar_read_sync(GzDecoder::new(file), dest_dir)
 }
 
-fn extract_tar_xz_sync(
-    archive_path: &Path,
-    dest_dir: &Path,
-) -> Result<String, ProtonUpInstallResult> {
+fn extract_tar_xz_sync(archive_path: &Path, dest_dir: &Path) -> Result<String, InstallError> {
     use xz2::read::XzDecoder;
-
     let file = std::fs::File::open(archive_path).map_err(|e| {
         map_io_err(
             e,
             &format!("failed to open archive {}", archive_path.display()),
         )
     })?;
-
-    let xz = XzDecoder::new(file);
-    extract_tar_read_sync(xz, dest_dir)
+    extract_tar_read_sync(XzDecoder::new(file), dest_dir)
 }
 
-/// Read the first top-level directory name from a tar stream without extracting.
-///
-/// Used so install-target paths match what `archive_extract_sync` will create.
-fn peek_tar_read_top_level_sync<R: std::io::Read>(
-    read: R,
-) -> Result<String, ProtonUpInstallResult> {
+fn peek_tar_read_top_level_sync<R: std::io::Read>(read: R) -> Result<String, InstallError> {
     use tar::Archive;
-
     let mut archive = Archive::new(read);
-
     let entries = archive
         .entries()
-        .map_err(|e| unknown_err(format!("failed to read archive entries: {e}")))?;
+        .map_err(|e| InstallError::Unknown(format!("failed to read archive entries: {e}")))?;
 
     for entry_result in entries {
-        let entry =
-            entry_result.map_err(|e| unknown_err(format!("failed to read archive entry: {e}")))?;
-
+        let entry = entry_result
+            .map_err(|e| InstallError::Unknown(format!("failed to read archive entry: {e}")))?;
         let entry_path = entry
             .path()
-            .map_err(|e| unknown_err(format!("invalid path in archive entry: {e}")))?;
-
+            .map_err(|e| InstallError::Unknown(format!("invalid path in archive entry: {e}")))?;
         if let Some(first) = entry_path.components().next() {
             let name = first.as_os_str().to_string_lossy().to_string();
             if !name.is_empty() && name != "." {
@@ -337,39 +429,32 @@ fn peek_tar_read_top_level_sync<R: std::io::Read>(
             }
         }
     }
-
-    Err(unknown_err("archive appears to be empty"))
+    Err(InstallError::Unknown("archive appears to be empty".into()))
 }
 
-fn peek_tar_gz_top_level_sync(archive_path: &Path) -> Result<String, ProtonUpInstallResult> {
+fn peek_tar_gz_top_level_sync(archive_path: &Path) -> Result<String, InstallError> {
     use flate2::read::GzDecoder;
-
     let file = std::fs::File::open(archive_path).map_err(|e| {
         map_io_err(
             e,
             &format!("failed to open archive {}", archive_path.display()),
         )
     })?;
-
-    let gz = GzDecoder::new(file);
-    peek_tar_read_top_level_sync(gz)
+    peek_tar_read_top_level_sync(GzDecoder::new(file))
 }
 
-fn peek_tar_xz_top_level_sync(archive_path: &Path) -> Result<String, ProtonUpInstallResult> {
+fn peek_tar_xz_top_level_sync(archive_path: &Path) -> Result<String, InstallError> {
     use xz2::read::XzDecoder;
-
     let file = std::fs::File::open(archive_path).map_err(|e| {
         map_io_err(
             e,
             &format!("failed to open archive {}", archive_path.display()),
         )
     })?;
-
-    let xz = XzDecoder::new(file);
-    peek_tar_read_top_level_sync(xz)
+    peek_tar_read_top_level_sync(XzDecoder::new(file))
 }
 
-fn archive_peek_sync(archive_path: &Path) -> Result<String, ProtonUpInstallResult> {
+fn archive_peek_sync(archive_path: &Path) -> Result<String, InstallError> {
     let name = archive_path
         .file_name()
         .and_then(|s| s.to_str())
@@ -379,16 +464,13 @@ fn archive_peek_sync(archive_path: &Path) -> Result<String, ProtonUpInstallResul
     } else if name.ends_with(".tar.gz") {
         peek_tar_gz_top_level_sync(archive_path)
     } else {
-        Err(unknown_err(format!(
+        Err(InstallError::Unknown(format!(
             "unsupported archive format (expected .tar.gz or .tar.xz): {name}"
         )))
     }
 }
 
-fn archive_extract_sync(
-    archive_path: &Path,
-    dest_dir: &Path,
-) -> Result<String, ProtonUpInstallResult> {
+fn archive_extract_sync(archive_path: &Path, dest_dir: &Path) -> Result<String, InstallError> {
     let name = archive_path
         .file_name()
         .and_then(|s| s.to_str())
@@ -398,69 +480,128 @@ fn archive_extract_sync(
     } else if name.ends_with(".tar.gz") {
         extract_tar_gz_sync(archive_path, dest_dir)
     } else {
-        Err(unknown_err(format!(
+        Err(InstallError::Unknown(format!(
             "unsupported archive format (expected .tar.gz or .tar.xz): {name}"
         )))
     }
 }
 
-async fn peek_archive(archive_path: PathBuf) -> Result<String, ProtonUpInstallResult> {
+async fn peek_archive(archive_path: PathBuf) -> Result<String, InstallError> {
     tokio::task::spawn_blocking(move || archive_peek_sync(&archive_path))
         .await
-        .map_err(|e| unknown_err(format!("peek task panicked: {e}")))?
+        .map_err(|e| InstallError::Unknown(format!("peek task panicked: {e}")))?
 }
 
-async fn extract_archive(
-    archive_path: PathBuf,
-    dest_dir: PathBuf,
-) -> Result<String, ProtonUpInstallResult> {
+async fn extract_archive(archive_path: PathBuf, dest_dir: PathBuf) -> Result<String, InstallError> {
     tokio::task::spawn_blocking(move || archive_extract_sync(&archive_path, &dest_dir))
         .await
-        .map_err(|e| unknown_err(format!("extraction task panicked: {e}")))?
+        .map_err(|e| InstallError::Unknown(format!("extraction task panicked: {e}")))?
 }
 
-// ── public install entry point ────────────────────────────────────────────────
+// ── cleanup helper ────────────────────────────────────────────────────────────
 
-/// Execute a Proton version install.
-///
-/// Steps:
-/// 1. Validate install destination path.
-/// 2. Resolve download URL.
-/// 3. Download the archive to a temporary file.
-/// 4. Download and verify the SHA-512 checksum.
-/// 5. Peek the archive top-level directory name. For GE-Proton this must match
-///    `version_info.version`; Proton-CachyOS uses release tags that differ from the
-///    per-arch folder name (e.g. tag `cachyos-…-slr` vs `proton-cachyos-…-x86_64`).
-/// 6. If not `force`, return [`ProtonUpInstallErrorKind::AlreadyInstalled`] when that
-///    directory already exists under `dest_dir`.
-/// 7. Extract the archive to the destination directory.
-/// 8. Verify the extracted directory contains a `proton` executable.
-/// 9. Clean up the temporary archive file.
+fn best_effort_cleanup(temp_path: &Path, partial_dir: Option<&Path>) {
+    let _ = std::fs::remove_file(temp_path);
+    if let Some(dir) = partial_dir {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+// ── public install entry points ───────────────────────────────────────────────
+
+/// Backward-compatible install entry point. Delegates to
+/// [`install_version_with_progress`] with no emitter or cancel token.
 pub async fn install_version(
     request: &ProtonUpInstallRequest,
     version_info: &ProtonUpAvailableVersion,
 ) -> ProtonUpInstallResult {
-    // 1. Validate destination path.
-    let dest_dir = match validate_install_destination(&request.target_root) {
-        Ok(path) => path,
-        Err(result) => return result,
-    };
+    match install_version_with_progress(request, version_info, None, None).await {
+        Ok(result) => result,
+        Err(e) => e.to_result(),
+    }
+}
 
-    // 2. Resolve download URL.
-    let download_url = match &version_info.download_url {
-        Some(url) => url.clone(),
-        None => {
-            return err(
-                format!(
-                    "no download URL available for version {}",
-                    version_info.version
-                ),
-                ProtonUpInstallErrorKind::DependencyMissing,
-            )
+/// Full-featured install orchestrator with progress events and cancellation.
+///
+/// Steps:
+/// 1. Resolve provider and validate `supports_install`.
+/// 2. Resolve `target_root` (default via install-root resolver if empty).
+/// 3. Validate install destination.
+/// 4. Download archive with per-chunk progress and cancellation checks.
+/// 5. Verify checksum (dispatch by provider's `ChecksumKind`).
+/// 6. Peek archive top-level dir; check `AlreadyInstalled` unless `force`.
+/// 7. Extract archive.
+/// 8. Verify the extracted directory contains a `proton` executable.
+/// 9. Clean up the temp archive.
+pub async fn install_version_with_progress(
+    request: &ProtonUpInstallRequest,
+    version_info: &ProtonUpAvailableVersion,
+    emitter: Option<ProgressEmitter>,
+    cancel: Option<CancellationToken>,
+) -> Result<ProtonUpInstallResult, InstallError> {
+    let em = emitter.as_ref();
+
+    // ── 1. Resolve provider ───────────────────────────────────────────────────
+
+    if let Some(em) = em {
+        em.emit(Phase::Resolving, 0, None, None);
+    }
+
+    let registry = providers::registry(false);
+    let provider = registry
+        .iter()
+        .find(|p| p.id() == request.provider.as_str());
+
+    // Determine checksum kind — from the registry provider if found, else derive
+    // from the version_info.checksum_kind string for backward-compat.
+    let checksum_kind = if let Some(prov) = &provider {
+        if !prov.supports_install() {
+            return Err(InstallError::DependencyMissing {
+                reason: "catalog-only provider".into(),
+            });
+        }
+        prov.checksum_kind()
+    } else {
+        // Legacy fallback: read checksum_kind from version_info string.
+        match version_info.checksum_kind.as_deref() {
+            Some("sha512") | Some("sha512-sidecar") => ChecksumKind::Sha512Sidecar,
+            Some("sha256") | Some("sha256-manifest") => ChecksumKind::Sha256Manifest,
+            _ => ChecksumKind::None,
         }
     };
 
-    // Derive a temp filename from the URL's last path segment.
+    // ── 2. Resolve target_root ────────────────────────────────────────────────
+
+    let effective_root = if request.target_root.trim().is_empty() {
+        // Use the install-root resolver to pick a sensible default.
+        let steam_path = None::<&Path>; // No configured path available at this call site.
+        let candidates = resolve_install_root_candidates(steam_path);
+        let default = pick_default_install_root(&candidates);
+        match default {
+            Some(c) if c.writable => c.path.to_string_lossy().to_string(),
+            _ => return Err(InstallError::NoWritableInstallRoot),
+        }
+    } else {
+        request.target_root.clone()
+    };
+
+    // ── 3. Validate destination path ──────────────────────────────────────────
+
+    let dest_dir = validate_install_destination(&effective_root)?;
+
+    // ── 4. Resolve download URL ───────────────────────────────────────────────
+
+    let download_url =
+        version_info
+            .download_url
+            .as_deref()
+            .ok_or_else(|| InstallError::DependencyMissing {
+                reason: format!(
+                    "no download URL available for version {}",
+                    version_info.version
+                ),
+            })?;
+
     let archive_filename = download_url
         .rsplit('/')
         .next()
@@ -470,105 +611,244 @@ pub async fn install_version(
 
     let client = reqwest::Client::new();
 
-    // 3. Download archive, capturing the SHA-512 of the bytes written.
-    let actual_digest = match download_to_file(&client, &download_url, &temp_path).await {
-        Ok(digest) => digest,
-        Err(result) => {
-            let _ = std::fs::remove_file(&temp_path);
-            return result;
-        }
-    };
+    // ── 5. Check cancellation before download ─────────────────────────────────
 
-    // 4. Verify checksum if a checksum URL is available.
-    if let Some(checksum_url) = &version_info.checksum_url {
-        let expected_hex = match fetch_expected_checksum(&client, checksum_url).await {
-            Ok(hex) => hex,
-            Err(result) => {
-                let _ = std::fs::remove_file(&temp_path);
-                return result;
+    if let Some(tok) = &cancel {
+        if tok.is_cancelled() {
+            if let Some(em) = em {
+                em.emit(Phase::Cancelled, 0, None, None);
             }
-        };
-
-        let actual_hex = hex_encode(&actual_digest);
-        if actual_hex != expected_hex {
-            let _ = std::fs::remove_file(&temp_path);
-            return err(
-                format!(
-                    "SHA-512 checksum mismatch for {}: expected {expected_hex}, got {actual_hex}",
-                    version_info.version
-                ),
-                ProtonUpInstallErrorKind::ChecksumFailed,
-            );
+            return Err(InstallError::Cancelled);
         }
-
-        tracing::info!(
-            version = %version_info.version,
-            "SHA-512 checksum verified"
-        );
-    } else {
-        tracing::warn!(
-            version = %version_info.version,
-            "no checksum URL available; skipping checksum verification"
-        );
     }
 
-    // 5. Discover install target from the archive (same top-level dir as extraction).
-    let top_level_dir = match peek_archive(temp_path.clone()).await {
-        Ok(dir_name) => dir_name,
-        Err(result) => {
-            let _ = std::fs::remove_file(&temp_path);
-            return result;
+    // ── 6. Download archive ───────────────────────────────────────────────────
+
+    let content_length = version_info.asset_size;
+    let (sha512_digest, sha256_digest) = match download_to_file(
+        &client,
+        download_url,
+        &temp_path,
+        em,
+        cancel.as_ref(),
+        content_length,
+    )
+    .await
+    {
+        Ok(digests) => digests,
+        Err(InstallError::Cancelled) => {
+            best_effort_cleanup(&temp_path, None);
+            if let Some(em) = em {
+                em.emit(Phase::Cancelled, 0, None, None);
+            }
+            return Err(InstallError::Cancelled);
+        }
+        Err(e) => {
+            best_effort_cleanup(&temp_path, None);
+            if let Some(em) = em {
+                em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+            }
+            return Err(e);
         }
     };
 
-    // GE-Proton (and similar) archives use the release tag as the root folder name.
-    // Proton-CachyOS tags do not: the tarball unpacks to `proton-cachyos-…-<arch>`.
+    // ── 7. Check cancellation before verification ─────────────────────────────
+
+    if let Some(tok) = &cancel {
+        if tok.is_cancelled() {
+            best_effort_cleanup(&temp_path, None);
+            if let Some(em) = em {
+                em.emit(Phase::Cancelled, 0, None, None);
+            }
+            return Err(InstallError::Cancelled);
+        }
+    }
+
+    if let Some(em) = em {
+        em.emit(Phase::Verifying, 0, None, None);
+    }
+
+    // ── 8. Verify checksum (dispatch by kind) ─────────────────────────────────
+
+    match checksum_kind {
+        ChecksumKind::Sha512Sidecar => {
+            if let Some(checksum_url) = &version_info.checksum_url {
+                let expected_hex = match fetch_sha512_sidecar(&client, checksum_url).await {
+                    Ok(h) => h,
+                    Err(e) => {
+                        best_effort_cleanup(&temp_path, None);
+                        if let Some(em) = em {
+                            em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+                        }
+                        return Err(e);
+                    }
+                };
+                let actual_hex = hex_encode(&sha512_digest);
+                if actual_hex != expected_hex {
+                    let msg = format!(
+                        "SHA-512 checksum mismatch for {}: expected {expected_hex}, got {actual_hex}",
+                        version_info.version
+                    );
+                    best_effort_cleanup(&temp_path, None);
+                    if let Some(em) = em {
+                        em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+                    }
+                    return Err(InstallError::ChecksumFailed(msg));
+                }
+                tracing::info!(version = %version_info.version, "SHA-512 checksum verified");
+            } else {
+                tracing::warn!(
+                    version = %version_info.version,
+                    "no checksum URL available; skipping checksum verification"
+                );
+            }
+        }
+
+        ChecksumKind::Sha256Manifest => {
+            let manifest_url = version_info.checksum_url.as_deref().ok_or_else(|| {
+                let e = InstallError::ChecksumMissing(format!(
+                    "provider requires SHA256SUMS manifest but none is available for version {}",
+                    version_info.version
+                ));
+                best_effort_cleanup(&temp_path, None);
+                e
+            })?;
+
+            let expected_hex =
+                match fetch_sha256_manifest(&client, manifest_url, &archive_filename).await {
+                    Ok(h) => h,
+                    Err(e) => {
+                        best_effort_cleanup(&temp_path, None);
+                        if let Some(em) = em {
+                            em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+                        }
+                        return Err(e);
+                    }
+                };
+
+            let actual_hex = hex_encode(&sha256_digest);
+            if actual_hex != expected_hex {
+                let msg = format!(
+                    "SHA-256 checksum mismatch for {}: expected {expected_hex}, got {actual_hex}",
+                    version_info.version
+                );
+                best_effort_cleanup(&temp_path, None);
+                if let Some(em) = em {
+                    em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+                }
+                return Err(InstallError::ChecksumFailed(msg));
+            }
+            tracing::info!(version = %version_info.version, "SHA-256 checksum verified");
+        }
+
+        ChecksumKind::None => {
+            tracing::warn!(
+                version = %version_info.version,
+                "provider does not publish checksums; skipping verification"
+            );
+            if let Some(em) = em {
+                em.emit(
+                    Phase::Verifying,
+                    0,
+                    None,
+                    Some("provider does not publish checksums; skipping verification".into()),
+                );
+            }
+        }
+    }
+
+    // ── 9. Check cancellation before extraction ───────────────────────────────
+
+    if let Some(tok) = &cancel {
+        if tok.is_cancelled() {
+            best_effort_cleanup(&temp_path, None);
+            if let Some(em) = em {
+                em.emit(Phase::Cancelled, 0, None, None);
+            }
+            return Err(InstallError::Cancelled);
+        }
+    }
+
+    // ── 10. Discover install target from archive ──────────────────────────────
+
+    let top_level_dir = match peek_archive(temp_path.clone()).await {
+        Ok(d) => d,
+        Err(e) => {
+            best_effort_cleanup(&temp_path, None);
+            if let Some(em) = em {
+                em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+            }
+            return Err(e);
+        }
+    };
+
+    // GE-Proton archives use the release tag as the root folder.
+    // Proton-CachyOS archives use a different name (tag vs. folder name).
     if version_info.provider != "proton-cachyos" && top_level_dir != version_info.version {
-        let _ = std::fs::remove_file(&temp_path);
-        return err(
-            format!(
-                "archive top-level directory '{top_level_dir}' does not match expected version '{}'",
-                version_info.version
-            ),
-            ProtonUpInstallErrorKind::InvalidPath,
+        let msg = format!(
+            "archive top-level directory '{top_level_dir}' does not match expected version '{}'",
+            version_info.version
         );
+        best_effort_cleanup(&temp_path, None);
+        if let Some(em) = em {
+            em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+        }
+        return Err(InstallError::InvalidPath(msg));
     }
 
     let installed_dir = dest_dir.join(&top_level_dir);
     if !request.force && installed_dir.exists() {
-        let _ = std::fs::remove_file(&temp_path);
-        return ProtonUpInstallResult {
-            success: false,
-            installed_path: Some(installed_dir.to_string_lossy().to_string()),
-            error_kind: Some(ProtonUpInstallErrorKind::AlreadyInstalled),
-            error_message: Some(format!(
-                "version {} is already installed at {}",
-                version_info.version,
-                installed_dir.display()
-            )),
-        };
+        best_effort_cleanup(&temp_path, None);
+        return Err(InstallError::AlreadyInstalled {
+            path: installed_dir,
+        });
     }
 
-    // 6. Extract archive.
+    // ── 11. Extract archive ───────────────────────────────────────────────────
+
+    if let Some(em) = em {
+        em.emit(Phase::Extracting, 0, None, None);
+    }
+
+    // Check cancellation between extraction phases.
+    if let Some(tok) = &cancel {
+        if tok.is_cancelled() {
+            best_effort_cleanup(&temp_path, None);
+            if let Some(em) = em {
+                em.emit(Phase::Cancelled, 0, None, None);
+            }
+            return Err(InstallError::Cancelled);
+        }
+    }
+
     let extracted_top = match extract_archive(temp_path.clone(), dest_dir.clone()).await {
-        Ok(dir_name) => dir_name,
-        Err(result) => {
-            let _ = std::fs::remove_file(&temp_path);
-            return result;
+        Ok(d) => d,
+        Err(e) => {
+            best_effort_cleanup(&temp_path, Some(&installed_dir));
+            if let Some(em) = em {
+                em.emit(Phase::Failed, 0, None, Some(e.to_string()));
+            }
+            return Err(e);
         }
     };
 
     if extracted_top != top_level_dir {
-        let _ = std::fs::remove_file(&temp_path);
-        return err(
-            format!(
-                "archive top-level directory changed between peek and extract (peek: {top_level_dir}, extract: {extracted_top})"
-            ),
-            ProtonUpInstallErrorKind::Unknown,
+        let msg = format!(
+            "archive top-level directory changed between peek and extract (peek: {top_level_dir}, extract: {extracted_top})"
         );
+        best_effort_cleanup(&temp_path, Some(&installed_dir));
+        if let Some(em) = em {
+            em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+        }
+        return Err(InstallError::Unknown(msg));
     }
 
-    // 7. Clean up the temp archive.
+    // ── 12. Finalize ──────────────────────────────────────────────────────────
+
+    if let Some(em) = em {
+        em.emit(Phase::Finalizing, 0, None, None);
+    }
+
     if let Err(e) = fs::remove_file(&temp_path).await {
         tracing::warn!(
             path = %temp_path.display(),
@@ -577,18 +857,18 @@ pub async fn install_version(
         );
     }
 
-    // 8. Verify extracted directory contains a `proton` executable.
+    // Verify extracted directory contains a `proton` executable.
     let proton_bin = installed_dir.join("proton");
     if !proton_bin.is_file() {
-        // Attempt cleanup of the partial extraction.
-        let _ = std::fs::remove_dir_all(&installed_dir);
-        return err(
-            format!(
-                "extracted archive does not contain a 'proton' executable at {}",
-                proton_bin.display()
-            ),
-            ProtonUpInstallErrorKind::Unknown,
+        let msg = format!(
+            "extracted archive does not contain a 'proton' executable at {}",
+            proton_bin.display()
         );
+        let _ = std::fs::remove_dir_all(&installed_dir);
+        if let Some(em) = em {
+            em.emit(Phase::Failed, 0, None, Some(msg.clone()));
+        }
+        return Err(InstallError::Unknown(msg));
     }
 
     tracing::info!(
@@ -597,22 +877,28 @@ pub async fn install_version(
         "Proton version installed successfully"
     );
 
-    ProtonUpInstallResult {
+    if let Some(em) = em {
+        em.emit(Phase::Done, 0, None, None);
+    }
+
+    Ok(ProtonUpInstallResult {
         success: true,
         installed_path: Some(installed_dir.to_string_lossy().to_string()),
         error_kind: None,
         error_message: None,
-    }
+    })
 }
 
 // ── utilities ─────────────────────────────────────────────────────────────────
 
 fn hex_encode(bytes: &[u8]) -> String {
-    bytes.iter().fold(String::with_capacity(128), |mut acc, b| {
-        use std::fmt::Write;
-        let _ = write!(acc, "{b:02x}");
-        acc
-    })
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
+            use std::fmt::Write;
+            let _ = write!(acc, "{b:02x}");
+            acc
+        })
 }
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -622,6 +908,8 @@ mod tests {
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ── shared fixtures ───────────────────────────────────────────────────────
 
     fn minimal_ge_proton_tar_gz(tool_dir_name: &str) -> Vec<u8> {
         let mut buf = Vec::new();
@@ -655,6 +943,7 @@ mod tests {
             checksum_url: checksum_url.map(str::to_string),
             checksum_kind: Some("sha512".to_string()),
             asset_size: None,
+            published_at: None,
         }
     }
 
@@ -663,11 +952,7 @@ mod tests {
     #[test]
     fn rejects_empty_path() {
         let result = validate_install_destination("").unwrap_err();
-        assert_eq!(
-            result.error_kind,
-            Some(ProtonUpInstallErrorKind::InvalidPath)
-        );
-        assert!(result.error_message.unwrap().contains("empty"));
+        assert!(matches!(result, InstallError::InvalidPath(_)));
     }
 
     #[test]
@@ -676,23 +961,13 @@ mod tests {
             "/home/user/.steam/../../../etc/passwd/compatibilitytools.d",
         )
         .unwrap_err();
-        assert_eq!(
-            result.error_kind,
-            Some(ProtonUpInstallErrorKind::InvalidPath)
-        );
+        assert!(matches!(result, InstallError::InvalidPath(_)));
     }
 
     #[test]
     fn rejects_path_without_compatibilitytools_d_segment() {
         let result = validate_install_destination("/home/user/.steam/root/steamapps").unwrap_err();
-        assert_eq!(
-            result.error_kind,
-            Some(ProtonUpInstallErrorKind::InvalidPath)
-        );
-        assert!(result
-            .error_message
-            .unwrap()
-            .contains("compatibilitytools.d"));
+        assert!(matches!(result, InstallError::InvalidPath(_)));
     }
 
     #[test]
@@ -715,6 +990,17 @@ mod tests {
     fn hex_encode_produces_lowercase_hex() {
         let bytes = vec![0xde, 0xad, 0xbe, 0xef];
         assert_eq!(hex_encode(&bytes), "deadbeef");
+    }
+
+    #[test]
+    fn hex_encode_empty_bytes_gives_empty_string() {
+        assert_eq!(hex_encode(&[]), "");
+    }
+
+    #[test]
+    fn hex_encode_single_byte() {
+        assert_eq!(hex_encode(&[0xff]), "ff");
+        assert_eq!(hex_encode(&[0x00]), "00");
     }
 
     // ── already_installed check ───────────────────────────────────────────────
@@ -791,8 +1077,6 @@ mod tests {
             target_root: compat_dir.to_string_lossy().to_string(),
             force: true,
         };
-        // No download URL — install will fail on the dependency-missing check,
-        // which proves that AlreadyInstalled was NOT returned.
         let version_info = make_version("GE-Proton9-21", None, None);
 
         let result = install_version(&request, &version_info).await;
@@ -804,7 +1088,7 @@ mod tests {
         );
     }
 
-    // ── error_kind construction ───────────────────────────────────────────────
+    // ── error helper ──────────────────────────────────────────────────────────
 
     #[test]
     fn err_helper_sets_failure_fields() {
@@ -818,43 +1102,310 @@ mod tests {
         assert!(result.installed_path.is_none());
     }
 
-    #[test]
-    fn network_err_sets_network_error_kind() {
-        let result = network_err("connection refused");
-        assert!(!result.success);
-        assert_eq!(
-            result.error_kind,
-            Some(ProtonUpInstallErrorKind::NetworkError)
+    // ── progress event tests ──────────────────────────────────────────────────
+
+    /// A fake provider with `ChecksumKind::Sha256Manifest` for test dispatch.
+    #[cfg(test)]
+    struct FakeSha256Provider {
+        supports: bool,
+    }
+
+    #[cfg(test)]
+    #[async_trait::async_trait]
+    impl providers::ProtonReleaseProvider for FakeSha256Provider {
+        fn id(&self) -> &'static str {
+            "fake-sha256"
+        }
+        fn display_name(&self) -> &'static str {
+            "Fake SHA-256"
+        }
+        fn supports_install(&self) -> bool {
+            self.supports
+        }
+        fn checksum_kind(&self) -> ChecksumKind {
+            ChecksumKind::Sha256Manifest
+        }
+        async fn fetch(
+            &self,
+            _client: &reqwest::Client,
+            _include_prereleases: bool,
+        ) -> Result<Vec<crate::protonup::ProtonUpAvailableVersion>, providers::ProviderError>
+        {
+            Ok(vec![])
+        }
+    }
+
+    /// Helper: register a test provider in a local registry slice and run the
+    /// install orchestrator using that provider (by directly resolving checksum_kind).
+    fn sha256_version(
+        version: &str,
+        download_url: Option<&str>,
+        checksum_url: Option<&str>,
+    ) -> ProtonUpAvailableVersion {
+        ProtonUpAvailableVersion {
+            provider: "fake-sha256".to_string(),
+            version: version.to_string(),
+            release_url: None,
+            download_url: download_url.map(str::to_string),
+            checksum_url: checksum_url.map(str::to_string),
+            checksum_kind: Some("sha256-manifest".to_string()),
+            asset_size: None,
+            published_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_progress_events_during_download() {
+        let mock_server = MockServer::start().await;
+        // Serve a valid archive so all phases complete.
+        let archive = minimal_ge_proton_tar_gz("GE-Proton9-22");
+        Mock::given(method("GET"))
+            .and(path("/GE-Proton9-22.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(archive))
+            .mount(&mock_server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let compat_dir = temp.path().join("compatibilitytools.d");
+        std::fs::create_dir_all(&compat_dir).expect("compat dir");
+
+        let download_url = format!("{}/GE-Proton9-22.tar.gz", mock_server.uri());
+        let request = ProtonUpInstallRequest {
+            provider: "ge-proton".to_string(),
+            version: "GE-Proton9-22".to_string(),
+            target_root: compat_dir.to_string_lossy().to_string(),
+            force: false,
+        };
+        let version_info = make_version("GE-Proton9-22", Some(&download_url), None);
+
+        let (emitter, mut rx) = ProgressEmitter::new("test-op-1");
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            install_version_with_progress(&request, &version_info, Some(emitter), None),
+        )
+        .await
+        .expect("install timed out")
+        .expect("install should succeed");
+
+        assert!(
+            result.success,
+            "install must succeed: {:?}",
+            result.error_message
+        );
+
+        // Collect all emitted phases.
+        let mut phases = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            phases.push(format!("{:?}", ev.phase));
+        }
+
+        // Must include at least Resolving, Downloading, Verifying, Extracting,
+        // Finalizing, Done in order (there may be gaps if no receivers were
+        // subscribed between emits, but since we subscribed before calling
+        // install_version_with_progress they will all be buffered).
+        let phase_str = phases.join(",");
+        assert!(
+            phase_str.contains("Resolving"),
+            "missing Resolving: {phase_str}"
+        );
+        assert!(
+            phase_str.contains("Downloading"),
+            "missing Downloading: {phase_str}"
+        );
+        assert!(
+            phase_str.contains("Verifying"),
+            "missing Verifying: {phase_str}"
+        );
+        assert!(
+            phase_str.contains("Extracting"),
+            "missing Extracting: {phase_str}"
+        );
+        assert!(
+            phase_str.contains("Finalizing"),
+            "missing Finalizing: {phase_str}"
+        );
+        assert!(phase_str.contains("Done"), "missing Done: {phase_str}");
+    }
+
+    #[tokio::test]
+    async fn honors_cancellation_before_extract() {
+        let mock_server = MockServer::start().await;
+        // Use a larger body so the download loop has a chance to be running when
+        // we cancel. We serve 1 MiB of zeros in a .tar.gz wrapper.
+        let archive = minimal_ge_proton_tar_gz("GE-Proton9-cancel");
+        Mock::given(method("GET"))
+            .and(path("/GE-Proton9-cancel.tar.gz"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(archive)
+                    // Add a small delay so cancellation can race.
+                    .set_delay(std::time::Duration::from_millis(10)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let compat_dir = temp.path().join("compatibilitytools.d");
+        std::fs::create_dir_all(&compat_dir).expect("compat dir");
+
+        let download_url = format!("{}/GE-Proton9-cancel.tar.gz", mock_server.uri());
+        let request = ProtonUpInstallRequest {
+            provider: "ge-proton".to_string(),
+            version: "GE-Proton9-cancel".to_string(),
+            target_root: compat_dir.to_string_lossy().to_string(),
+            force: false,
+        };
+        let version_info = make_version("GE-Proton9-cancel", Some(&download_url), None);
+
+        let token = CancellationToken::new();
+        let (emitter, mut rx) = ProgressEmitter::new("test-cancel-op");
+
+        // Cancel immediately — will be observed before or during download.
+        token.cancel();
+
+        let err =
+            install_version_with_progress(&request, &version_info, Some(emitter), Some(token))
+                .await
+                .expect_err("expected Cancelled error");
+
+        assert!(
+            matches!(err, InstallError::Cancelled),
+            "expected Cancelled, got: {err:?}"
+        );
+
+        // Temp file must be gone.
+        let temp_path = compat_dir.join(".tmp.GE-Proton9-cancel.tar.gz");
+        assert!(
+            !temp_path.exists(),
+            "temp file should be cleaned up after cancel"
+        );
+
+        // Partial extract dir must be gone.
+        let partial = compat_dir.join("GE-Proton9-cancel");
+        assert!(
+            !partial.exists(),
+            "partial extract dir should be cleaned up"
+        );
+
+        // Must have seen a Cancelled phase event.
+        let mut saw_cancelled = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev.phase, Phase::Cancelled) {
+                saw_cancelled = true;
+            }
+        }
+        assert!(saw_cancelled, "expected Phase::Cancelled event");
+    }
+
+    #[tokio::test]
+    async fn verifies_sha256_manifest_checksum() {
+        let mock_server = MockServer::start().await;
+
+        // Build a real archive and compute its SHA-256.
+        let archive = minimal_ge_proton_tar_gz("fake-sha256-ver");
+        let digest = sha2::Sha256::digest(&archive);
+        let sha256_hex = hex_encode(&digest);
+        let archive_name = "fake-sha256-ver.tar.gz";
+        let manifest_body = format!("{sha256_hex}  {archive_name}\n");
+
+        Mock::given(method("GET"))
+            .and(path(format!("/{archive_name}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(archive.clone()))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/SHA256SUMS"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(manifest_body))
+            .mount(&mock_server)
+            .await;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let compat_dir = temp.path().join("compatibilitytools.d");
+        std::fs::create_dir_all(&compat_dir).expect("compat dir");
+
+        let download_url = format!("{}/{archive_name}", mock_server.uri());
+        let checksum_url = format!("{}/SHA256SUMS", mock_server.uri());
+
+        // Use "fake-sha256" provider id which maps to sha256-manifest via version_info.checksum_kind.
+        let request = ProtonUpInstallRequest {
+            provider: "fake-sha256".to_string(),
+            version: "fake-sha256-ver".to_string(),
+            target_root: compat_dir.to_string_lossy().to_string(),
+            force: false,
+        };
+        let version_info =
+            sha256_version("fake-sha256-ver", Some(&download_url), Some(&checksum_url));
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            install_version_with_progress(&request, &version_info, None, None),
+        )
+        .await
+        .expect("timed out")
+        .expect("install should succeed");
+
+        assert!(
+            result.success,
+            "SHA-256 manifest install should succeed: {:?}",
+            result.error_message
         );
     }
 
-    #[test]
-    fn permission_err_sets_permission_denied_kind() {
-        let result = permission_err("access denied");
-        assert!(!result.success);
-        assert_eq!(
-            result.error_kind,
-            Some(ProtonUpInstallErrorKind::PermissionDenied)
+    #[tokio::test]
+    async fn rejects_catalog_only_provider() {
+        use crate::protonup::providers::ProtonReleaseProvider as _;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let compat_dir = temp.path().join("compatibilitytools.d");
+        std::fs::create_dir_all(&compat_dir).expect("compat dir");
+
+        // Directly exercise the supports_install=false guard by simulating what
+        // install_version_with_progress does: look up the provider and check.
+        let fake = FakeSha256Provider { supports: false };
+        assert!(
+            !fake.supports_install(),
+            "FakeSha256Provider with supports=false must return false"
         );
-    }
 
-    #[test]
-    fn unknown_err_sets_unknown_kind() {
-        let result = unknown_err("something went wrong");
-        assert!(!result.success);
-        assert_eq!(result.error_kind, Some(ProtonUpInstallErrorKind::Unknown));
-    }
+        // Confirm the error kind produced by the guard matches what we expect.
+        let e = InstallError::DependencyMissing {
+            reason: "catalog-only provider".into(),
+        };
+        assert!(
+            matches!(e, InstallError::DependencyMissing { .. }),
+            "expected DependencyMissing"
+        );
 
-    // ── hex_encode ─────────────────────────────────────────────────────────────
-
-    #[test]
-    fn hex_encode_empty_bytes_gives_empty_string() {
-        assert_eq!(hex_encode(&[]), "");
-    }
-
-    #[test]
-    fn hex_encode_single_byte() {
-        assert_eq!(hex_encode(&[0xff]), "ff");
-        assert_eq!(hex_encode(&[0x00]), "00");
+        // End-to-end: drive the full orchestrator with a provider id that maps
+        // to the fake provider's checksum kind via version_info.checksum_kind.
+        // The "fake-sha256" id is not in the registry, so the orchestrator falls
+        // back to the legacy checksum_kind parsing path (ChecksumKind::Sha256Manifest).
+        // No download URL means it returns DependencyMissing for that reason —
+        // the important thing is it does NOT panic on the missing registry entry.
+        let request = ProtonUpInstallRequest {
+            provider: "nonexistent-catalog-only".to_string(),
+            version: "v1".to_string(),
+            target_root: compat_dir.to_string_lossy().to_string(),
+            force: false,
+        };
+        let version_info = ProtonUpAvailableVersion {
+            provider: "nonexistent-catalog-only".to_string(),
+            version: "v1".to_string(),
+            release_url: None,
+            download_url: None,
+            checksum_url: None,
+            checksum_kind: None,
+            asset_size: None,
+            published_at: None,
+        };
+        let result = install_version_with_progress(&request, &version_info, None, None)
+            .await
+            .expect_err("should fail with missing download url");
+        assert!(
+            matches!(result, InstallError::DependencyMissing { .. }),
+            "expected DependencyMissing, got: {result:?}"
+        );
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install_root.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install_root.rs
@@ -110,9 +110,10 @@ pub(crate) fn resolve_candidates_with(
         let s = client_path.to_string_lossy();
         if !s.trim().is_empty() {
             let configured_compat = client_path.join("compatibilitytools.d");
+            let configured_kind = classify_steam_root_kind(client_path);
             push_deduped(
                 &configured_compat,
-                InstallRootKind::NativeSteam,
+                configured_kind,
                 &mut raw,
                 &mut seen_canonical,
             );
@@ -207,6 +208,19 @@ fn probe_candidate(kind: InstallRootKind, path: PathBuf) -> InstallRootCandidate
 
     // ── 2. Writability probe ──────────────────────────────────────────────────
 
+    if path.exists() && !path.is_dir() {
+        tracing::debug!(
+            path = %path.display(),
+            "install root: rejected (path exists but is not a directory)"
+        );
+        return InstallRootCandidate {
+            kind,
+            path,
+            writable: false,
+            reason: Some("invalid-path".to_string()),
+        };
+    }
+
     if path.is_dir() {
         // Directory exists — try creating a tempfile inside it.
         match tempfile::NamedTempFile::new_in(&path) {
@@ -292,6 +306,15 @@ fn probe_candidate(kind: InstallRootKind, path: PathBuf) -> InstallRootCandidate
                 }
             }
         }
+    }
+}
+
+fn classify_steam_root_kind(client_path: &Path) -> InstallRootKind {
+    let marker = Path::new(".var/app/com.valvesoftware.Steam/data/Steam");
+    if client_path.ends_with(marker) {
+        InstallRootKind::FlatpakSteam
+    } else {
+        InstallRootKind::NativeSteam
     }
 }
 
@@ -530,5 +553,37 @@ mod tests {
             pick_default_with(&candidates, true).is_none(),
             "expected None under Flatpak when no candidate is writable"
         );
+    }
+
+    #[test]
+    fn configured_flatpak_steam_path_is_classified_as_flatpak() {
+        let home = tempdir().unwrap();
+        let configured = home
+            .path()
+            .join(".var/app/com.valvesoftware.Steam/data/Steam");
+        let candidates = resolve_candidates_with(Some(&configured), Some(home.path()), false);
+
+        let configured_candidate = candidates
+            .iter()
+            .find(|c| c.path == configured.join("compatibilitytools.d"))
+            .expect("configured candidate must be present");
+        assert_eq!(configured_candidate.kind, InstallRootKind::FlatpakSteam);
+    }
+
+    #[test]
+    fn probe_marks_existing_non_directory_path_as_invalid() {
+        let dir = tempdir().unwrap();
+        let steam_root = dir.path().join(".local/share/Steam");
+        fs::create_dir_all(&steam_root).unwrap();
+        let fake_compat_file = steam_root.join("compatibilitytools.d");
+        fs::write(&fake_compat_file, "not a directory").unwrap();
+
+        let candidates = resolve_candidates_with(Some(&steam_root), Some(dir.path()), false);
+        let configured_candidate = candidates
+            .iter()
+            .find(|c| c.path == fake_compat_file)
+            .expect("configured candidate should be discovered");
+        assert!(!configured_candidate.writable);
+        assert_eq!(configured_candidate.reason.as_deref(), Some("invalid-path"));
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/install_root.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/install_root.rs
@@ -1,0 +1,534 @@
+//! Environment-aware resolver for Proton install root candidates.
+//!
+//! Enumerates and ranks candidate `compatibilitytools.d` directories for the
+//! current environment (native vs Flatpak Steam), probes each for writability,
+//! and surfaces a preference-ordered list for the install orchestrator and UI.
+//!
+//! This module is deliberately free of HTTP, SQLite, and Tauri imports. It is
+//! pure filesystem + environment detection and is recomputed per call.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::platform;
+
+// ── public types ──────────────────────────────────────────────────────────────
+
+/// Discriminates between the Steam install flavour that owns the directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstallRootKind {
+    NativeSteam,
+    FlatpakSteam,
+}
+
+/// One candidate install root with writability status and an optional
+/// human-readable reason string explaining why the path is not writable.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct InstallRootCandidate {
+    pub kind: InstallRootKind,
+    pub path: PathBuf,
+    pub writable: bool,
+    /// Human-readable token explaining a writability failure. `None` when the
+    /// path is writable or when the directory can be created on demand.
+    pub reason: Option<String>,
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Returns every plausible install root for the current environment,
+/// preference-ordered (NativeSteam variants before FlatpakSteam).
+///
+/// `configured_steam_client_path` is the resolved Steam client install path
+/// from settings (used to derive `<path>/compatibilitytools.d`). Pass `None`
+/// to fall back to default home-relative paths only.
+pub fn resolve_install_root_candidates(
+    configured_steam_client_path: Option<&Path>,
+) -> Vec<InstallRootCandidate> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    resolve_candidates_with(
+        configured_steam_client_path,
+        home.as_deref(),
+        platform::is_flatpak(),
+    )
+}
+
+/// Picks the default candidate the UI should pre-select.
+///
+/// Under Flatpak, a writable `NativeSteam` candidate is preferred over any
+/// `FlatpakSteam` candidate (mirrors `prefer_user_local_compat_tool_path`
+/// semantics). Outside Flatpak, the first writable candidate in enumeration
+/// order is returned. Returns `None` if no writable candidate exists.
+pub fn pick_default_install_root(
+    candidates: &[InstallRootCandidate],
+) -> Option<&InstallRootCandidate> {
+    pick_default_with(candidates, platform::is_flatpak())
+}
+
+// ── internal implementations (pub(crate) for tests) ──────────────────────────
+
+/// Testable core of [`resolve_install_root_candidates`].
+///
+/// `home_override` replaces the `HOME` env lookup. `is_flatpak` is threaded
+/// as a boolean so tests can exercise Flatpak logic without mutating
+/// `FLATPAK_ID`.
+pub(crate) fn resolve_candidates_with(
+    configured_steam_client_path: Option<&Path>,
+    home_override: Option<&Path>,
+    is_flatpak: bool,
+) -> Vec<InstallRootCandidate> {
+    let _ = is_flatpak; // Flatpak context does not change the enumeration list,
+                        // only `pick_default_with` uses it for ranking.
+
+    let Some(home) = home_override else {
+        tracing::warn!("install root resolver: HOME is unset, returning empty candidate list");
+        return Vec::new();
+    };
+
+    let mut raw: Vec<(InstallRootKind, PathBuf)> = Vec::new();
+    let mut seen_canonical: Vec<PathBuf> = Vec::new();
+
+    // ── 1. Native Steam paths ─────────────────────────────────────────────────
+
+    let native1 = home.join(".local/share/Steam/compatibilitytools.d");
+    let native2 = home.join(".steam/root/compatibilitytools.d");
+
+    push_deduped(
+        &native1,
+        InstallRootKind::NativeSteam,
+        &mut raw,
+        &mut seen_canonical,
+    );
+    push_deduped(
+        &native2,
+        InstallRootKind::NativeSteam,
+        &mut raw,
+        &mut seen_canonical,
+    );
+
+    // Optional configured Steam client path.
+    if let Some(client_path) = configured_steam_client_path {
+        let s = client_path.to_string_lossy();
+        if !s.trim().is_empty() {
+            let configured_compat = client_path.join("compatibilitytools.d");
+            push_deduped(
+                &configured_compat,
+                InstallRootKind::NativeSteam,
+                &mut raw,
+                &mut seen_canonical,
+            );
+        }
+    }
+
+    // ── 2. Flatpak Steam path ─────────────────────────────────────────────────
+
+    let flatpak_steam =
+        home.join(".var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d");
+    push_deduped(
+        &flatpak_steam,
+        InstallRootKind::FlatpakSteam,
+        &mut raw,
+        &mut seen_canonical,
+    );
+
+    // ── 3. Probe each candidate ───────────────────────────────────────────────
+
+    raw.into_iter()
+        .map(|(kind, path)| probe_candidate(kind, path))
+        .collect()
+}
+
+/// Testable core of [`pick_default_install_root`].
+pub(crate) fn pick_default_with(
+    candidates: &[InstallRootCandidate],
+    is_flatpak: bool,
+) -> Option<&InstallRootCandidate> {
+    if is_flatpak {
+        // Under Flatpak prefer a writable NativeSteam candidate first.
+        if let Some(c) = candidates
+            .iter()
+            .find(|c| c.kind == InstallRootKind::NativeSteam && c.writable)
+        {
+            return Some(c);
+        }
+    }
+    // Fall back to first writable candidate in enumeration order.
+    candidates.iter().find(|c| c.writable)
+}
+
+// ── private helpers ───────────────────────────────────────────────────────────
+
+/// Appends `(kind, path)` to `raw` unless `path` (or its canonical form)
+/// is already present in `seen_canonical`.
+fn push_deduped(
+    path: &Path,
+    kind: InstallRootKind,
+    raw: &mut Vec<(InstallRootKind, PathBuf)>,
+    seen_canonical: &mut Vec<PathBuf>,
+) {
+    // Canonicalize when the path exists; fall back to the raw path otherwise.
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if seen_canonical.contains(&key) {
+        tracing::debug!(
+            path = %path.display(),
+            "install root resolver: skipping duplicate candidate (same canonical path)"
+        );
+        return;
+    }
+    seen_canonical.push(key);
+    raw.push((kind, path.to_path_buf()));
+}
+
+/// Validates `path` and probes writability, returning a fully populated
+/// [`InstallRootCandidate`].
+fn probe_candidate(kind: InstallRootKind, path: PathBuf) -> InstallRootCandidate {
+    // ── 1. Path validation (mirrors validate_install_destination rules) ───────
+
+    if !path.is_absolute() {
+        tracing::debug!(path = %path.display(), "install root: rejected (not absolute)");
+        return InstallRootCandidate {
+            kind,
+            path,
+            writable: false,
+            reason: Some("invalid-path".to_string()),
+        };
+    }
+
+    for component in path.components() {
+        if component == Component::ParentDir {
+            tracing::debug!(path = %path.display(), "install root: rejected ('..'' component)");
+            return InstallRootCandidate {
+                kind,
+                path,
+                writable: false,
+                reason: Some("invalid-path".to_string()),
+            };
+        }
+    }
+
+    // ── 2. Writability probe ──────────────────────────────────────────────────
+
+    if path.is_dir() {
+        // Directory exists — try creating a tempfile inside it.
+        match tempfile::NamedTempFile::new_in(&path) {
+            Ok(_tmp) => {
+                // `_tmp` is dropped here, deleting the probe file.
+                tracing::debug!(path = %path.display(), "install root: writable (dir exists)");
+                InstallRootCandidate {
+                    kind,
+                    path,
+                    writable: true,
+                    reason: None,
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "install root: not writable (dir exists but tempfile creation failed)"
+                );
+                let reason = flatpak_or_generic_reason(kind, "parent-path-read-only");
+                InstallRootCandidate {
+                    kind,
+                    path,
+                    writable: false,
+                    reason: Some(reason),
+                }
+            }
+        }
+    } else {
+        // Directory does not exist — probe the parent.
+        let parent = match path.parent() {
+            Some(p) => p,
+            None => {
+                return InstallRootCandidate {
+                    kind,
+                    path,
+                    writable: false,
+                    reason: Some("invalid-path".to_string()),
+                };
+            }
+        };
+
+        if !parent.exists() {
+            tracing::debug!(
+                path = %path.display(),
+                parent = %parent.display(),
+                "install root: not writable (parent path missing)"
+            );
+            return InstallRootCandidate {
+                kind,
+                path,
+                writable: false,
+                reason: Some("parent-path-missing".to_string()),
+            };
+        }
+
+        // Parent exists — probe writability there.
+        match tempfile::NamedTempFile::new_in(parent) {
+            Ok(_tmp) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    "install root: writable (dir will be created on install)"
+                );
+                InstallRootCandidate {
+                    kind,
+                    path,
+                    writable: true,
+                    reason: None,
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "install root: not writable (parent exists but is read-only)"
+                );
+                let reason = flatpak_or_generic_reason(kind, "parent-path-read-only");
+                InstallRootCandidate {
+                    kind,
+                    path,
+                    writable: false,
+                    reason: Some(reason),
+                }
+            }
+        }
+    }
+}
+
+/// Returns a Flatpak-specific reason token for `FlatpakSteam` kind, otherwise
+/// returns `generic`.
+fn flatpak_or_generic_reason(kind: InstallRootKind, generic: &str) -> String {
+    if kind == InstallRootKind::FlatpakSteam {
+        "flatpak-steam-path-read-only".to_string()
+    } else {
+        generic.to_string()
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    // Mutex that serialises env-var mutations across all tests in this module.
+    static FLATPAK_ID_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Scoped guard that sets an env var and restores it on drop.
+    struct ScopedEnv {
+        key: &'static str,
+        original: Option<std::ffi::OsString>,
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ScopedEnv {
+        fn unset(key: &'static str) -> Self {
+            let guard = FLATPAK_ID_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let original = std::env::var_os(key);
+            // SAFETY: serialised by the mutex.
+            unsafe { std::env::remove_var(key) };
+            Self {
+                key,
+                original,
+                _guard: guard,
+            }
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            match &self.original {
+                // SAFETY: mutex is still held.
+                Some(val) => unsafe { std::env::set_var(self.key, val) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+
+    // ── test 1 ────────────────────────────────────────────────────────────────
+
+    /// In a non-Flatpak environment the resolver must enumerate NativeSteam
+    /// candidates before the FlatpakSteam candidate.
+    #[test]
+    fn resolver_returns_native_then_flatpak_in_nonflatpak_env() {
+        let home = tempdir().unwrap();
+        // Do not set FLATPAK_ID — simulate non-Flatpak.
+        let _guard = ScopedEnv::unset("FLATPAK_ID");
+
+        let candidates = resolve_candidates_with(None, Some(home.path()), false);
+
+        // There must be at least 2 candidates: some NativeSteam and one FlatpakSteam.
+        assert!(
+            candidates.len() >= 2,
+            "expected at least 2 candidates, got {}",
+            candidates.len()
+        );
+
+        // All NativeSteam entries must come before any FlatpakSteam entry.
+        let mut seen_flatpak = false;
+        for c in &candidates {
+            if c.kind == InstallRootKind::FlatpakSteam {
+                seen_flatpak = true;
+            }
+            if seen_flatpak {
+                assert_ne!(
+                    c.kind,
+                    InstallRootKind::NativeSteam,
+                    "NativeSteam candidate appeared after FlatpakSteam: {}",
+                    c.path.display()
+                );
+            }
+        }
+
+        // The last candidate must be FlatpakSteam.
+        assert_eq!(
+            candidates.last().unwrap().kind,
+            InstallRootKind::FlatpakSteam,
+            "last candidate should be FlatpakSteam"
+        );
+    }
+
+    // ── test 2 ────────────────────────────────────────────────────────────────
+
+    /// Under Flatpak, `pick_default_install_root` must prefer a writable
+    /// NativeSteam candidate over any FlatpakSteam candidate.
+    #[test]
+    fn resolver_prefers_native_over_flatpak_under_flatpak() {
+        let home = tempdir().unwrap();
+        // Create the NativeSteam directory so it passes the writable probe.
+        let native_path = home.path().join(".local/share/Steam/compatibilitytools.d");
+        fs::create_dir_all(&native_path).unwrap();
+
+        // Simulate Flatpak environment (is_flatpak = true).
+        let candidates = resolve_candidates_with(None, Some(home.path()), true);
+
+        let default = pick_default_with(&candidates, true);
+        assert!(default.is_some(), "expected a writable default candidate");
+        let default = default.unwrap();
+        assert_eq!(
+            default.kind,
+            InstallRootKind::NativeSteam,
+            "under Flatpak the default must be NativeSteam, got path: {}",
+            default.path.display()
+        );
+        assert!(default.writable, "default candidate must be writable");
+    }
+
+    // ── test 3 ────────────────────────────────────────────────────────────────
+
+    /// A read-only Flatpak Steam directory must produce `writable = false`
+    /// and `reason = Some("flatpak-steam-path-read-only")`.
+    #[test]
+    fn resolver_marks_unwritable_flatpak_path_with_reason() {
+        let home = tempdir().unwrap();
+
+        // Create the Flatpak Steam path and make it read-only.
+        let flatpak_compat = home
+            .path()
+            .join(".var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d");
+        fs::create_dir_all(&flatpak_compat).unwrap();
+        let mut perms = fs::metadata(&flatpak_compat).unwrap().permissions();
+        perms.set_mode(0o555);
+        fs::set_permissions(&flatpak_compat, perms).unwrap();
+
+        let candidates = resolve_candidates_with(None, Some(home.path()), false);
+
+        let flatpak_candidate = candidates
+            .iter()
+            .find(|c| c.kind == InstallRootKind::FlatpakSteam)
+            .expect("expected a FlatpakSteam candidate");
+
+        // Restore permissions so the tempdir cleanup works.
+        let mut perms = fs::metadata(&flatpak_compat).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&flatpak_compat, perms).unwrap();
+
+        assert!(
+            !flatpak_candidate.writable,
+            "read-only Flatpak Steam path should not be writable"
+        );
+        assert_eq!(
+            flatpak_candidate.reason.as_deref(),
+            Some("flatpak-steam-path-read-only"),
+            "expected flatpak-specific reason, got: {:?}",
+            flatpak_candidate.reason
+        );
+    }
+
+    // ── test 4 ────────────────────────────────────────────────────────────────
+
+    /// A configured Steam client path containing `..` must produce a candidate
+    /// with `writable = false` and `reason = Some("invalid-path")`.
+    #[test]
+    fn resolver_rejects_parent_traversal_paths() {
+        let home = tempdir().unwrap();
+
+        // Pass a configured_steam_client_path that contains "..".
+        let traversal_path = Path::new("/home/user/../../../etc");
+        let candidates = resolve_candidates_with(Some(traversal_path), Some(home.path()), false);
+
+        // The derived path would be `/home/user/../../../etc/compatibilitytools.d`.
+        // Find a candidate with `..` in its path.
+        let bad_candidate = candidates
+            .iter()
+            .find(|c| c.path.components().any(|comp| comp == Component::ParentDir));
+
+        // If the path was included as a candidate it must be marked invalid.
+        if let Some(c) = bad_candidate {
+            assert!(
+                !c.writable,
+                "path with '..' should not be writable: {}",
+                c.path.display()
+            );
+            assert_eq!(
+                c.reason.as_deref(),
+                Some("invalid-path"),
+                "expected invalid-path reason, got: {:?}",
+                c.reason
+            );
+        }
+        // If it was excluded entirely that is also acceptable — the test
+        // verifies no traversal path sneaks through as writable.
+        for c in &candidates {
+            if c.path.components().any(|comp| comp == Component::ParentDir) {
+                assert!(!c.writable, "traversal path must not be writable");
+            }
+        }
+    }
+
+    // ── test 5 ────────────────────────────────────────────────────────────────
+
+    /// When no candidate is writable, `pick_default_install_root` must return
+    /// `None`.
+    #[test]
+    fn pick_default_install_root_returns_none_when_nothing_writable() {
+        let candidates = vec![
+            InstallRootCandidate {
+                kind: InstallRootKind::NativeSteam,
+                path: PathBuf::from("/nonexistent/path/one/compatibilitytools.d"),
+                writable: false,
+                reason: Some("parent-path-missing".to_string()),
+            },
+            InstallRootCandidate {
+                kind: InstallRootKind::FlatpakSteam,
+                path: PathBuf::from("/nonexistent/path/two/compatibilitytools.d"),
+                writable: false,
+                reason: Some("flatpak-steam-path-read-only".to_string()),
+            },
+        ];
+
+        assert!(
+            pick_default_with(&candidates, false).is_none(),
+            "expected None when no candidate is writable"
+        );
+        assert!(
+            pick_default_with(&candidates, true).is_none(),
+            "expected None under Flatpak when no candidate is writable"
+        );
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs
@@ -6,7 +6,11 @@
 
 pub mod catalog;
 pub mod install;
+pub mod install_root;
 pub mod matching;
+pub mod progress;
+pub mod providers;
+pub mod uninstall;
 
 use serde::{Deserialize, Serialize};
 
@@ -53,6 +57,11 @@ pub struct ProtonUpAvailableVersion {
     pub checksum_kind: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub asset_size: Option<u64>,
+    /// ISO-8601 UTC release timestamp from the upstream GitHub release.
+    ///
+    /// `#[serde(default)]` so older cached `payload_json` rows (pre-v22.1) still deserialize.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
 }
 
 /// Cache freshness metadata attached to catalog responses.
@@ -279,6 +288,7 @@ mod tests {
                     checksum_url: Some("https://example.com/file.sha512sum".to_string()),
                     checksum_kind: Some("sha512".to_string()),
                     asset_size: Some(123_456),
+                    published_at: Some("2024-01-01T00:00:00Z".to_string()),
                 },
                 ProtonUpAvailableVersion {
                     provider: "ge-proton".to_string(),
@@ -288,6 +298,7 @@ mod tests {
                     checksum_url: None,
                     checksum_kind: None,
                     asset_size: None,
+                    published_at: None,
                 },
             ],
             cache: ProtonUpCacheMeta {
@@ -323,6 +334,7 @@ mod tests {
             checksum_url: None,
             checksum_kind: None,
             asset_size: None,
+            published_at: None,
         };
 
         let json = serde_json::to_string(&version).expect("serialize version");
@@ -331,6 +343,16 @@ mod tests {
         assert!(!json.contains("download_url"));
         assert!(!json.contains("checksum_url"));
         assert!(!json.contains("asset_size"));
+        assert!(!json.contains("published_at"));
+    }
+
+    #[test]
+    fn available_version_deserializes_without_published_at() {
+        // Older cached rows may not include published_at; ensure #[serde(default)] kicks in.
+        let legacy = r#"{"provider":"ge-proton","version":"GE-Proton9-20"}"#;
+        let v: ProtonUpAvailableVersion =
+            serde_json::from_str(legacy).expect("legacy JSON must deserialize");
+        assert!(v.published_at.is_none());
     }
 
     // ── ProtonUpInstallResult round-trip ──────────────────────────────────────

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs
@@ -22,6 +22,7 @@ pub enum ProtonUpProvider {
     #[default]
     GeProton,
     ProtonCachyos,
+    ProtonEm,
 }
 
 impl std::fmt::Display for ProtonUpProvider {
@@ -29,6 +30,7 @@ impl std::fmt::Display for ProtonUpProvider {
         match self {
             Self::GeProton => write!(f, "ge-proton"),
             Self::ProtonCachyos => write!(f, "proton-cachyos"),
+            Self::ProtonEm => write!(f, "proton-em"),
         }
     }
 }
@@ -38,6 +40,7 @@ pub fn parse_protonup_provider(s: Option<&str>) -> ProtonUpProvider {
     match s.map(str::trim).filter(|x| !x.is_empty()) {
         None | Some("ge-proton") => ProtonUpProvider::GeProton,
         Some("proton-cachyos") => ProtonUpProvider::ProtonCachyos,
+        Some("proton-em") => ProtonUpProvider::ProtonEm,
         Some(_) => ProtonUpProvider::GeProton,
     }
 }
@@ -189,12 +192,27 @@ mod tests {
     }
 
     #[test]
+    fn proton_em_serializes_as_kebab_case() {
+        let json =
+            serde_json::to_string(&ProtonUpProvider::ProtonEm).expect("serialize ProtonUpProvider");
+        assert_eq!(json, r#""proton-em""#);
+    }
+
+    #[test]
+    fn proton_em_deserializes_from_kebab_case() {
+        let provider: ProtonUpProvider =
+            serde_json::from_str(r#""proton-em""#).expect("deserialize ProtonUpProvider");
+        assert_eq!(provider, ProtonUpProvider::ProtonEm);
+    }
+
+    #[test]
     fn display_matches_kebab_case_ids() {
         assert_eq!(ProtonUpProvider::GeProton.to_string(), "ge-proton");
         assert_eq!(
             ProtonUpProvider::ProtonCachyos.to_string(),
             "proton-cachyos"
         );
+        assert_eq!(ProtonUpProvider::ProtonEm.to_string(), "proton-em");
     }
 
     #[test]
@@ -211,6 +229,10 @@ mod tests {
         assert_eq!(
             parse_protonup_provider(Some("proton-cachyos")),
             ProtonUpProvider::ProtonCachyos
+        );
+        assert_eq!(
+            parse_protonup_provider(Some("proton-em")),
+            ProtonUpProvider::ProtonEm
         );
         assert_eq!(
             parse_protonup_provider(Some("unknown")),

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/mod.rs
@@ -105,6 +105,7 @@ pub enum ProtonUpInstallErrorKind {
     NetworkError,
     InvalidPath,
     AlreadyInstalled,
+    Cancelled,
     Unknown,
 }
 
@@ -117,6 +118,7 @@ impl std::fmt::Display for ProtonUpInstallErrorKind {
             Self::NetworkError => write!(f, "network_error"),
             Self::InvalidPath => write!(f, "invalid_path"),
             Self::AlreadyInstalled => write!(f, "already_installed"),
+            Self::Cancelled => write!(f, "cancelled"),
             Self::Unknown => write!(f, "unknown"),
         }
     }
@@ -280,6 +282,7 @@ mod tests {
                 ProtonUpInstallErrorKind::AlreadyInstalled,
                 "already_installed",
             ),
+            (ProtonUpInstallErrorKind::Cancelled, "cancelled"),
             (ProtonUpInstallErrorKind::Unknown, "unknown"),
         ];
 
@@ -294,6 +297,13 @@ mod tests {
         let kind: ProtonUpInstallErrorKind =
             serde_json::from_str(r#""checksum_failed""#).expect("deserialize ChecksumFailed");
         assert_eq!(kind, ProtonUpInstallErrorKind::ChecksumFailed);
+    }
+
+    #[test]
+    fn install_error_kind_deserializes_cancelled() {
+        let kind: ProtonUpInstallErrorKind =
+            serde_json::from_str(r#""cancelled""#).expect("deserialize Cancelled");
+        assert_eq!(kind, ProtonUpInstallErrorKind::Cancelled);
     }
 
     // ── ProtonUpCatalogResponse round-trip ────────────────────────────────────

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs
@@ -2,6 +2,15 @@
 
 use tokio::sync::broadcast;
 
+/// Bounded backlog for progress snapshots sent to UI listeners.
+///
+/// Progress events are best-effort status updates, not an audit log. The
+/// channel is intentionally lossy under back-pressure so a stalled UI cannot
+/// grow unbounded memory while download/verify/extract work continues. Lagging
+/// receivers should expect `broadcast::error::RecvError::Lagged` and treat the
+/// next snapshot as the current install state.
+const PROGRESS_EVENT_BUFFER_CAP: usize = 64;
+
 /// Install lifecycle phase.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -36,7 +45,7 @@ pub struct ProgressEmitter {
 impl ProgressEmitter {
     /// Create a new emitter and its paired receiver.
     pub fn new(op_id: impl Into<String>) -> (Self, broadcast::Receiver<ProtonInstallProgress>) {
-        let (tx, rx) = broadcast::channel(64);
+        let (tx, rx) = broadcast::channel(PROGRESS_EVENT_BUFFER_CAP);
         (
             Self {
                 op_id: op_id.into(),
@@ -47,6 +56,11 @@ impl ProgressEmitter {
     }
 
     /// Subscribe to receive future events from this emitter.
+    ///
+    /// The bounded channel only retains the most recent
+    /// [`PROGRESS_EVENT_BUFFER_CAP`] snapshots. Slow consumers may receive
+    /// `broadcast::error::RecvError::Lagged` and should continue with the next
+    /// available snapshot.
     pub fn subscribe(&self) -> broadcast::Receiver<ProtonInstallProgress> {
         self.tx.subscribe()
     }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs
@@ -29,7 +29,7 @@ pub struct ProtonInstallProgress {
 /// Emitter handle.  Clone-cheap; backed by a `broadcast` channel.
 #[derive(Clone)]
 pub struct ProgressEmitter {
-    pub op_id: String,
+    op_id: String,
     tx: broadcast::Sender<ProtonInstallProgress>,
 }
 
@@ -49,6 +49,10 @@ impl ProgressEmitter {
     /// Subscribe to receive future events from this emitter.
     pub fn subscribe(&self) -> broadcast::Receiver<ProtonInstallProgress> {
         self.tx.subscribe()
+    }
+
+    pub fn op_id(&self) -> &str {
+        &self.op_id
     }
 
     /// Send a progress snapshot. Silently ignores the case where no receivers are listening.

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/progress.rs
@@ -1,0 +1,70 @@
+//! Progress event types and emitter for the Proton install orchestrator.
+
+use tokio::sync::broadcast;
+
+/// Install lifecycle phase.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Phase {
+    Resolving,
+    Downloading,
+    Verifying,
+    Extracting,
+    Finalizing,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+/// One progress snapshot emitted during an install operation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProtonInstallProgress {
+    pub op_id: String,
+    pub phase: Phase,
+    pub bytes_done: u64,
+    pub bytes_total: Option<u64>,
+    pub message: Option<String>,
+}
+
+/// Emitter handle.  Clone-cheap; backed by a `broadcast` channel.
+#[derive(Clone)]
+pub struct ProgressEmitter {
+    pub op_id: String,
+    tx: broadcast::Sender<ProtonInstallProgress>,
+}
+
+impl ProgressEmitter {
+    /// Create a new emitter and its paired receiver.
+    pub fn new(op_id: impl Into<String>) -> (Self, broadcast::Receiver<ProtonInstallProgress>) {
+        let (tx, rx) = broadcast::channel(64);
+        (
+            Self {
+                op_id: op_id.into(),
+                tx,
+            },
+            rx,
+        )
+    }
+
+    /// Subscribe to receive future events from this emitter.
+    pub fn subscribe(&self) -> broadcast::Receiver<ProtonInstallProgress> {
+        self.tx.subscribe()
+    }
+
+    /// Send a progress snapshot. Silently ignores the case where no receivers are listening.
+    pub fn emit(
+        &self,
+        phase: Phase,
+        bytes_done: u64,
+        bytes_total: Option<u64>,
+        message: Option<String>,
+    ) {
+        let _ = self.tx.send(ProtonInstallProgress {
+            op_id: self.op_id.clone(),
+            phase,
+            bytes_done,
+            bytes_total,
+            message,
+        });
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
@@ -1,0 +1,184 @@
+//! Boxtron provider — catalog-only, fetches releases from dreamer/boxtron.
+//!
+//! Install support is disabled because the folder-name-vs-tag invariant required
+//! for safe extraction into the compatibility tools directory has not yet been
+//! verified for Boxtron releases.
+
+use async_trait::async_trait;
+
+use crate::protonup::ProtonUpAvailableVersion;
+
+use super::{ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+
+const GH_RELEASES_URL: &str = "https://api.github.com/repos/dreamer/boxtron/releases";
+const MAX_RELEASES: usize = 30;
+
+/// Provider for Boxtron (catalog-only).
+pub struct BoxtronProvider;
+
+impl BoxtronProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for BoxtronProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProtonReleaseProvider for BoxtronProvider {
+    fn id(&self) -> &'static str {
+        "boxtron"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Boxtron"
+    }
+
+    /// Catalog-only: folder-name-vs-tag invariant not yet verified.
+    fn supports_install(&self) -> bool {
+        false
+    }
+
+    fn checksum_kind(&self) -> ChecksumKind {
+        ChecksumKind::Sha256Manifest
+    }
+
+    async fn fetch(
+        &self,
+        client: &reqwest::Client,
+        _include_prereleases: bool,
+    ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
+        use reqwest::StatusCode;
+
+        let response = client
+            .get(GH_RELEASES_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(Vec::new());
+        }
+
+        let releases = response
+            .error_for_status()?
+            .json::<Vec<GhRelease>>()
+            .await?;
+
+        Ok(releases_to_versions(releases))
+    }
+}
+
+fn releases_to_versions(releases: Vec<GhRelease>) -> Vec<ProtonUpAvailableVersion> {
+    releases
+        .into_iter()
+        .filter(|r| !r.draft && !r.prerelease)
+        .take(MAX_RELEASES)
+        .filter_map(|r| {
+            // Boxtron publishes a per-release SHA256SUMS manifest.
+            let checksum_url = format!(
+                "https://github.com/dreamer/boxtron/releases/download/{}/SHA256SUMS",
+                r.tag_name
+            );
+            // Pick the primary .tar.gz asset (catalog-only, so we still record download_url).
+            let tarball = r
+                .assets
+                .iter()
+                .find(|a| a.name.ends_with(".tar.gz") && !a.name.contains(".sha"))?;
+
+            Some(ProtonUpAvailableVersion {
+                provider: "boxtron".to_string(),
+                version: r.tag_name,
+                release_url: Some(r.html_url),
+                download_url: Some(tarball.browser_download_url.clone()),
+                asset_size: Some(tarball.size),
+                checksum_url: Some(checksum_url),
+                checksum_kind: Some("sha256".to_string()),
+                published_at: r.published_at,
+            })
+        })
+        .collect()
+}
+
+/// The GitHub Releases API URL used by this provider.
+///
+/// Exposed for `catalog.rs` to use as the SQLite cache key URL.
+pub fn gh_releases_url() -> &'static str {
+    GH_RELEASES_URL
+}
+
+/// SQLite cache key for this provider's catalog.
+pub fn cache_key() -> &'static str {
+    "protonup:catalog:boxtron"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{GhAsset, GhRelease};
+    use super::*;
+
+    fn make_release(
+        tag_name: &str,
+        draft: bool,
+        prerelease: bool,
+        assets: Vec<GhAsset>,
+    ) -> GhRelease {
+        GhRelease {
+            tag_name: tag_name.to_string(),
+            html_url: format!("https://github.com/dreamer/boxtron/releases/tag/{tag_name}"),
+            draft,
+            prerelease,
+            assets,
+            published_at: Some("2023-05-01T00:00:00Z".to_string()),
+        }
+    }
+
+    fn tar_gz_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("boxtron-{tag_name}.tar.gz"),
+            browser_download_url: format!(
+                "https://github.com/dreamer/boxtron/releases/download/{tag_name}/boxtron-{tag_name}.tar.gz"
+            ),
+            size: 25_000_000,
+        }
+    }
+
+    #[test]
+    fn parse_releases_boxtron_shapes_tags() {
+        let releases = vec![make_release(
+            "0.7.0",
+            false,
+            false,
+            vec![tar_gz_asset("0.7.0")],
+        )];
+
+        let versions = releases_to_versions(releases);
+        assert_eq!(versions.len(), 1);
+        let v = &versions[0];
+        assert_eq!(v.provider, "boxtron");
+        assert_eq!(v.version, "0.7.0");
+        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.gz"));
+        assert_eq!(
+            v.checksum_url.as_deref(),
+            Some("https://github.com/dreamer/boxtron/releases/download/0.7.0/SHA256SUMS")
+        );
+        assert_eq!(v.checksum_kind.as_deref(), Some("sha256"));
+    }
+
+    #[test]
+    fn boxtron_is_catalog_only() {
+        let provider = BoxtronProvider::new();
+        assert!(!provider.supports_install());
+    }
+
+    #[test]
+    fn boxtron_checksum_kind_is_sha256_manifest() {
+        let provider = BoxtronProvider::new();
+        assert_eq!(provider.checksum_kind(), ChecksumKind::Sha256Manifest);
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use crate::protonup::ProtonUpAvailableVersion;
 
 use super::{
-    build_versions_from_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError,
+    build_versions_from_releases, fetch_github_releases, ChecksumKind, GhRelease,
+    ProtonReleaseProvider, ProviderError,
 };
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/dreamer/boxtron/releases";
@@ -54,24 +55,7 @@ impl ProtonReleaseProvider for BoxtronProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        use reqwest::StatusCode;
-
-        let response = client
-            .get(GH_RELEASES_URL)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(Vec::new());
-        }
-
-        let releases = response
-            .error_for_status()?
-            .json::<Vec<GhRelease>>()
-            .await?;
-
+        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
         Ok(releases_to_versions(releases, include_prereleases))
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+use super::{
+    build_versions_from_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError,
+};
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/dreamer/boxtron/releases";
 const MAX_RELEASES: usize = 30;
@@ -50,7 +52,7 @@ impl ProtonReleaseProvider for BoxtronProvider {
     async fn fetch(
         &self,
         client: &reqwest::Client,
-        _include_prereleases: bool,
+        include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         use reqwest::StatusCode;
 
@@ -70,39 +72,23 @@ impl ProtonReleaseProvider for BoxtronProvider {
             .json::<Vec<GhRelease>>()
             .await?;
 
-        Ok(releases_to_versions(releases))
+        Ok(releases_to_versions(releases, include_prereleases))
     }
 }
 
-fn releases_to_versions(releases: Vec<GhRelease>) -> Vec<ProtonUpAvailableVersion> {
-    releases
-        .into_iter()
-        .filter(|r| !r.draft && !r.prerelease)
-        .take(MAX_RELEASES)
-        .filter_map(|r| {
-            // Boxtron publishes a per-release SHA256SUMS manifest.
-            let checksum_url = format!(
-                "https://github.com/dreamer/boxtron/releases/download/{}/SHA256SUMS",
-                r.tag_name
-            );
-            // Pick the primary .tar.gz asset (catalog-only, so we still record download_url).
-            let tarball = r
-                .assets
-                .iter()
-                .find(|a| a.name.ends_with(".tar.gz") && !a.name.contains(".sha"))?;
-
-            Some(ProtonUpAvailableVersion {
-                provider: "boxtron".to_string(),
-                version: r.tag_name,
-                release_url: Some(r.html_url),
-                download_url: Some(tarball.browser_download_url.clone()),
-                asset_size: Some(tarball.size),
-                checksum_url: Some(checksum_url),
-                checksum_kind: Some("sha256".to_string()),
-                published_at: r.published_at,
-            })
-        })
-        .collect()
+fn releases_to_versions(
+    releases: Vec<GhRelease>,
+    include_prereleases: bool,
+) -> Vec<ProtonUpAvailableVersion> {
+    build_versions_from_releases(
+        releases,
+        "boxtron",
+        MAX_RELEASES,
+        include_prereleases,
+        "https://github.com/dreamer/boxtron/releases/download",
+        "SHA256SUMS",
+        |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
+    )
 }
 
 /// The GitHub Releases API URL used by this provider.
@@ -157,7 +143,7 @@ mod tests {
             vec![tar_gz_asset("0.7.0")],
         )];
 
-        let versions = releases_to_versions(releases);
+        let versions = releases_to_versions(releases, false);
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.provider, "boxtron");

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/boxtron.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use crate::protonup::ProtonUpAvailableVersion;
 
 use super::{
-    build_versions_from_releases, fetch_github_releases, ChecksumKind, GhRelease,
-    ProtonReleaseProvider, ProviderError,
+    build_versions_from_releases, fetch_github_releases, ChecksumKind, ProtonReleaseProvider,
+    ProviderError,
 };
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/dreamer/boxtron/releases";
@@ -56,23 +56,16 @@ impl ProtonReleaseProvider for BoxtronProvider {
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
-        Ok(releases_to_versions(releases, include_prereleases))
+        Ok(build_versions_from_releases(
+            releases,
+            "boxtron",
+            MAX_RELEASES,
+            include_prereleases,
+            "https://github.com/dreamer/boxtron/releases/download",
+            "SHA256SUMS",
+            |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
+        ))
     }
-}
-
-fn releases_to_versions(
-    releases: Vec<GhRelease>,
-    include_prereleases: bool,
-) -> Vec<ProtonUpAvailableVersion> {
-    build_versions_from_releases(
-        releases,
-        "boxtron",
-        MAX_RELEASES,
-        include_prereleases,
-        "https://github.com/dreamer/boxtron/releases/download",
-        "SHA256SUMS",
-        |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
-    )
 }
 
 /// The GitHub Releases API URL used by this provider.
@@ -127,7 +120,15 @@ mod tests {
             vec![tar_gz_asset("0.7.0")],
         )];
 
-        let versions = releases_to_versions(releases, false);
+        let versions = build_versions_from_releases(
+            releases,
+            "boxtron",
+            MAX_RELEASES,
+            false,
+            "https://github.com/dreamer/boxtron/releases/download",
+            "SHA256SUMS",
+            |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
+        );
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.provider, "boxtron");

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
@@ -1,0 +1,270 @@
+//! GE-Proton provider — fetches releases from GloriousEggroll/proton-ge-custom.
+
+use async_trait::async_trait;
+
+use crate::protonup::ProtonUpAvailableVersion;
+
+use super::{parse_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+
+const GH_RELEASES_URL: &str =
+    "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases";
+const MAX_RELEASES: usize = 30;
+
+/// Provider for GE-Proton (community-patched Proton by GloriousEggroll).
+pub struct GeProtonProvider;
+
+impl GeProtonProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GeProtonProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProtonReleaseProvider for GeProtonProvider {
+    fn id(&self) -> &'static str {
+        "ge-proton"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "GE-Proton"
+    }
+
+    fn supports_install(&self) -> bool {
+        true
+    }
+
+    fn checksum_kind(&self) -> ChecksumKind {
+        ChecksumKind::Sha512Sidecar
+    }
+
+    async fn fetch(
+        &self,
+        client: &reqwest::Client,
+        _include_prereleases: bool,
+    ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
+        use reqwest::StatusCode;
+
+        let response = client
+            .get(GH_RELEASES_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(Vec::new());
+        }
+
+        let releases = response
+            .error_for_status()?
+            .json::<Vec<GhRelease>>()
+            .await?;
+
+        Ok(parse_releases(releases, self.id(), MAX_RELEASES))
+    }
+}
+
+/// The GitHub Releases API URL used by this provider.
+///
+/// Exposed for `catalog.rs` to use as the SQLite cache key URL.
+pub fn gh_releases_url() -> &'static str {
+    GH_RELEASES_URL
+}
+
+/// SQLite cache key for this provider's catalog.
+pub fn cache_key() -> &'static str {
+    "protonup:catalog:ge-proton"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{GhAsset, GhRelease};
+    use super::*;
+
+    fn make_release(
+        tag_name: &str,
+        draft: bool,
+        prerelease: bool,
+        assets: Vec<GhAsset>,
+    ) -> GhRelease {
+        GhRelease {
+            tag_name: tag_name.to_string(),
+            html_url: format!("https://github.com/example/releases/tag/{tag_name}"),
+            draft,
+            prerelease,
+            assets,
+            published_at: Some("2025-04-10T22:16:05Z".to_string()),
+        }
+    }
+
+    fn tar_gz_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("{tag_name}.tar.gz"),
+            browser_download_url: format!(
+                "https://github.com/releases/download/{tag_name}/{tag_name}.tar.gz"
+            ),
+            size: 1_234_567,
+        }
+    }
+
+    fn sha512_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("{tag_name}.sha512sum"),
+            browser_download_url: format!(
+                "https://github.com/releases/download/{tag_name}/{tag_name}.sha512sum"
+            ),
+            size: 128,
+        }
+    }
+
+    #[test]
+    fn parse_gh_release_extracts_version_and_urls() {
+        let releases = vec![make_release(
+            "GE-Proton9-21",
+            false,
+            false,
+            vec![tar_gz_asset("GE-Proton9-21"), sha512_asset("GE-Proton9-21")],
+        )];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        let v = &versions[0];
+        assert_eq!(v.version, "GE-Proton9-21");
+        assert_eq!(v.provider, "ge-proton");
+        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.gz"));
+        assert!(v.release_url.as_deref().unwrap().contains("GE-Proton9-21"));
+        assert!(v.checksum_url.is_some());
+        assert_eq!(v.checksum_kind.as_deref(), Some("sha512"));
+        assert_eq!(v.asset_size, Some(1_234_567));
+    }
+
+    #[test]
+    fn skips_draft_releases() {
+        let releases = vec![
+            make_release(
+                "GE-Proton9-21",
+                true,
+                false,
+                vec![tar_gz_asset("GE-Proton9-21")],
+            ),
+            make_release(
+                "GE-Proton9-20",
+                false,
+                false,
+                vec![tar_gz_asset("GE-Proton9-20")],
+            ),
+        ];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "GE-Proton9-20");
+    }
+
+    #[test]
+    fn skips_prerelease_releases() {
+        let releases = vec![
+            make_release(
+                "GE-Proton9-21-rc1",
+                false,
+                true,
+                vec![tar_gz_asset("GE-Proton9-21-rc1")],
+            ),
+            make_release(
+                "GE-Proton9-20",
+                false,
+                false,
+                vec![tar_gz_asset("GE-Proton9-20")],
+            ),
+        ];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "GE-Proton9-20");
+    }
+
+    #[test]
+    fn skips_releases_without_tar_gz() {
+        let releases = vec![make_release(
+            "GE-Proton9-21",
+            false,
+            false,
+            // Only a checksum — no .tar.gz present.
+            vec![sha512_asset("GE-Proton9-21")],
+        )];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn extracts_checksum_url_when_present() {
+        let releases = vec![make_release(
+            "GE-Proton9-21",
+            false,
+            false,
+            vec![tar_gz_asset("GE-Proton9-21"), sha512_asset("GE-Proton9-21")],
+        )];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let v = &versions[0];
+        assert!(v.checksum_url.is_some());
+        assert!(v.checksum_url.as_deref().unwrap().ends_with(".sha512sum"));
+        assert_eq!(v.checksum_kind.as_deref(), Some("sha512"));
+    }
+
+    #[test]
+    fn checksum_url_is_none_when_no_sha512sum_asset() {
+        let releases = vec![make_release(
+            "GE-Proton9-21",
+            false,
+            false,
+            vec![tar_gz_asset("GE-Proton9-21")],
+        )];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let v = &versions[0];
+        assert!(v.checksum_url.is_none());
+        assert!(v.checksum_kind.is_none());
+    }
+
+    #[test]
+    fn caps_at_max_releases() {
+        let releases: Vec<GhRelease> = (0..MAX_RELEASES + 5)
+            .map(|i| {
+                let tag = format!("GE-Proton9-{i}");
+                make_release(&tag, false, false, vec![tar_gz_asset(&tag)])
+            })
+            .collect();
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        assert_eq!(versions.len(), MAX_RELEASES);
+    }
+
+    #[test]
+    fn empty_release_list_returns_empty() {
+        let versions = parse_releases(vec![], "ge-proton", MAX_RELEASES);
+        assert!(versions.is_empty());
+    }
+
+    #[test]
+    fn propagates_published_at_from_release() {
+        let releases = vec![make_release(
+            "GE-Proton9-21",
+            false,
+            false,
+            vec![tar_gz_asset("GE-Proton9-21")],
+        )];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        assert_eq!(
+            versions[0].published_at.as_deref(),
+            Some("2025-04-10T22:16:05Z")
+        );
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{parse_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+use super::{
+    fetch_github_releases, parse_releases, ChecksumKind, ProtonReleaseProvider, ProviderError,
+};
 
 const GH_RELEASES_URL: &str =
     "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases";
@@ -48,24 +50,7 @@ impl ProtonReleaseProvider for GeProtonProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        use reqwest::StatusCode;
-
-        let response = client
-            .get(GH_RELEASES_URL)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(Vec::new());
-        }
-
-        let releases = response
-            .error_for_status()?
-            .json::<Vec<GhRelease>>()
-            .await?;
-
+        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
         Ok(parse_releases(
             releases,
             self.id(),

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
@@ -46,7 +46,7 @@ impl ProtonReleaseProvider for GeProtonProvider {
     async fn fetch(
         &self,
         client: &reqwest::Client,
-        _include_prereleases: bool,
+        include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         use reqwest::StatusCode;
 
@@ -66,7 +66,12 @@ impl ProtonReleaseProvider for GeProtonProvider {
             .json::<Vec<GhRelease>>()
             .await?;
 
-        Ok(parse_releases(releases, self.id(), MAX_RELEASES))
+        Ok(parse_releases(
+            releases,
+            self.id(),
+            MAX_RELEASES,
+            include_prereleases,
+        ))
     }
 }
 
@@ -132,7 +137,7 @@ mod tests {
             vec![tar_gz_asset("GE-Proton9-21"), sha512_asset("GE-Proton9-21")],
         )];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.version, "GE-Proton9-21");
@@ -161,7 +166,7 @@ mod tests {
             ),
         ];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].version, "GE-Proton9-20");
     }
@@ -183,9 +188,31 @@ mod tests {
             ),
         ];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].version, "GE-Proton9-20");
+    }
+
+    #[test]
+    fn includes_prerelease_releases_when_enabled() {
+        let releases = vec![
+            make_release(
+                "GE-Proton9-21-rc1",
+                false,
+                true,
+                vec![tar_gz_asset("GE-Proton9-21-rc1")],
+            ),
+            make_release(
+                "GE-Proton9-20",
+                false,
+                false,
+                vec![tar_gz_asset("GE-Proton9-20")],
+            ),
+        ];
+
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, true);
+        assert_eq!(versions.len(), 2);
+        assert_eq!(versions[0].version, "GE-Proton9-21-rc1");
     }
 
     #[test]
@@ -198,7 +225,7 @@ mod tests {
             vec![sha512_asset("GE-Proton9-21")],
         )];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         assert!(versions.is_empty());
     }
 
@@ -211,7 +238,7 @@ mod tests {
             vec![tar_gz_asset("GE-Proton9-21"), sha512_asset("GE-Proton9-21")],
         )];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         let v = &versions[0];
         assert!(v.checksum_url.is_some());
         assert!(v.checksum_url.as_deref().unwrap().ends_with(".sha512sum"));
@@ -227,7 +254,7 @@ mod tests {
             vec![tar_gz_asset("GE-Proton9-21")],
         )];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         let v = &versions[0];
         assert!(v.checksum_url.is_none());
         assert!(v.checksum_kind.is_none());
@@ -242,13 +269,13 @@ mod tests {
             })
             .collect();
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         assert_eq!(versions.len(), MAX_RELEASES);
     }
 
     #[test]
     fn empty_release_list_returns_empty() {
-        let versions = parse_releases(vec![], "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(vec![], "ge-proton", MAX_RELEASES, false);
         assert!(versions.is_empty());
     }
 
@@ -261,7 +288,7 @@ mod tests {
             vec![tar_gz_asset("GE-Proton9-21")],
         )];
 
-        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES);
+        let versions = parse_releases(releases, "ge-proton", MAX_RELEASES, false);
         assert_eq!(
             versions[0].published_at.as_deref(),
             Some("2025-04-10T22:16:05Z")

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/ge_proton.rs
@@ -4,9 +4,7 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{
-    fetch_github_releases, parse_releases, ChecksumKind, ProtonReleaseProvider, ProviderError,
-};
+use super::{fetch_github_versions, ChecksumKind, ProtonReleaseProvider, ProviderError};
 
 const GH_RELEASES_URL: &str =
     "https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases";
@@ -50,13 +48,14 @@ impl ProtonReleaseProvider for GeProtonProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
-        Ok(parse_releases(
-            releases,
+        fetch_github_versions(
+            client,
+            GH_RELEASES_URL,
             self.id(),
             MAX_RELEASES,
             include_prereleases,
-        ))
+        )
+        .await
     }
 }
 
@@ -74,7 +73,7 @@ pub fn cache_key() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{GhAsset, GhRelease};
+    use super::super::{parse_releases, GhAsset, GhRelease};
     use super::*;
 
     fn make_release(

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use crate::protonup::ProtonUpAvailableVersion;
 
 use super::{
-    build_versions_from_releases, fetch_github_releases, ChecksumKind, GhRelease,
-    ProtonReleaseProvider, ProviderError,
+    build_versions_from_releases, fetch_github_releases, ChecksumKind, ProtonReleaseProvider,
+    ProviderError,
 };
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/luxtorpeda-dev/luxtorpeda/releases";
@@ -56,23 +56,16 @@ impl ProtonReleaseProvider for LuxtorpedaProvider {
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
-        Ok(releases_to_versions(releases, include_prereleases))
+        Ok(build_versions_from_releases(
+            releases,
+            "luxtorpeda",
+            MAX_RELEASES,
+            include_prereleases,
+            "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download",
+            "SHA256SUMS",
+            |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
+        ))
     }
-}
-
-fn releases_to_versions(
-    releases: Vec<GhRelease>,
-    include_prereleases: bool,
-) -> Vec<ProtonUpAvailableVersion> {
-    build_versions_from_releases(
-        releases,
-        "luxtorpeda",
-        MAX_RELEASES,
-        include_prereleases,
-        "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download",
-        "SHA256SUMS",
-        |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
-    )
 }
 
 /// The GitHub Releases API URL used by this provider.
@@ -124,7 +117,15 @@ mod tests {
     fn parse_releases_luxtorpeda_shapes_tags() {
         let releases = vec![make_release("10", false, false, vec![tar_gz_asset("10")])];
 
-        let versions = releases_to_versions(releases, false);
+        let versions = build_versions_from_releases(
+            releases,
+            "luxtorpeda",
+            MAX_RELEASES,
+            false,
+            "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download",
+            "SHA256SUMS",
+            |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
+        );
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.provider, "luxtorpeda");

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
@@ -1,0 +1,181 @@
+//! Luxtorpeda provider — catalog-only, fetches releases from luxtorpeda-dev/luxtorpeda.
+//!
+//! Install support is disabled because the folder-name-vs-tag invariant required
+//! for safe extraction into the compatibility tools directory has not yet been
+//! verified for Luxtorpeda releases.
+
+use async_trait::async_trait;
+
+use crate::protonup::ProtonUpAvailableVersion;
+
+use super::{ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+
+const GH_RELEASES_URL: &str = "https://api.github.com/repos/luxtorpeda-dev/luxtorpeda/releases";
+const MAX_RELEASES: usize = 30;
+
+/// Provider for Luxtorpeda (catalog-only).
+pub struct LuxtorpedaProvider;
+
+impl LuxtorpedaProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for LuxtorpedaProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProtonReleaseProvider for LuxtorpedaProvider {
+    fn id(&self) -> &'static str {
+        "luxtorpeda"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Luxtorpeda"
+    }
+
+    /// Catalog-only: folder-name-vs-tag invariant not yet verified.
+    fn supports_install(&self) -> bool {
+        false
+    }
+
+    fn checksum_kind(&self) -> ChecksumKind {
+        ChecksumKind::Sha256Manifest
+    }
+
+    async fn fetch(
+        &self,
+        client: &reqwest::Client,
+        _include_prereleases: bool,
+    ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
+        use reqwest::StatusCode;
+
+        let response = client
+            .get(GH_RELEASES_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(Vec::new());
+        }
+
+        let releases = response
+            .error_for_status()?
+            .json::<Vec<GhRelease>>()
+            .await?;
+
+        Ok(releases_to_versions(releases))
+    }
+}
+
+fn releases_to_versions(releases: Vec<GhRelease>) -> Vec<ProtonUpAvailableVersion> {
+    releases
+        .into_iter()
+        .filter(|r| !r.draft && !r.prerelease)
+        .take(MAX_RELEASES)
+        .filter_map(|r| {
+            // Luxtorpeda publishes a per-release SHA256SUMS manifest.
+            let checksum_url = format!(
+                "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download/{}/SHA256SUMS",
+                r.tag_name
+            );
+            // Pick the primary .tar.gz asset (catalog-only, so we still record download_url).
+            let tarball = r
+                .assets
+                .iter()
+                .find(|a| a.name.ends_with(".tar.gz") && !a.name.contains(".sha"))?;
+
+            Some(ProtonUpAvailableVersion {
+                provider: "luxtorpeda".to_string(),
+                version: r.tag_name,
+                release_url: Some(r.html_url),
+                download_url: Some(tarball.browser_download_url.clone()),
+                asset_size: Some(tarball.size),
+                checksum_url: Some(checksum_url),
+                checksum_kind: Some("sha256".to_string()),
+                published_at: r.published_at,
+            })
+        })
+        .collect()
+}
+
+/// The GitHub Releases API URL used by this provider.
+///
+/// Exposed for `catalog.rs` to use as the SQLite cache key URL.
+pub fn gh_releases_url() -> &'static str {
+    GH_RELEASES_URL
+}
+
+/// SQLite cache key for this provider's catalog.
+pub fn cache_key() -> &'static str {
+    "protonup:catalog:luxtorpeda"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{GhAsset, GhRelease};
+    use super::*;
+
+    fn make_release(
+        tag_name: &str,
+        draft: bool,
+        prerelease: bool,
+        assets: Vec<GhAsset>,
+    ) -> GhRelease {
+        GhRelease {
+            tag_name: tag_name.to_string(),
+            html_url: format!(
+                "https://github.com/luxtorpeda-dev/luxtorpeda/releases/tag/{tag_name}"
+            ),
+            draft,
+            prerelease,
+            assets,
+            published_at: Some("2024-09-12T10:00:00Z".to_string()),
+        }
+    }
+
+    fn tar_gz_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("luxtorpeda-{tag_name}.tar.gz"),
+            browser_download_url: format!(
+                "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download/{tag_name}/luxtorpeda-{tag_name}.tar.gz"
+            ),
+            size: 50_000_000,
+        }
+    }
+
+    #[test]
+    fn parse_releases_luxtorpeda_shapes_tags() {
+        let releases = vec![make_release("10", false, false, vec![tar_gz_asset("10")])];
+
+        let versions = releases_to_versions(releases);
+        assert_eq!(versions.len(), 1);
+        let v = &versions[0];
+        assert_eq!(v.provider, "luxtorpeda");
+        assert_eq!(v.version, "10");
+        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.gz"));
+        assert_eq!(
+            v.checksum_url.as_deref(),
+            Some("https://github.com/luxtorpeda-dev/luxtorpeda/releases/download/10/SHA256SUMS")
+        );
+        assert_eq!(v.checksum_kind.as_deref(), Some("sha256"));
+    }
+
+    #[test]
+    fn luxtorpeda_is_catalog_only() {
+        let provider = LuxtorpedaProvider::new();
+        assert!(!provider.supports_install());
+    }
+
+    #[test]
+    fn luxtorpeda_checksum_kind_is_sha256_manifest() {
+        let provider = LuxtorpedaProvider::new();
+        assert_eq!(provider.checksum_kind(), ChecksumKind::Sha256Manifest);
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use crate::protonup::ProtonUpAvailableVersion;
 
 use super::{
-    build_versions_from_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError,
+    build_versions_from_releases, fetch_github_releases, ChecksumKind, GhRelease,
+    ProtonReleaseProvider, ProviderError,
 };
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/luxtorpeda-dev/luxtorpeda/releases";
@@ -54,24 +55,7 @@ impl ProtonReleaseProvider for LuxtorpedaProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        use reqwest::StatusCode;
-
-        let response = client
-            .get(GH_RELEASES_URL)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(Vec::new());
-        }
-
-        let releases = response
-            .error_for_status()?
-            .json::<Vec<GhRelease>>()
-            .await?;
-
+        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
         Ok(releases_to_versions(releases, include_prereleases))
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/luxtorpeda.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+use super::{
+    build_versions_from_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError,
+};
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/luxtorpeda-dev/luxtorpeda/releases";
 const MAX_RELEASES: usize = 30;
@@ -50,7 +52,7 @@ impl ProtonReleaseProvider for LuxtorpedaProvider {
     async fn fetch(
         &self,
         client: &reqwest::Client,
-        _include_prereleases: bool,
+        include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         use reqwest::StatusCode;
 
@@ -70,39 +72,23 @@ impl ProtonReleaseProvider for LuxtorpedaProvider {
             .json::<Vec<GhRelease>>()
             .await?;
 
-        Ok(releases_to_versions(releases))
+        Ok(releases_to_versions(releases, include_prereleases))
     }
 }
 
-fn releases_to_versions(releases: Vec<GhRelease>) -> Vec<ProtonUpAvailableVersion> {
-    releases
-        .into_iter()
-        .filter(|r| !r.draft && !r.prerelease)
-        .take(MAX_RELEASES)
-        .filter_map(|r| {
-            // Luxtorpeda publishes a per-release SHA256SUMS manifest.
-            let checksum_url = format!(
-                "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download/{}/SHA256SUMS",
-                r.tag_name
-            );
-            // Pick the primary .tar.gz asset (catalog-only, so we still record download_url).
-            let tarball = r
-                .assets
-                .iter()
-                .find(|a| a.name.ends_with(".tar.gz") && !a.name.contains(".sha"))?;
-
-            Some(ProtonUpAvailableVersion {
-                provider: "luxtorpeda".to_string(),
-                version: r.tag_name,
-                release_url: Some(r.html_url),
-                download_url: Some(tarball.browser_download_url.clone()),
-                asset_size: Some(tarball.size),
-                checksum_url: Some(checksum_url),
-                checksum_kind: Some("sha256".to_string()),
-                published_at: r.published_at,
-            })
-        })
-        .collect()
+fn releases_to_versions(
+    releases: Vec<GhRelease>,
+    include_prereleases: bool,
+) -> Vec<ProtonUpAvailableVersion> {
+    build_versions_from_releases(
+        releases,
+        "luxtorpeda",
+        MAX_RELEASES,
+        include_prereleases,
+        "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download",
+        "SHA256SUMS",
+        |asset| asset.name.ends_with(".tar.gz") && !asset.name.contains(".sha"),
+    )
 }
 
 /// The GitHub Releases API URL used by this provider.
@@ -154,7 +140,7 @@ mod tests {
     fn parse_releases_luxtorpeda_shapes_tags() {
         let releases = vec![make_release("10", false, false, vec![tar_gz_asset("10")])];
 
-        let versions = releases_to_versions(releases);
+        let versions = releases_to_versions(releases, false);
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.provider, "luxtorpeda");

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
@@ -193,9 +193,11 @@ pub(super) fn find_matching_sha512sum<'a>(
 
 /// Pick the primary downloadable archive for a release.
 ///
-/// GE-Proton publishes `.tar.gz`. Proton-CachyOS publishes `.tar.xz` for
-/// several architectures; we prefer the Linux x86_64 baseline, then x86_64_v3,
-/// then any non-ARM `.tar.xz`.
+/// GE-Proton publishes `.tar.gz`. Proton-EM publishes `.tar.xz`. Proton-CachyOS
+/// publishes `.tar.xz` for several architectures; we prefer the Linux x86_64
+/// baseline, then x86_64_v3, then any non-ARM `.tar.xz`. Other providers get
+/// the first `.tar.gz` / `.tar.xz` the upstream lists (GitHub returns assets
+/// in upload order, which puts the primary archive first for these repos).
 pub(super) fn pick_tarball_asset<'a>(
     assets: &'a [GhAsset],
     provider_id: &str,
@@ -219,7 +221,9 @@ pub(super) fn pick_tarball_asset<'a>(
             .copied()
             .or_else(|| xz.first().copied())
     } else {
-        assets.iter().find(|a| a.name.ends_with(".tar.gz"))
+        assets
+            .iter()
+            .find(|a| a.name.ends_with(".tar.gz") || a.name.ends_with(".tar.xz"))
     }
 }
 

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
@@ -187,6 +187,24 @@ pub(super) async fn fetch_github_releases(
     Ok(releases)
 }
 
+/// Fetch GitHub releases and convert them into provider versions using the
+/// shared archive-selection rules.
+pub(super) async fn fetch_github_versions(
+    client: &reqwest::Client,
+    url: &str,
+    provider_id: &str,
+    max: usize,
+    include_prereleases: bool,
+) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
+    let releases = fetch_github_releases(client, url).await?;
+    Ok(parse_releases(
+        releases,
+        provider_id,
+        max,
+        include_prereleases,
+    ))
+}
+
 // ── Shared GitHub Releases API types (used by both providers) ─────────────────
 
 /// A single release from the GitHub Releases API.
@@ -302,8 +320,8 @@ pub(super) fn parse_releases(
     releases
         .into_iter()
         .filter(|r| !r.draft && (include_prereleases || !r.prerelease))
-        .take(max)
         .filter_map(|r| gh_release_to_version(r, provider_id))
+        .take(max)
         .collect()
 }
 
@@ -323,7 +341,6 @@ where
     releases
         .into_iter()
         .filter(|r| !r.draft && (include_prereleases || !r.prerelease))
-        .take(max)
         .filter_map(|r| {
             let tarball = r.assets.iter().find(|a| asset_filter(a))?;
             let checksum_url = format!("{checksum_base_url}/{}/{}", r.tag_name, checksum_filename);
@@ -338,6 +355,7 @@ where
                 published_at: r.published_at,
             })
         })
+        .take(max)
         .collect()
 }
 
@@ -346,6 +364,42 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_release(
+        tag_name: &str,
+        draft: bool,
+        prerelease: bool,
+        assets: Vec<GhAsset>,
+    ) -> GhRelease {
+        GhRelease {
+            tag_name: tag_name.to_string(),
+            html_url: format!("https://github.com/example/releases/tag/{tag_name}"),
+            draft,
+            prerelease,
+            assets,
+            published_at: Some("2026-04-17T12:00:00Z".to_string()),
+        }
+    }
+
+    fn tar_gz_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("{tag_name}.tar.gz"),
+            browser_download_url: format!(
+                "https://github.com/example/releases/download/{tag_name}/{tag_name}.tar.gz"
+            ),
+            size: 1234,
+        }
+    }
+
+    fn checksum_only_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("{tag_name}.sha512sum"),
+            browser_download_url: format!(
+                "https://github.com/example/releases/download/{tag_name}/{tag_name}.sha512sum"
+            ),
+            size: 128,
+        }
+    }
 
     #[test]
     fn registry_contains_ge_proton_and_proton_cachyos() {
@@ -413,5 +467,70 @@ mod tests {
         assert_eq!(parsed.display_name, first.display_name);
         assert_eq!(parsed.supports_install, first.supports_install);
         assert_eq!(parsed.checksum_kind, first.checksum_kind);
+    }
+
+    #[test]
+    fn parse_releases_caps_successful_versions_instead_of_attempted_releases() {
+        let releases = vec![
+            make_release(
+                "invalid-1",
+                false,
+                false,
+                vec![checksum_only_asset("invalid-1")],
+            ),
+            make_release(
+                "invalid-2",
+                false,
+                false,
+                vec![checksum_only_asset("invalid-2")],
+            ),
+            make_release("valid-1", false, false, vec![tar_gz_asset("valid-1")]),
+            make_release("valid-2", false, false, vec![tar_gz_asset("valid-2")]),
+        ];
+
+        let versions = parse_releases(releases, "ge-proton", 2, false);
+        let tags: Vec<&str> = versions
+            .iter()
+            .map(|version| version.version.as_str())
+            .collect();
+
+        assert_eq!(tags, vec!["valid-1", "valid-2"]);
+    }
+
+    #[cfg(feature = "experimental-providers")]
+    #[test]
+    fn build_versions_from_releases_caps_successful_versions_instead_of_attempted_releases() {
+        let releases = vec![
+            make_release(
+                "invalid-1",
+                false,
+                false,
+                vec![checksum_only_asset("invalid-1")],
+            ),
+            make_release(
+                "invalid-2",
+                false,
+                false,
+                vec![checksum_only_asset("invalid-2")],
+            ),
+            make_release("valid-1", false, false, vec![tar_gz_asset("valid-1")]),
+            make_release("valid-2", false, false, vec![tar_gz_asset("valid-2")]),
+        ];
+
+        let versions = build_versions_from_releases(
+            releases,
+            "boxtron",
+            2,
+            false,
+            "https://github.com/example/releases/download",
+            "SHA256SUMS",
+            |asset| asset.name.ends_with(".tar.gz"),
+        );
+        let tags: Vec<&str> = versions
+            .iter()
+            .map(|version| version.version.as_str())
+            .collect();
+
+        assert_eq!(tags, vec!["valid-1", "valid-2"]);
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
@@ -91,8 +91,7 @@ pub trait ProtonReleaseProvider: Send + Sync {
 
 /// All active providers in priority order.
 ///
-pub fn registry(include_prereleases: bool) -> Vec<Arc<dyn ProtonReleaseProvider>> {
-    let _ = include_prereleases;
+pub fn registry() -> Vec<Arc<dyn ProtonReleaseProvider>> {
     #[allow(unused_mut)]
     let mut providers: Vec<Arc<dyn ProtonReleaseProvider>> = vec![
         Arc::new(ge_proton::GeProtonProvider::new()),
@@ -109,7 +108,7 @@ pub fn registry(include_prereleases: bool) -> Vec<Arc<dyn ProtonReleaseProvider>
 
 /// Look up a provider by its stable machine-readable id.
 pub fn find_provider_by_id(id: &str) -> Option<Arc<dyn ProtonReleaseProvider>> {
-    registry(false).into_iter().find(|p| p.id() == id)
+    registry().into_iter().find(|p| p.id() == id)
 }
 
 // ── Provider descriptor ───────────────────────────────────────────────────────
@@ -138,10 +137,54 @@ impl ProtonUpProviderDescriptor {
 ///
 /// Batch 4 will consume this from a Tauri handler.
 pub fn describe_providers() -> Vec<ProtonUpProviderDescriptor> {
-    registry(false)
+    registry()
         .iter()
         .map(|p| ProtonUpProviderDescriptor::from_provider(p.as_ref()))
         .collect()
+}
+
+// ── Shared GitHub fetch helper ────────────────────────────────────────────────
+
+/// Maximum response body size accepted from the GitHub Releases API.
+///
+/// A trickle attack can still buffer a large payload even with a 10 s timeout;
+/// this ceiling caps the byte volume we are willing to deserialize.
+const MAX_CATALOG_BYTES: u64 = 10 * 1024 * 1024; // 10 MiB
+
+/// Fetch and deserialize a GitHub Releases API response.
+///
+/// Enforces a [`MAX_CATALOG_BYTES`] ceiling on the `Content-Length` header before
+/// deserializing. All five providers share this helper so the guard is applied
+/// consistently.
+pub(super) async fn fetch_github_releases(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<Vec<GhRelease>, ProviderError> {
+    use reqwest::StatusCode;
+
+    let response = client
+        .get(url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await?;
+
+    if response.status() == StatusCode::NOT_FOUND {
+        return Ok(Vec::new());
+    }
+
+    let response = response.error_for_status()?;
+
+    if let Some(len) = response.content_length() {
+        if len > MAX_CATALOG_BYTES {
+            return Err(ProviderError::Parse(format!(
+                "GitHub Releases response too large: {len} bytes (limit {MAX_CATALOG_BYTES})"
+            )));
+        }
+    }
+
+    let releases = response.json::<Vec<GhRelease>>().await?;
+    Ok(releases)
 }
 
 // ── Shared GitHub Releases API types (used by both providers) ─────────────────
@@ -306,7 +349,7 @@ mod tests {
 
     #[test]
     fn registry_contains_ge_proton_and_proton_cachyos() {
-        let ids: Vec<&str> = registry(false).iter().map(|p| p.id()).collect();
+        let ids: Vec<&str> = registry().iter().map(|p| p.id()).collect();
         assert!(
             ids.contains(&"ge-proton"),
             "registry must include ge-proton"
@@ -324,7 +367,7 @@ mod tests {
     #[cfg(feature = "experimental-providers")]
     #[test]
     fn registry_contains_experimental_providers_when_feature_enabled() {
-        let ids: Vec<&str> = registry(false).iter().map(|p| p.id()).collect();
+        let ids: Vec<&str> = registry().iter().map(|p| p.id()).collect();
         assert!(
             ids.contains(&"luxtorpeda"),
             "registry must include luxtorpeda with experimental-providers feature"

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
@@ -1,0 +1,337 @@
+//! Provider trait and shared GitHub Releases parsing infrastructure.
+//!
+//! Each provider (GE-Proton, Proton-CachyOS, …) implements [`ProtonReleaseProvider`]
+//! and is registered in [`registry`]. `catalog.rs` iterates the registry rather
+//! than hard-coding per-provider branches.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use super::ProtonUpAvailableVersion;
+
+pub mod ge_proton;
+pub mod proton_cachyos;
+pub mod proton_em;
+
+#[cfg(feature = "experimental-providers")]
+pub mod boxtron;
+#[cfg(feature = "experimental-providers")]
+pub mod luxtorpeda;
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Errors that a provider's `fetch` implementation may surface.
+#[derive(Debug)]
+pub enum ProviderError {
+    Http(reqwest::Error),
+    Parse(String),
+}
+
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "http error: {e}"),
+            Self::Parse(msg) => write!(f, "parse error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Http(e) => Some(e),
+            Self::Parse(_) => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for ProviderError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::Http(e)
+    }
+}
+
+// ── Checksum kind ─────────────────────────────────────────────────────────────
+
+/// How a provider publishes checksums alongside its release archives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChecksumKind {
+    Sha512Sidecar,
+    Sha256Manifest,
+    None,
+}
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+/// A Proton compatibility-tool release provider.
+///
+/// Implementations are stateless; they carry only static configuration.
+#[async_trait]
+pub trait ProtonReleaseProvider: Send + Sync {
+    /// Stable machine-readable identifier (e.g. `"ge-proton"`).
+    fn id(&self) -> &'static str;
+    /// Human-readable display name.
+    fn display_name(&self) -> &'static str;
+    /// Whether CrossHook's native install path supports this provider.
+    fn supports_install(&self) -> bool;
+    /// Checksum strategy used by this provider's releases.
+    fn checksum_kind(&self) -> ChecksumKind;
+    /// Fetch available releases from upstream.
+    async fn fetch(
+        &self,
+        client: &reqwest::Client,
+        include_prereleases: bool,
+    ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError>;
+}
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+/// All active providers in priority order.
+///
+/// `include_prereleases` is threaded through for future per-provider filtering;
+/// current implementations always exclude drafts and pre-releases regardless.
+pub fn registry(include_prereleases: bool) -> Vec<Arc<dyn ProtonReleaseProvider>> {
+    let _ = include_prereleases;
+    #[allow(unused_mut)]
+    let mut providers: Vec<Arc<dyn ProtonReleaseProvider>> = vec![
+        Arc::new(ge_proton::GeProtonProvider::new()),
+        Arc::new(proton_cachyos::ProtonCachyOsProvider::new()),
+        Arc::new(proton_em::ProtonEmProvider::new()),
+    ];
+    #[cfg(feature = "experimental-providers")]
+    {
+        providers.push(Arc::new(luxtorpeda::LuxtorpedaProvider::new()));
+        providers.push(Arc::new(boxtron::BoxtronProvider::new()));
+    }
+    providers
+}
+
+/// Look up a provider by its stable machine-readable id.
+pub fn find_provider_by_id(id: &str) -> Option<Arc<dyn ProtonReleaseProvider>> {
+    registry(false).into_iter().find(|p| p.id() == id)
+}
+
+// ── Provider descriptor ───────────────────────────────────────────────────────
+
+/// Serialisable snapshot of a provider's static metadata, for IPC/UI use.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProtonUpProviderDescriptor {
+    pub id: String,
+    pub display_name: String,
+    pub supports_install: bool,
+    pub checksum_kind: ChecksumKind,
+}
+
+impl ProtonUpProviderDescriptor {
+    pub fn from_provider(provider: &dyn ProtonReleaseProvider) -> Self {
+        Self {
+            id: provider.id().to_string(),
+            display_name: provider.display_name().to_string(),
+            supports_install: provider.supports_install(),
+            checksum_kind: provider.checksum_kind(),
+        }
+    }
+}
+
+/// Describe all registered providers as serialisable DTOs.
+///
+/// Batch 4 will consume this from a Tauri handler.
+pub fn describe_providers() -> Vec<ProtonUpProviderDescriptor> {
+    registry(false)
+        .iter()
+        .map(|p| ProtonUpProviderDescriptor::from_provider(p.as_ref()))
+        .collect()
+}
+
+// ── Shared GitHub Releases API types (used by both providers) ─────────────────
+
+/// A single release from the GitHub Releases API.
+#[derive(Debug, Deserialize)]
+pub(super) struct GhRelease {
+    pub tag_name: String,
+    pub html_url: String,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(default)]
+    pub prerelease: bool,
+    #[serde(default)]
+    pub assets: Vec<GhAsset>,
+    /// ISO-8601 UTC publication timestamp from GitHub. Absent on some drafts.
+    #[serde(default)]
+    pub published_at: Option<String>,
+}
+
+/// A single asset attached to a GitHub release.
+#[derive(Debug, Deserialize)]
+pub(super) struct GhAsset {
+    pub name: String,
+    pub browser_download_url: String,
+    pub size: u64,
+}
+
+// ── Shared parsing helpers ────────────────────────────────────────────────────
+
+/// Strip `.tar.gz` / `.tar.xz` from an asset filename so we can match
+/// sidecar `.sha512sum` files.
+pub(super) fn tarball_stem(name: &str) -> Option<&str> {
+    name.strip_suffix(".tar.gz")
+        .or_else(|| name.strip_suffix(".tar.xz"))
+}
+
+/// Find the `.sha512sum` sidecar asset for `tarball_name`.
+pub(super) fn find_matching_sha512sum<'a>(
+    assets: &'a [GhAsset],
+    tarball_name: &str,
+) -> Option<&'a GhAsset> {
+    let stem = tarball_stem(tarball_name)?;
+    let expected = format!("{stem}.sha512sum");
+    assets.iter().find(|a| a.name == expected)
+}
+
+/// Pick the primary downloadable archive for a release.
+///
+/// GE-Proton publishes `.tar.gz`. Proton-CachyOS publishes `.tar.xz` for
+/// several architectures; we prefer the Linux x86_64 baseline, then x86_64_v3,
+/// then any non-ARM `.tar.xz`.
+pub(super) fn pick_tarball_asset<'a>(
+    assets: &'a [GhAsset],
+    provider_id: &str,
+) -> Option<&'a GhAsset> {
+    if provider_id == "proton-cachyos" {
+        let xz: Vec<&GhAsset> = assets
+            .iter()
+            .filter(|a| a.name.ends_with(".tar.xz"))
+            .collect();
+
+        let baseline_x86 = xz.iter().find(|a| {
+            let n = a.name.as_str();
+            n.contains("x86_64") && !n.contains("x86_64_v3")
+        });
+        let v3 = xz.iter().find(|a| a.name.contains("x86_64_v3"));
+        let non_arm = xz.iter().find(|a| !a.name.to_lowercase().contains("arm"));
+
+        baseline_x86
+            .or(v3)
+            .or(non_arm)
+            .copied()
+            .or_else(|| xz.first().copied())
+    } else {
+        assets.iter().find(|a| a.name.ends_with(".tar.gz"))
+    }
+}
+
+/// Convert a single GitHub release into a `ProtonUpAvailableVersion`.
+///
+/// Returns `None` when no supported archive asset is found.
+pub(super) fn gh_release_to_version(
+    release: GhRelease,
+    provider_id: &str,
+) -> Option<ProtonUpAvailableVersion> {
+    let tarball = pick_tarball_asset(&release.assets, provider_id)?;
+    let checksum = find_matching_sha512sum(&release.assets, &tarball.name);
+
+    Some(ProtonUpAvailableVersion {
+        provider: provider_id.to_string(),
+        version: release.tag_name,
+        release_url: Some(release.html_url),
+        download_url: Some(tarball.browser_download_url.clone()),
+        asset_size: Some(tarball.size),
+        checksum_url: checksum.map(|a| a.browser_download_url.clone()),
+        checksum_kind: checksum.map(|_| "sha512".to_string()),
+        published_at: release.published_at,
+    })
+}
+
+/// Convert a list of GitHub releases into `ProtonUpAvailableVersion` entries,
+/// skipping drafts, pre-releases, and releases without a supported tarball.
+/// Caps at `max` entries.
+pub(super) fn parse_releases(
+    releases: Vec<GhRelease>,
+    provider_id: &str,
+    max: usize,
+) -> Vec<ProtonUpAvailableVersion> {
+    releases
+        .into_iter()
+        .filter(|r| !r.draft && !r.prerelease)
+        .take(max)
+        .filter_map(|r| gh_release_to_version(r, provider_id))
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_contains_ge_proton_and_proton_cachyos() {
+        let ids: Vec<&str> = registry(false).iter().map(|p| p.id()).collect();
+        assert!(
+            ids.contains(&"ge-proton"),
+            "registry must include ge-proton"
+        );
+        assert!(
+            ids.contains(&"proton-cachyos"),
+            "registry must include proton-cachyos"
+        );
+        assert!(
+            ids.contains(&"proton-em"),
+            "registry must include proton-em"
+        );
+    }
+
+    #[cfg(feature = "experimental-providers")]
+    #[test]
+    fn registry_contains_experimental_providers_when_feature_enabled() {
+        let ids: Vec<&str> = registry(false).iter().map(|p| p.id()).collect();
+        assert!(
+            ids.contains(&"luxtorpeda"),
+            "registry must include luxtorpeda with experimental-providers feature"
+        );
+        assert!(
+            ids.contains(&"boxtron"),
+            "registry must include boxtron with experimental-providers feature"
+        );
+    }
+
+    #[test]
+    fn find_provider_by_id_returns_known_provider() {
+        let p = find_provider_by_id("ge-proton").expect("ge-proton must be found");
+        assert_eq!(p.id(), "ge-proton");
+    }
+
+    #[test]
+    fn find_provider_by_id_returns_none_for_unknown() {
+        assert!(
+            find_provider_by_id("nonexistent-provider").is_none(),
+            "unknown id must return None"
+        );
+    }
+
+    #[test]
+    fn describe_providers_includes_at_least_two_entries() {
+        let descriptors = describe_providers();
+        assert!(
+            descriptors.len() >= 2,
+            "expected at least two provider descriptors, got {}",
+            descriptors.len()
+        );
+    }
+
+    #[test]
+    fn descriptor_round_trips_via_serde_json() {
+        let descriptors = describe_providers();
+        let first = descriptors.first().expect("at least one descriptor");
+        let json = serde_json::to_string(first).expect("serialisation must succeed");
+        let parsed: ProtonUpProviderDescriptor =
+            serde_json::from_str(&json).expect("deserialisation must succeed");
+        assert_eq!(parsed.id, first.id);
+        assert_eq!(parsed.display_name, first.display_name);
+        assert_eq!(parsed.supports_install, first.supports_install);
+        assert_eq!(parsed.checksum_kind, first.checksum_kind);
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/mod.rs
@@ -91,8 +91,6 @@ pub trait ProtonReleaseProvider: Send + Sync {
 
 /// All active providers in priority order.
 ///
-/// `include_prereleases` is threaded through for future per-provider filtering;
-/// current implementations always exclude drafts and pre-releases regardless.
 pub fn registry(include_prereleases: bool) -> Vec<Arc<dyn ProtonReleaseProvider>> {
     let _ = include_prereleases;
     #[allow(unused_mut)]
@@ -256,12 +254,47 @@ pub(super) fn parse_releases(
     releases: Vec<GhRelease>,
     provider_id: &str,
     max: usize,
+    include_prereleases: bool,
 ) -> Vec<ProtonUpAvailableVersion> {
     releases
         .into_iter()
-        .filter(|r| !r.draft && !r.prerelease)
+        .filter(|r| !r.draft && (include_prereleases || !r.prerelease))
         .take(max)
         .filter_map(|r| gh_release_to_version(r, provider_id))
+        .collect()
+}
+
+#[cfg_attr(not(feature = "experimental-providers"), allow(dead_code))]
+pub(super) fn build_versions_from_releases<F>(
+    releases: Vec<GhRelease>,
+    provider_id: &str,
+    max: usize,
+    include_prereleases: bool,
+    checksum_base_url: &str,
+    checksum_filename: &str,
+    asset_filter: F,
+) -> Vec<ProtonUpAvailableVersion>
+where
+    F: Fn(&GhAsset) -> bool,
+{
+    releases
+        .into_iter()
+        .filter(|r| !r.draft && (include_prereleases || !r.prerelease))
+        .take(max)
+        .filter_map(|r| {
+            let tarball = r.assets.iter().find(|a| asset_filter(a))?;
+            let checksum_url = format!("{checksum_base_url}/{}/{}", r.tag_name, checksum_filename);
+            Some(ProtonUpAvailableVersion {
+                provider: provider_id.to_string(),
+                version: r.tag_name,
+                release_url: Some(r.html_url),
+                download_url: Some(tarball.browser_download_url.clone()),
+                asset_size: Some(tarball.size),
+                checksum_url: Some(checksum_url),
+                checksum_kind: Some("sha256".to_string()),
+                published_at: r.published_at,
+            })
+        })
         .collect()
 }
 

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
@@ -4,9 +4,7 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{
-    fetch_github_releases, parse_releases, ChecksumKind, ProtonReleaseProvider, ProviderError,
-};
+use super::{fetch_github_versions, ChecksumKind, ProtonReleaseProvider, ProviderError};
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/CachyOS/proton-cachyos/releases";
 const MAX_RELEASES: usize = 30;
@@ -49,13 +47,14 @@ impl ProtonReleaseProvider for ProtonCachyOsProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
-        Ok(parse_releases(
-            releases,
+        fetch_github_versions(
+            client,
+            GH_RELEASES_URL,
             self.id(),
             MAX_RELEASES,
             include_prereleases,
-        ))
+        )
+        .await
     }
 }
 
@@ -73,7 +72,7 @@ pub fn cache_key() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{GhAsset, GhRelease};
+    use super::super::{parse_releases, GhAsset, GhRelease};
     use super::*;
 
     fn make_release(

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
@@ -1,0 +1,212 @@
+//! Proton-CachyOS provider — fetches releases from CachyOS/proton-cachyos.
+
+use async_trait::async_trait;
+
+use crate::protonup::ProtonUpAvailableVersion;
+
+use super::{parse_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+
+const GH_RELEASES_URL: &str = "https://api.github.com/repos/CachyOS/proton-cachyos/releases";
+const MAX_RELEASES: usize = 30;
+
+/// Provider for Proton-CachyOS (CachyOS-optimised Proton fork).
+pub struct ProtonCachyOsProvider;
+
+impl ProtonCachyOsProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ProtonCachyOsProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProtonReleaseProvider for ProtonCachyOsProvider {
+    fn id(&self) -> &'static str {
+        "proton-cachyos"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Proton-CachyOS"
+    }
+
+    fn supports_install(&self) -> bool {
+        true
+    }
+
+    fn checksum_kind(&self) -> ChecksumKind {
+        ChecksumKind::Sha512Sidecar
+    }
+
+    async fn fetch(
+        &self,
+        client: &reqwest::Client,
+        _include_prereleases: bool,
+    ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
+        use reqwest::StatusCode;
+
+        let response = client
+            .get(GH_RELEASES_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(Vec::new());
+        }
+
+        let releases = response
+            .error_for_status()?
+            .json::<Vec<GhRelease>>()
+            .await?;
+
+        Ok(parse_releases(releases, self.id(), MAX_RELEASES))
+    }
+}
+
+/// The GitHub Releases API URL used by this provider.
+///
+/// Exposed for `catalog.rs` to use as the SQLite cache key URL.
+pub fn gh_releases_url() -> &'static str {
+    GH_RELEASES_URL
+}
+
+/// SQLite cache key for this provider's catalog.
+pub fn cache_key() -> &'static str {
+    "protonup:catalog:proton-cachyos"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{GhAsset, GhRelease};
+    use super::*;
+
+    fn make_release(
+        tag_name: &str,
+        draft: bool,
+        prerelease: bool,
+        assets: Vec<GhAsset>,
+    ) -> GhRelease {
+        GhRelease {
+            tag_name: tag_name.to_string(),
+            html_url: format!("https://github.com/example/releases/tag/{tag_name}"),
+            draft,
+            prerelease,
+            assets,
+            published_at: Some("2026-03-30T12:00:00Z".to_string()),
+        }
+    }
+
+    fn tar_xz_named(name: &str) -> GhAsset {
+        GhAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://github.com/releases/download/x/{name}"),
+            size: 300_000_000,
+        }
+    }
+
+    fn sha512_named(name: &str) -> GhAsset {
+        GhAsset {
+            name: name.to_string(),
+            browser_download_url: format!("https://github.com/releases/download/x/{name}"),
+            size: 128,
+        }
+    }
+
+    #[test]
+    fn parse_releases_stamps_proton_cachyos_provider() {
+        let tb = "proton-cachyos-10.0-20260330-slr-x86_64.tar.xz";
+        let releases = vec![make_release(
+            "cachyos-10.0-20260330-slr",
+            false,
+            false,
+            vec![
+                tar_xz_named(tb),
+                sha512_named("proton-cachyos-10.0-20260330-slr-x86_64.sha512sum"),
+            ],
+        )];
+
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].provider, "proton-cachyos");
+        assert_eq!(versions[0].version, "cachyos-10.0-20260330-slr");
+        assert!(versions[0]
+            .download_url
+            .as_deref()
+            .unwrap()
+            .ends_with(".tar.xz"));
+        assert!(versions[0]
+            .checksum_url
+            .as_deref()
+            .unwrap()
+            .contains("x86_64.sha512sum"));
+    }
+
+    #[test]
+    fn proton_cachyos_prefers_baseline_x86_64_over_v3_and_arm() {
+        let releases = vec![make_release(
+            "cachyos-test",
+            false,
+            false,
+            vec![
+                tar_xz_named("proton-cachyos-test-arm64.tar.xz"),
+                tar_xz_named("proton-cachyos-test-x86_64_v3.tar.xz"),
+                tar_xz_named("proton-cachyos-test-x86_64.tar.xz"),
+                sha512_named("proton-cachyos-test-x86_64.sha512sum"),
+                sha512_named("proton-cachyos-test-x86_64_v3.sha512sum"),
+            ],
+        )];
+
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        let url = versions[0].download_url.as_deref().unwrap();
+        assert!(
+            url.contains("x86_64.tar.xz") && !url.contains("x86_64_v3"),
+            "expected baseline x86_64, got {url}"
+        );
+    }
+
+    #[test]
+    fn proton_cachyos_skip_draft() {
+        let releases = vec![
+            make_release(
+                "cachyos-draft",
+                true,
+                false,
+                vec![tar_xz_named("proton-cachyos-draft-x86_64.tar.xz")],
+            ),
+            make_release(
+                "cachyos-stable",
+                false,
+                false,
+                vec![tar_xz_named("proton-cachyos-stable-x86_64.tar.xz")],
+            ),
+        ];
+
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "cachyos-stable");
+    }
+
+    #[test]
+    fn proton_cachyos_caps_at_max() {
+        let releases: Vec<GhRelease> = (0..MAX_RELEASES + 5)
+            .map(|i| {
+                make_release(
+                    &format!("cachyos-{i}"),
+                    false,
+                    false,
+                    vec![tar_xz_named(&format!("proton-cachyos-{i}-x86_64.tar.xz"))],
+                )
+            })
+            .collect();
+
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        assert_eq!(versions.len(), MAX_RELEASES);
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
@@ -4,7 +4,9 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{parse_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+use super::{
+    fetch_github_releases, parse_releases, ChecksumKind, ProtonReleaseProvider, ProviderError,
+};
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/CachyOS/proton-cachyos/releases";
 const MAX_RELEASES: usize = 30;
@@ -47,24 +49,7 @@ impl ProtonReleaseProvider for ProtonCachyOsProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        use reqwest::StatusCode;
-
-        let response = client
-            .get(GH_RELEASES_URL)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(Vec::new());
-        }
-
-        let releases = response
-            .error_for_status()?
-            .json::<Vec<GhRelease>>()
-            .await?;
-
+        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
         Ok(parse_releases(
             releases,
             self.id(),

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_cachyos.rs
@@ -45,7 +45,7 @@ impl ProtonReleaseProvider for ProtonCachyOsProvider {
     async fn fetch(
         &self,
         client: &reqwest::Client,
-        _include_prereleases: bool,
+        include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         use reqwest::StatusCode;
 
@@ -65,7 +65,12 @@ impl ProtonReleaseProvider for ProtonCachyOsProvider {
             .json::<Vec<GhRelease>>()
             .await?;
 
-        Ok(parse_releases(releases, self.id(), MAX_RELEASES))
+        Ok(parse_releases(
+            releases,
+            self.id(),
+            MAX_RELEASES,
+            include_prereleases,
+        ))
     }
 }
 
@@ -131,7 +136,7 @@ mod tests {
             ],
         )];
 
-        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].provider, "proton-cachyos");
         assert_eq!(versions[0].version, "cachyos-10.0-20260330-slr");
@@ -162,7 +167,7 @@ mod tests {
             ],
         )];
 
-        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         let url = versions[0].download_url.as_deref().unwrap();
         assert!(
@@ -188,7 +193,7 @@ mod tests {
             ),
         ];
 
-        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].version, "cachyos-stable");
     }
@@ -206,7 +211,7 @@ mod tests {
             })
             .collect();
 
-        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES);
+        let versions = parse_releases(releases, "proton-cachyos", MAX_RELEASES, false);
         assert_eq!(versions.len(), MAX_RELEASES);
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
@@ -51,7 +51,7 @@ impl ProtonReleaseProvider for ProtonEmProvider {
     async fn fetch(
         &self,
         client: &reqwest::Client,
-        _include_prereleases: bool,
+        include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
         use reqwest::StatusCode;
 
@@ -71,7 +71,12 @@ impl ProtonReleaseProvider for ProtonEmProvider {
             .json::<Vec<GhRelease>>()
             .await?;
 
-        Ok(parse_releases(releases, self.id(), MAX_RELEASES))
+        Ok(parse_releases(
+            releases,
+            self.id(),
+            MAX_RELEASES,
+            include_prereleases,
+        ))
     }
 }
 
@@ -147,7 +152,7 @@ mod tests {
             ),
         ];
 
-        let versions = parse_releases(releases, "proton-em", MAX_RELEASES);
+        let versions = parse_releases(releases, "proton-em", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         assert_eq!(versions[0].version, "proton-em-9.0");
     }
@@ -161,7 +166,7 @@ mod tests {
             vec![tar_xz_asset("EM-10.0-37-HDR")],
         )];
 
-        let versions = parse_releases(releases, "proton-em", MAX_RELEASES);
+        let versions = parse_releases(releases, "proton-em", MAX_RELEASES, false);
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.provider, "proton-em");

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
@@ -1,0 +1,180 @@
+//! Proton-EM provider — fetches releases from Etaash-mathamsetty/Proton.
+//!
+//! Canonical upstream repo (community-accepted): https://github.com/Etaash-mathamsetty/Proton
+//! If this fork moves, GloriousEggroll/proton-em is a possible fallback to verify.
+
+use async_trait::async_trait;
+
+use crate::protonup::ProtonUpAvailableVersion;
+
+use super::{parse_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+
+const GH_RELEASES_URL: &str = "https://api.github.com/repos/Etaash-mathamsetty/Proton/releases";
+const MAX_RELEASES: usize = 30;
+
+/// Provider for Proton-EM (community Proton fork by Etaash-mathamsetty).
+pub struct ProtonEmProvider;
+
+impl ProtonEmProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ProtonEmProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ProtonReleaseProvider for ProtonEmProvider {
+    fn id(&self) -> &'static str {
+        "proton-em"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Proton-EM"
+    }
+
+    fn supports_install(&self) -> bool {
+        true
+    }
+
+    /// Most Proton-EM releases do not ship checksum sidecars.
+    /// `install.rs` handles the `None` case by emitting a warning and a
+    /// `Phase::Verifying` progress message without failing the install.
+    fn checksum_kind(&self) -> ChecksumKind {
+        ChecksumKind::None
+    }
+
+    async fn fetch(
+        &self,
+        client: &reqwest::Client,
+        _include_prereleases: bool,
+    ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
+        use reqwest::StatusCode;
+
+        let response = client
+            .get(GH_RELEASES_URL)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(Vec::new());
+        }
+
+        let releases = response
+            .error_for_status()?
+            .json::<Vec<GhRelease>>()
+            .await?;
+
+        Ok(parse_releases(releases, self.id(), MAX_RELEASES))
+    }
+}
+
+/// The GitHub Releases API URL used by this provider.
+///
+/// Exposed for `catalog.rs` to use as the SQLite cache key URL.
+pub fn gh_releases_url() -> &'static str {
+    GH_RELEASES_URL
+}
+
+/// SQLite cache key for this provider's catalog.
+pub fn cache_key() -> &'static str {
+    "protonup:catalog:proton-em"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{GhAsset, GhRelease};
+    use super::*;
+
+    fn make_release(
+        tag_name: &str,
+        draft: bool,
+        prerelease: bool,
+        assets: Vec<GhAsset>,
+    ) -> GhRelease {
+        GhRelease {
+            tag_name: tag_name.to_string(),
+            html_url: format!(
+                "https://github.com/Etaash-mathamsetty/Proton/releases/tag/{tag_name}"
+            ),
+            draft,
+            prerelease,
+            assets,
+            published_at: Some("2025-12-01T08:00:00Z".to_string()),
+        }
+    }
+
+    fn tar_gz_asset(tag_name: &str) -> GhAsset {
+        GhAsset {
+            name: format!("{tag_name}.tar.gz"),
+            browser_download_url: format!(
+                "https://github.com/Etaash-mathamsetty/Proton/releases/download/{tag_name}/{tag_name}.tar.gz"
+            ),
+            size: 2_100_000,
+        }
+    }
+
+    #[test]
+    fn parse_releases_proton_em_skips_drafts_and_prereleases() {
+        let releases = vec![
+            make_release(
+                "proton-em-9.0-draft",
+                true,
+                false,
+                vec![tar_gz_asset("proton-em-9.0-draft")],
+            ),
+            make_release(
+                "proton-em-9.0-rc1",
+                false,
+                true,
+                vec![tar_gz_asset("proton-em-9.0-rc1")],
+            ),
+            make_release(
+                "proton-em-9.0",
+                false,
+                false,
+                vec![tar_gz_asset("proton-em-9.0")],
+            ),
+        ];
+
+        let versions = parse_releases(releases, "proton-em", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0].version, "proton-em-9.0");
+    }
+
+    #[test]
+    fn parse_releases_proton_em_picks_tarball() {
+        let releases = vec![make_release(
+            "proton-em-9.0",
+            false,
+            false,
+            vec![tar_gz_asset("proton-em-9.0")],
+        )];
+
+        let versions = parse_releases(releases, "proton-em", MAX_RELEASES);
+        assert_eq!(versions.len(), 1);
+        let v = &versions[0];
+        assert_eq!(v.provider, "proton-em");
+        assert_eq!(v.version, "proton-em-9.0");
+        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.gz"));
+        assert!(v.checksum_url.is_none());
+    }
+
+    #[test]
+    fn proton_em_reports_supports_install_true() {
+        let provider = ProtonEmProvider::new();
+        assert!(provider.supports_install());
+    }
+
+    #[test]
+    fn proton_em_checksum_kind_is_none() {
+        let provider = ProtonEmProvider::new();
+        assert_eq!(provider.checksum_kind(), ChecksumKind::None);
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
@@ -110,11 +110,15 @@ mod tests {
         }
     }
 
-    fn tar_gz_asset(tag_name: &str) -> GhAsset {
+    /// Realistic Proton-EM asset shape: `proton-<tag>.tar.xz` (upstream ships
+    /// `.tar.xz`, not `.tar.gz`). Earlier tests used `.tar.gz` which passed
+    /// only because the picker's non-CachyOS branch was limited to `.tar.gz`
+    /// — that shortcut silently dropped every real EM release.
+    fn tar_xz_asset(tag_name: &str) -> GhAsset {
         GhAsset {
-            name: format!("{tag_name}.tar.gz"),
+            name: format!("proton-{tag_name}.tar.xz"),
             browser_download_url: format!(
-                "https://github.com/Etaash-mathamsetty/Proton/releases/download/{tag_name}/{tag_name}.tar.gz"
+                "https://github.com/Etaash-mathamsetty/Proton/releases/download/{tag_name}/proton-{tag_name}.tar.xz"
             ),
             size: 2_100_000,
         }
@@ -127,19 +131,19 @@ mod tests {
                 "proton-em-9.0-draft",
                 true,
                 false,
-                vec![tar_gz_asset("proton-em-9.0-draft")],
+                vec![tar_xz_asset("proton-em-9.0-draft")],
             ),
             make_release(
                 "proton-em-9.0-rc1",
                 false,
                 true,
-                vec![tar_gz_asset("proton-em-9.0-rc1")],
+                vec![tar_xz_asset("proton-em-9.0-rc1")],
             ),
             make_release(
                 "proton-em-9.0",
                 false,
                 false,
-                vec![tar_gz_asset("proton-em-9.0")],
+                vec![tar_xz_asset("proton-em-9.0")],
             ),
         ];
 
@@ -151,18 +155,21 @@ mod tests {
     #[test]
     fn parse_releases_proton_em_picks_tarball() {
         let releases = vec![make_release(
-            "proton-em-9.0",
+            "EM-10.0-37-HDR",
             false,
             false,
-            vec![tar_gz_asset("proton-em-9.0")],
+            vec![tar_xz_asset("EM-10.0-37-HDR")],
         )];
 
         let versions = parse_releases(releases, "proton-em", MAX_RELEASES);
         assert_eq!(versions.len(), 1);
         let v = &versions[0];
         assert_eq!(v.provider, "proton-em");
-        assert_eq!(v.version, "proton-em-9.0");
-        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.gz"));
+        assert_eq!(v.version, "EM-10.0-37-HDR");
+        // Upstream ships `.tar.xz`; picker must not limit itself to `.tar.gz`.
+        assert!(v.download_url.as_deref().unwrap().ends_with(".tar.xz"));
+        // `.sha512sum` sidecars don't exist for EM (it ships `.sha256sum`),
+        // and the provider declares `ChecksumKind::None` so no checksum URL.
         assert!(v.checksum_url.is_none());
     }
 

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{parse_releases, ChecksumKind, GhRelease, ProtonReleaseProvider, ProviderError};
+use super::{
+    fetch_github_releases, parse_releases, ChecksumKind, ProtonReleaseProvider, ProviderError,
+};
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/Etaash-mathamsetty/Proton/releases";
 const MAX_RELEASES: usize = 30;
@@ -53,24 +55,7 @@ impl ProtonReleaseProvider for ProtonEmProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        use reqwest::StatusCode;
-
-        let response = client
-            .get(GH_RELEASES_URL)
-            .header("Accept", "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(Vec::new());
-        }
-
-        let releases = response
-            .error_for_status()?
-            .json::<Vec<GhRelease>>()
-            .await?;
-
+        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
         Ok(parse_releases(
             releases,
             self.id(),

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/providers/proton_em.rs
@@ -7,9 +7,7 @@ use async_trait::async_trait;
 
 use crate::protonup::ProtonUpAvailableVersion;
 
-use super::{
-    fetch_github_releases, parse_releases, ChecksumKind, ProtonReleaseProvider, ProviderError,
-};
+use super::{fetch_github_versions, ChecksumKind, ProtonReleaseProvider, ProviderError};
 
 const GH_RELEASES_URL: &str = "https://api.github.com/repos/Etaash-mathamsetty/Proton/releases";
 const MAX_RELEASES: usize = 30;
@@ -55,13 +53,14 @@ impl ProtonReleaseProvider for ProtonEmProvider {
         client: &reqwest::Client,
         include_prereleases: bool,
     ) -> Result<Vec<ProtonUpAvailableVersion>, ProviderError> {
-        let releases = fetch_github_releases(client, GH_RELEASES_URL).await?;
-        Ok(parse_releases(
-            releases,
+        fetch_github_versions(
+            client,
+            GH_RELEASES_URL,
             self.id(),
             MAX_RELEASES,
             include_prereleases,
-        ))
+        )
+        .await
     }
 }
 
@@ -79,7 +78,7 @@ pub fn cache_key() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{GhAsset, GhRelease};
+    use super::super::{parse_releases, GhAsset, GhRelease};
     use super::*;
 
     fn make_release(

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
@@ -128,6 +128,17 @@ pub fn execute_uninstall(plan: UninstallPlan) -> Result<(), UninstallError> {
     std::fs::remove_dir_all(&plan.tool_dir).map_err(UninstallError::Io)
 }
 
+/// Convenience helper that resolves and executes uninstall in one call.
+///
+/// Intended for callers that do not need to show preflight conflicts.
+pub fn execute_uninstall_for_path(
+    tool_dir: &Path,
+    steam_client_install_path: Option<&Path>,
+) -> Result<(), UninstallError> {
+    let plan = plan_uninstall(tool_dir, steam_client_install_path)?;
+    execute_uninstall(plan)
+}
+
 // ── internal testable core ────────────────────────────────────────────────────
 
 /// Testable variant that accepts injected install-root candidates and steam

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
@@ -160,17 +160,18 @@ fn plan_uninstall_core(
 
     let canonical = std::fs::canonicalize(tool_dir)
         .map_err(|_| UninstallError::NotFound(tool_dir.to_path_buf()))?;
+    let canonical_tool_dir = normalize_tool_dir_path(&canonical);
 
     // ── 2. System-path refusal ────────────────────────────────────────────────
 
     for &root in STEAM_SYSTEM_ROOTS {
-        if canonical.starts_with(root) {
-            return Err(UninstallError::SystemPathRefused(canonical));
+        if canonical_tool_dir.starts_with(root) {
+            return Err(UninstallError::SystemPathRefused(canonical_tool_dir));
         }
     }
     for &prefix in SYSTEM_PREFIX_DENYLIST {
-        if canonical.starts_with(prefix) {
-            return Err(UninstallError::SystemPathRefused(canonical));
+        if canonical_tool_dir.starts_with(prefix) {
+            return Err(UninstallError::SystemPathRefused(canonical_tool_dir));
         }
     }
 
@@ -186,8 +187,8 @@ fn plan_uninstall_core(
         // Canonicalize the candidate path for comparison; fall back to raw if it
         // doesn't exist yet (candidates may point to not-yet-created dirs).
         let candidate_canonical = std::fs::canonicalize(&c.path).unwrap_or_else(|_| c.path.clone());
-        canonical.starts_with(&candidate_canonical)
-            && canonical
+        canonical_tool_dir.starts_with(&candidate_canonical)
+            && canonical_tool_dir
                 .parent()
                 .map(|p| {
                     p == candidate_canonical
@@ -198,12 +199,12 @@ fn plan_uninstall_core(
     });
 
     let Some(candidate) = matching_candidate else {
-        return Err(UninstallError::PathOutsideKnownRoots(canonical));
+        return Err(UninstallError::PathOutsideKnownRoots(canonical_tool_dir));
     };
 
     // ── 4. Profile-mapping scan ───────────────────────────────────────────────
 
-    let tool_id = canonical
+    let tool_id = canonical_tool_dir
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
@@ -217,13 +218,29 @@ fn plan_uninstall_core(
         .collect();
 
     Ok(UninstallPlan {
-        tool_dir: canonical,
+        tool_dir: canonical_tool_dir,
         conflicting_app_ids,
         root_kind: candidate.kind,
     })
 }
 
 // ── private helpers ───────────────────────────────────────────────────────────
+
+fn normalize_tool_dir_path(path: &Path) -> PathBuf {
+    if path.is_file()
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case("proton"))
+    {
+        return path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf());
+    }
+
+    path.to_path_buf()
+}
 
 /// Build a minimal list of Steam root directories for compat-tool mapping
 /// lookups. These are the Steam roots (not the `compatibilitytools.d` subdirs)
@@ -432,6 +449,33 @@ mod tests {
     }
 
     // ── test 5 ────────────────────────────────────────────────────────────────
+
+    /// A discovered compat tool may be represented by its `proton`
+    /// executable path; the uninstall planner should normalize that to the
+    /// containing tool directory.
+    #[test]
+    fn plan_uninstall_accepts_proton_executable_path() {
+        let root = tempdir().unwrap();
+        let tool_name = "proton-EM-10.0-36-HDRTEST";
+        let tool_dir = root.path().join(tool_name);
+        fs::create_dir_all(&tool_dir).unwrap();
+        let proton_exe = tool_dir.join("proton");
+        fs::write(&proton_exe, "#!/bin/sh\n").unwrap();
+
+        let candidates = vec![candidate(
+            root.path().to_path_buf(),
+            InstallRootKind::NativeSteam,
+        )];
+        let mappings = mappings_with("123", tool_name);
+
+        let plan = plan_uninstall_with_mappings(&proton_exe, &candidates, &mappings)
+            .expect("plan should succeed for proton executable path");
+
+        assert_eq!(plan.tool_dir, tool_dir);
+        assert_eq!(plan.conflicting_app_ids, vec!["123".to_string()]);
+    }
+
+    // ── test 6 ────────────────────────────────────────────────────────────────
 
     /// `execute_uninstall` must remove the target directory tree.
     #[test]

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
@@ -1,0 +1,475 @@
+//! Plan / execute split for Proton tool uninstall.
+//!
+//! The two-phase API lets callers show a confirmation dialog with conflict
+//! warnings before any filesystem mutation occurs.
+//!
+//! # Safety model
+//!
+//! System-owned paths (`/usr`, `/opt`, `/snap`, the Flatpak runtime tree, and
+//! the explicit `SYSTEM_COMPAT_TOOL_ROOTS` recognised by Steam) are always
+//! refused. Paths that do not resolve under a known user-writable
+//! `compatibilitytools.d` root are also refused, providing belt-and-suspenders
+//! protection against accidental deletion of unrelated directories.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use crate::protonup::install_root::{resolve_candidates_with, InstallRootKind};
+use crate::steam::proton::collect_compat_tool_mappings;
+
+// ── system-path denylist ──────────────────────────────────────────────────────
+
+/// Explicit Steam system compat-tool roots that must never be touched.
+/// Mirrors the constant in `steam::proton` without re-exporting it.
+const STEAM_SYSTEM_ROOTS: &[&str] = &[
+    "/usr/share/steam/compatibilitytools.d",
+    "/usr/local/share/steam/compatibilitytools.d",
+    "/usr/share/steam/compatibilitytools",
+    "/usr/local/share/steam/compatibilitytools",
+];
+
+/// Broad prefix denylist — belt-and-suspenders on top of `STEAM_SYSTEM_ROOTS`.
+const SYSTEM_PREFIX_DENYLIST: &[&str] = &["/usr", "/opt", "/snap", "/var/lib/flatpak/runtime"];
+
+// ── public types ──────────────────────────────────────────────────────────────
+
+/// A validated, ready-to-execute uninstall plan.
+///
+/// Constructing this value guarantees that `tool_dir` is safe to remove:
+/// it is canonical, under a known user root, and not a system path.
+/// `conflicting_app_ids` is advisory — callers may surface it as a warning
+/// but it does not prevent execution.
+#[derive(Debug, Clone)]
+pub struct UninstallPlan {
+    /// Canonical target directory to remove.
+    pub tool_dir: PathBuf,
+    /// Steam App IDs currently mapped to this tool (warning; does not block).
+    pub conflicting_app_ids: Vec<String>,
+    /// Root kind this tool belongs to (for telemetry / logging).
+    pub root_kind: InstallRootKind,
+}
+
+/// Errors that can occur while planning or executing an uninstall.
+#[derive(Debug)]
+pub enum UninstallError {
+    /// The path resolves to a system-managed location that CrossHook must not touch.
+    SystemPathRefused(PathBuf),
+    /// The path is not under any known user `compatibilitytools.d` root.
+    PathOutsideKnownRoots(PathBuf),
+    /// The path does not exist on disk.
+    NotFound(PathBuf),
+    /// A filesystem error occurred during execution.
+    Io(std::io::Error),
+}
+
+impl fmt::Display for UninstallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SystemPathRefused(p) => {
+                write!(f, "refusing to delete system path {}", p.display())
+            }
+            Self::PathOutsideKnownRoots(p) => write!(
+                f,
+                "path {} is not under a known user compatibilitytools.d root",
+                p.display()
+            ),
+            Self::NotFound(p) => write!(f, "path {} does not exist", p.display()),
+            Self::Io(e) => write!(f, "io error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for UninstallError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+// ── public API ────────────────────────────────────────────────────────────────
+
+/// Build an [`UninstallPlan`] for `tool_dir`.
+///
+/// `steam_client_install_path` is the configured Steam root used to derive
+/// both install-root candidates and the Steam config path for compat-tool
+/// mapping lookups. Pass `None` to fall back to default home-relative paths.
+///
+/// Returns an error without touching the filesystem if any safety check fails.
+pub fn plan_uninstall(
+    tool_dir: &Path,
+    steam_client_install_path: Option<&Path>,
+) -> Result<UninstallPlan, UninstallError> {
+    // Derive steam root candidates for both install-root validation and
+    // compat-tool mapping lookups.
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let install_candidates = resolve_candidates_with(
+        steam_client_install_path,
+        home.as_deref(),
+        crate::platform::is_flatpak(),
+    );
+
+    // Steam root candidates for `collect_compat_tool_mappings`.
+    // Use the same home-relative steam roots that `discover_steam_root_candidates`
+    // would use (but without requiring steamapps/ to exist, as this is a
+    // read-only config scan, not a full discovery).
+    let steam_roots = steam_roots_for_mapping(steam_client_install_path, home.as_deref());
+
+    plan_uninstall_with(tool_dir, &install_candidates, &steam_roots)
+}
+
+/// Execute a previously validated [`UninstallPlan`].
+///
+/// Removes `plan.tool_dir` recursively. On success the caller should
+/// refresh the installed-tool inventory via the existing rescan function;
+/// this module does not maintain a separate registry.
+pub fn execute_uninstall(plan: UninstallPlan) -> Result<(), UninstallError> {
+    std::fs::remove_dir_all(&plan.tool_dir).map_err(UninstallError::Io)
+}
+
+// ── internal testable core ────────────────────────────────────────────────────
+
+/// Testable variant that accepts injected install-root candidates and steam
+/// roots instead of deriving them from the environment.
+#[cfg(test)]
+pub(crate) fn plan_uninstall_with_mappings(
+    tool_dir: &Path,
+    install_candidates: &[crate::protonup::install_root::InstallRootCandidate],
+    mappings: &crate::steam::proton::CompatToolMappings,
+) -> Result<UninstallPlan, UninstallError> {
+    plan_uninstall_core(tool_dir, install_candidates, mappings)
+}
+
+fn plan_uninstall_with(
+    tool_dir: &Path,
+    install_candidates: &[crate::protonup::install_root::InstallRootCandidate],
+    steam_roots: &[PathBuf],
+) -> Result<UninstallPlan, UninstallError> {
+    let mut diag = Vec::new();
+    let mappings = collect_compat_tool_mappings(steam_roots, &mut diag);
+    plan_uninstall_core(tool_dir, install_candidates, &mappings)
+}
+
+fn plan_uninstall_core(
+    tool_dir: &Path,
+    install_candidates: &[crate::protonup::install_root::InstallRootCandidate],
+    mappings: &crate::steam::proton::CompatToolMappings,
+) -> Result<UninstallPlan, UninstallError> {
+    // ── 1. Canonicalize ───────────────────────────────────────────────────────
+
+    let canonical = std::fs::canonicalize(tool_dir)
+        .map_err(|_| UninstallError::NotFound(tool_dir.to_path_buf()))?;
+
+    // ── 2. System-path refusal ────────────────────────────────────────────────
+
+    for &root in STEAM_SYSTEM_ROOTS {
+        if canonical.starts_with(root) {
+            return Err(UninstallError::SystemPathRefused(canonical));
+        }
+    }
+    for &prefix in SYSTEM_PREFIX_DENYLIST {
+        if canonical.starts_with(prefix) {
+            return Err(UninstallError::SystemPathRefused(canonical));
+        }
+    }
+
+    // ── 3. User-root validation ───────────────────────────────────────────────
+    //
+    // The canonical path's parent must equal one of the candidate roots, OR
+    // the canonical path itself must be directly under a candidate root.
+    // Both checks are equivalent (parent == candidate iff path starts_with
+    // candidate and has exactly one more component), but we spell both out
+    // for clarity.
+
+    let matching_candidate = install_candidates.iter().find(|c| {
+        // Canonicalize the candidate path for comparison; fall back to raw if it
+        // doesn't exist yet (candidates may point to not-yet-created dirs).
+        let candidate_canonical = std::fs::canonicalize(&c.path).unwrap_or_else(|_| c.path.clone());
+        canonical.starts_with(&candidate_canonical)
+            && canonical
+                .parent()
+                .map(|p| {
+                    p == candidate_canonical
+                        || std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+                            == candidate_canonical
+                })
+                .unwrap_or(false)
+    });
+
+    let Some(candidate) = matching_candidate else {
+        return Err(UninstallError::PathOutsideKnownRoots(canonical));
+    };
+
+    // ── 4. Profile-mapping scan ───────────────────────────────────────────────
+
+    let tool_id = canonical
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    // Invert the mappings: mappings is AppID -> BTreeSet<tool_name>.
+    // Collect all AppIDs that reference this tool.
+    let conflicting_app_ids: Vec<String> = mappings
+        .iter()
+        .filter(|(_app_id, tool_names)| tool_names.contains(&tool_id))
+        .map(|(app_id, _)| app_id.clone())
+        .collect();
+
+    Ok(UninstallPlan {
+        tool_dir: canonical,
+        conflicting_app_ids,
+        root_kind: candidate.kind,
+    })
+}
+
+// ── private helpers ───────────────────────────────────────────────────────────
+
+/// Build a minimal list of Steam root directories for compat-tool mapping
+/// lookups. These are the Steam roots (not the `compatibilitytools.d` subdirs)
+/// because `collect_compat_tool_mappings` reads `config/config.vdf` and
+/// `userdata/<uid>/config/localconfig.vdf` from each root.
+fn steam_roots_for_mapping(
+    steam_client_install_path: Option<&Path>,
+    home: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+
+    if let Some(p) = steam_client_install_path {
+        if p.is_dir() {
+            roots.push(p.to_path_buf());
+        }
+    }
+
+    if let Some(home) = home {
+        let candidates = [
+            home.join(".steam/root"),
+            home.join(".local/share/Steam"),
+            home.join(".var/app/com.valvesoftware.Steam/data/Steam"),
+        ];
+        for c in candidates {
+            if c.is_dir() && !roots.contains(&c) {
+                roots.push(c);
+            }
+        }
+    }
+
+    roots
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protonup::install_root::{InstallRootCandidate, InstallRootKind};
+    use crate::steam::proton::CompatToolMappings;
+    use std::collections::{BTreeSet, HashMap};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn candidate(path: PathBuf, kind: InstallRootKind) -> InstallRootCandidate {
+        InstallRootCandidate {
+            kind,
+            path,
+            writable: true,
+            reason: None,
+        }
+    }
+
+    fn empty_mappings() -> CompatToolMappings {
+        HashMap::new()
+    }
+
+    fn mappings_with(app_id: &str, tool_name: &str) -> CompatToolMappings {
+        let mut m = HashMap::new();
+        let mut set = BTreeSet::new();
+        set.insert(tool_name.to_string());
+        m.insert(app_id.to_string(), set);
+        m
+    }
+
+    // ── test 1 ────────────────────────────────────────────────────────────────
+
+    /// A path under `/usr/share/steam/compatibilitytools.d` must be refused
+    /// even if it would otherwise pass other checks.
+    ///
+    /// We cannot `fs::canonicalize` a non-existent `/usr` path, so we skip
+    /// this test if the system path doesn't exist (i.e. in a sandbox without
+    /// `/usr/share/steam`). Instead we test the denylist logic by constructing
+    /// a tempdir that mimics the system structure only when possible.
+    ///
+    /// The real system-path guard is exercised at the prefix-denylist level:
+    /// any path that starts_with `/usr` is refused by `SYSTEM_PREFIX_DENYLIST`.
+    /// We verify this with a temp path whose canonical form starts with `/usr`
+    /// — which is impossible in a normal tempdir. So instead we verify that the
+    /// `plan_uninstall_core` denylist logic triggers for a known system root
+    /// by constructing the plan with a pre-canonicalized path equal to one of
+    /// the system roots.
+    #[test]
+    fn plan_uninstall_refuses_system_path() {
+        // We need a canonical path that resolves to a system denylist entry.
+        // Use the first SYSTEM_PREFIX_DENYLIST entry ("/usr"). If /usr exists
+        // we can build a subpath directly; if it doesn't we skip.
+        let usr = PathBuf::from("/usr");
+        if !usr.exists() {
+            return; // sandbox without /usr — skip
+        }
+
+        // Build a path under /usr/share/steam/compatibilitytools.d/SomeTool.
+        // We don't need it to exist; we test the prefix check via a fake
+        // canonical that we inject directly.
+        let fake_system_path = PathBuf::from("/usr/share/steam/compatibilitytools.d/GE-Proton10-1");
+
+        // We call the internal core with a pre-canonicalized path by cheating:
+        // create a tempdir and then check that any path starting with /usr is
+        // caught by the denylist before it reaches the user-root check.
+        // Since we can't canonicalize a non-existent path, we test via a real
+        // tempdir that is then checked against the denylist prefix.
+        //
+        // The simplest approach: verify that `plan_uninstall` on a path that
+        // starts with /usr returns SystemPathRefused. We use /usr itself (which
+        // exists) so canonicalize succeeds.
+        let result = plan_uninstall_with(
+            &PathBuf::from("/usr"),
+            &[candidate(
+                PathBuf::from("/usr"),
+                InstallRootKind::NativeSteam,
+            )],
+            &[],
+        );
+
+        // The denylist check happens before the user-root check.
+        // /usr is in SYSTEM_PREFIX_DENYLIST, so this must be refused.
+        // However, /usr's parent is /, so the user-root check would also fail.
+        // Either way we want SystemPathRefused or PathOutsideKnownRoots — both
+        // indicate the path was rejected. What matters is Ok() is not returned.
+        assert!(result.is_err(), "expected an error for a /usr path, got Ok");
+        match result.unwrap_err() {
+            UninstallError::SystemPathRefused(_) | UninstallError::PathOutsideKnownRoots(_) => {}
+            other => panic!("expected SystemPathRefused or PathOutsideKnownRoots, got: {other}"),
+        }
+
+        // Also verify a path that is explicitly listed in STEAM_SYSTEM_ROOTS.
+        // Build it as a real /usr/... subpath only if /usr exists.
+        let _ = fake_system_path; // used for documentation; not canonicalized
+    }
+
+    // ── test 2 ────────────────────────────────────────────────────────────────
+
+    /// A tool directory that is not under any known install root must return
+    /// `PathOutsideKnownRoots`.
+    #[test]
+    fn plan_uninstall_refuses_path_outside_known_roots() {
+        let unrelated = tempdir().unwrap();
+        let tool = unrelated.path().join("SomeTool");
+        fs::create_dir_all(&tool).unwrap();
+
+        // Candidate roots that have nothing to do with `unrelated`.
+        let other_root = tempdir().unwrap();
+        let candidates = vec![candidate(
+            other_root.path().to_path_buf(),
+            InstallRootKind::NativeSteam,
+        )];
+
+        let result = plan_uninstall_with_mappings(&tool, &candidates, &empty_mappings());
+
+        assert!(
+            matches!(result, Err(UninstallError::PathOutsideKnownRoots(_))),
+            "expected PathOutsideKnownRoots, got: {result:?}"
+        );
+    }
+
+    // ── test 3 ────────────────────────────────────────────────────────────────
+
+    /// When a Steam mapping exists for the tool basename, `conflicting_app_ids`
+    /// must be populated with the matched App ID.
+    #[test]
+    fn plan_uninstall_attaches_conflicting_app_ids() {
+        let root = tempdir().unwrap();
+        let tool_name = "GE-Proton10-1";
+        let tool_dir = root.path().join(tool_name);
+        fs::create_dir_all(&tool_dir).unwrap();
+
+        let candidates = vec![candidate(
+            root.path().to_path_buf(),
+            InstallRootKind::NativeSteam,
+        )];
+        let mappings = mappings_with("123", tool_name);
+
+        let plan = plan_uninstall_with_mappings(&tool_dir, &candidates, &mappings)
+            .expect("plan should succeed");
+
+        assert_eq!(
+            plan.conflicting_app_ids,
+            vec!["123".to_string()],
+            "expected App ID 123 in conflicting_app_ids"
+        );
+    }
+
+    // ── test 4 ────────────────────────────────────────────────────────────────
+
+    /// Happy-path: valid user-root child with no conflicts.
+    #[test]
+    fn plan_uninstall_accepts_user_root_happy_path() {
+        let root = tempdir().unwrap();
+        let tool_dir = root.path().join("GE-Proton9-20");
+        fs::create_dir_all(&tool_dir).unwrap();
+
+        let candidates = vec![candidate(
+            root.path().to_path_buf(),
+            InstallRootKind::NativeSteam,
+        )];
+
+        let plan = plan_uninstall_with_mappings(&tool_dir, &candidates, &empty_mappings())
+            .expect("plan should succeed");
+
+        assert!(
+            plan.conflicting_app_ids.is_empty(),
+            "expected no conflicting app IDs"
+        );
+        assert_eq!(plan.root_kind, InstallRootKind::NativeSteam);
+    }
+
+    // ── test 5 ────────────────────────────────────────────────────────────────
+
+    /// `execute_uninstall` must remove the target directory tree.
+    #[test]
+    fn execute_uninstall_removes_directory() {
+        let root = tempdir().unwrap();
+        let tool_dir = root.path().join("GE-Proton9-21");
+        fs::create_dir_all(tool_dir.join("files")).unwrap();
+        fs::write(tool_dir.join("files/proton"), b"fake binary").unwrap();
+
+        let candidates = vec![candidate(
+            root.path().to_path_buf(),
+            InstallRootKind::NativeSteam,
+        )];
+        let plan = plan_uninstall_with_mappings(&tool_dir, &candidates, &empty_mappings())
+            .expect("plan should succeed");
+
+        execute_uninstall(plan).expect("execute should succeed");
+
+        assert!(
+            !tool_dir.exists(),
+            "tool directory should have been removed"
+        );
+    }
+
+    // ── test 6 ────────────────────────────────────────────────────────────────
+
+    /// A path that doesn't exist must return `NotFound`.
+    #[test]
+    fn plan_uninstall_returns_not_found_for_missing_path() {
+        let root = tempdir().unwrap();
+        let missing = root.path().join("nonexistent-tool");
+        // Do NOT create this directory.
+
+        let result = plan_uninstall(&missing, None);
+
+        assert!(
+            matches!(result, Err(UninstallError::NotFound(_))),
+            "expected NotFound, got: {result:?}"
+        );
+    }
+}

--- a/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/protonup/uninstall.rs
@@ -173,6 +173,14 @@ fn plan_uninstall_core(
         .map_err(|_| UninstallError::NotFound(tool_dir.to_path_buf()))?;
     let canonical_tool_dir = normalize_tool_dir_path(&canonical);
 
+    plan_uninstall_canonicalized(canonical_tool_dir, install_candidates, mappings)
+}
+
+fn plan_uninstall_canonicalized(
+    canonical_tool_dir: PathBuf,
+    install_candidates: &[crate::protonup::install_root::InstallRootCandidate],
+    mappings: &crate::steam::proton::CompatToolMappings,
+) -> Result<UninstallPlan, UninstallError> {
     // ── 2. System-path refusal ────────────────────────────────────────────────
 
     for &root in STEAM_SYSTEM_ROOTS {
@@ -233,6 +241,19 @@ fn plan_uninstall_core(
         conflicting_app_ids,
         root_kind: candidate.kind,
     })
+}
+
+#[cfg(test)]
+fn plan_uninstall_with_canonical_path(
+    canonical_tool_dir: &Path,
+    install_candidates: &[crate::protonup::install_root::InstallRootCandidate],
+    mappings: &crate::steam::proton::CompatToolMappings,
+) -> Result<UninstallPlan, UninstallError> {
+    plan_uninstall_canonicalized(
+        canonical_tool_dir.to_path_buf(),
+        install_candidates,
+        mappings,
+    )
 }
 
 // ── private helpers ───────────────────────────────────────────────────────────
@@ -319,68 +340,95 @@ mod tests {
 
     // ── test 1 ────────────────────────────────────────────────────────────────
 
-    /// A path under `/usr/share/steam/compatibilitytools.d` must be refused
-    /// even if it would otherwise pass other checks.
-    ///
-    /// We cannot `fs::canonicalize` a non-existent `/usr` path, so we skip
-    /// this test if the system path doesn't exist (i.e. in a sandbox without
-    /// `/usr/share/steam`). Instead we test the denylist logic by constructing
-    /// a tempdir that mimics the system structure only when possible.
-    ///
-    /// The real system-path guard is exercised at the prefix-denylist level:
-    /// any path that starts_with `/usr` is refused by `SYSTEM_PREFIX_DENYLIST`.
-    /// We verify this with a temp path whose canonical form starts with `/usr`
-    /// — which is impossible in a normal tempdir. So instead we verify that the
-    /// `plan_uninstall_core` denylist logic triggers for a known system root
-    /// by constructing the plan with a pre-canonicalized path equal to one of
-    /// the system roots.
     #[test]
-    fn plan_uninstall_refuses_system_path() {
-        // We need a canonical path that resolves to a system denylist entry.
-        // Use the first SYSTEM_PREFIX_DENYLIST entry ("/usr"). If /usr exists
-        // we can build a subpath directly; if it doesn't we skip.
-        let usr = PathBuf::from("/usr");
-        if !usr.exists() {
-            return; // sandbox without /usr — skip
-        }
+    fn plan_uninstall_refuses_system_prefix_path() {
+        let canonical_tool_dir =
+            PathBuf::from("/usr/share/steam/compatibilitytools.d/GE-Proton10-1");
 
-        // Build a path under /usr/share/steam/compatibilitytools.d/SomeTool.
-        // We don't need it to exist; we test the prefix check via a fake
-        // canonical that we inject directly.
-        let fake_system_path = PathBuf::from("/usr/share/steam/compatibilitytools.d/GE-Proton10-1");
-
-        // We call the internal core with a pre-canonicalized path by cheating:
-        // create a tempdir and then check that any path starting with /usr is
-        // caught by the denylist before it reaches the user-root check.
-        // Since we can't canonicalize a non-existent path, we test via a real
-        // tempdir that is then checked against the denylist prefix.
-        //
-        // The simplest approach: verify that `plan_uninstall` on a path that
-        // starts with /usr returns SystemPathRefused. We use /usr itself (which
-        // exists) so canonicalize succeeds.
-        let result = plan_uninstall_with(
-            &PathBuf::from("/usr"),
+        let result = plan_uninstall_with_canonical_path(
+            &canonical_tool_dir,
             &[candidate(
-                PathBuf::from("/usr"),
+                PathBuf::from("/usr/share/steam/compatibilitytools.d"),
                 InstallRootKind::NativeSteam,
             )],
-            &[],
+            &empty_mappings(),
         );
 
-        // The denylist check happens before the user-root check.
-        // /usr is in SYSTEM_PREFIX_DENYLIST, so this must be refused.
-        // However, /usr's parent is /, so the user-root check would also fail.
-        // Either way we want SystemPathRefused or PathOutsideKnownRoots — both
-        // indicate the path was rejected. What matters is Ok() is not returned.
-        assert!(result.is_err(), "expected an error for a /usr path, got Ok");
-        match result.unwrap_err() {
-            UninstallError::SystemPathRefused(_) | UninstallError::PathOutsideKnownRoots(_) => {}
-            other => panic!("expected SystemPathRefused or PathOutsideKnownRoots, got: {other}"),
-        }
+        assert!(
+            matches!(
+                result,
+                Err(UninstallError::SystemPathRefused(ref path)) if path == &canonical_tool_dir
+            ),
+            "expected SystemPathRefused for /usr prefix, got: {result:?}"
+        );
+    }
 
-        // Also verify a path that is explicitly listed in STEAM_SYSTEM_ROOTS.
-        // Build it as a real /usr/... subpath only if /usr exists.
-        let _ = fake_system_path; // used for documentation; not canonicalized
+    #[test]
+    fn plan_uninstall_refuses_explicit_steam_system_root() {
+        let canonical_tool_dir = PathBuf::from(STEAM_SYSTEM_ROOTS[0]).join("GE-Proton10-1");
+
+        let result = plan_uninstall_with_canonical_path(
+            &canonical_tool_dir,
+            &[candidate(
+                PathBuf::from(STEAM_SYSTEM_ROOTS[0]),
+                InstallRootKind::NativeSteam,
+            )],
+            &empty_mappings(),
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(UninstallError::SystemPathRefused(ref path)) if path == &canonical_tool_dir
+            ),
+            "expected SystemPathRefused for explicit Steam system root, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn plan_uninstall_home_prefix_outside_known_roots() {
+        let canonical_tool_dir = PathBuf::from("/home/test-user/Games/GE-Proton10-1");
+
+        let result = plan_uninstall_with_canonical_path(
+            &canonical_tool_dir,
+            &[candidate(
+                PathBuf::from("/home/test-user/.local/share/Steam/compatibilitytools.d"),
+                InstallRootKind::NativeSteam,
+            )],
+            &empty_mappings(),
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(UninstallError::PathOutsideKnownRoots(ref path)) if path == &canonical_tool_dir
+            ),
+            "expected PathOutsideKnownRoots for broad /home prefix, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn plan_uninstall_accepts_valid_home_compat_root() {
+        let compat_root = PathBuf::from("/home/test-user/.local/share/Steam/compatibilitytools.d");
+        let canonical_tool_dir = compat_root.join("GE-Proton10-1");
+
+        let result = plan_uninstall_with_canonical_path(
+            &canonical_tool_dir,
+            &[candidate(compat_root, InstallRootKind::NativeSteam)],
+            &empty_mappings(),
+        );
+
+        assert!(
+            matches!(
+                result,
+                Ok(UninstallPlan {
+                    ref tool_dir,
+                    root_kind: InstallRootKind::NativeSteam,
+                    ..
+                }) if tool_dir == &canonical_tool_dir
+            ),
+            "expected valid home compat root to be accepted, got: {result:?}"
+        );
     }
 
     // ── test 2 ────────────────────────────────────────────────────────────────

--- a/src/crosshook-native/crates/crosshook-core/src/settings/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/settings/mod.rs
@@ -29,6 +29,10 @@ fn default_protonup_auto_suggest() -> bool {
     true
 }
 
+fn default_protonup_default_provider() -> String {
+    "ge-proton".to_string()
+}
+
 fn default_recent_files_limit() -> u32 {
     10
 }
@@ -215,6 +219,15 @@ pub struct AppSettingsData {
     /// Optional path override for ProtonUp binary; empty = auto-detect.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub protonup_binary_path: String,
+    /// Which provider to preselect in the Proton manager UI (e.g. `"ge-proton"`).
+    #[serde(default = "default_protonup_default_provider")]
+    pub protonup_default_provider: String,
+    /// Override the auto-picked install root for Proton downloads; empty = auto-resolve.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub protonup_default_install_root: String,
+    /// When true, include GitHub prereleases in the Proton catalog.
+    #[serde(default)]
+    pub protonup_include_prereleases: bool,
     /// User preference for umu-launcher vs direct Proton invocation.
     #[serde(default)]
     pub umu_preference: UmuPreference,
@@ -260,6 +273,9 @@ impl Default for AppSettingsData {
             external_trainer_sources: default_external_trainer_sources(),
             protonup_auto_suggest: default_protonup_auto_suggest(),
             protonup_binary_path: String::new(),
+            protonup_default_provider: default_protonup_default_provider(),
+            protonup_default_install_root: String::new(),
+            protonup_include_prereleases: false,
             umu_preference: UmuPreference::Auto,
             host_tool_dashboard_dismissed_hints: Vec::new(),
             host_tool_dashboard_default_category_filter: None,
@@ -308,6 +324,15 @@ impl fmt::Debug for AppSettingsData {
             .field("external_trainer_sources", &self.external_trainer_sources)
             .field("protonup_auto_suggest", &self.protonup_auto_suggest)
             .field("protonup_binary_path", &self.protonup_binary_path)
+            .field("protonup_default_provider", &self.protonup_default_provider)
+            .field(
+                "protonup_default_install_root",
+                &self.protonup_default_install_root,
+            )
+            .field(
+                "protonup_include_prereleases",
+                &self.protonup_include_prereleases,
+            )
             .field("umu_preference", &self.umu_preference)
             .field(
                 "host_tool_dashboard_dismissed_hints",
@@ -637,6 +662,42 @@ mod tests {
             loaded.protonup_binary_path.is_empty(),
             "protonup_binary_path should default to empty"
         );
+    }
+
+    #[test]
+    fn settings_backward_compat_without_protonup_manager_fields() {
+        // TOML that has pre-v22 settings including protonup_auto_suggest / protonup_binary_path
+        // but NOT the three new manager fields. Must parse cleanly and fill defaults.
+        let legacy_toml = r#"
+protonup_auto_suggest = true
+protonup_binary_path = ""
+# deliberately omit protonup_default_provider, protonup_default_install_root, protonup_include_prereleases
+        "#;
+        let parsed: AppSettingsData = toml::from_str(legacy_toml).expect("parses legacy toml");
+        assert_eq!(parsed.protonup_default_provider, "ge-proton");
+        assert_eq!(parsed.protonup_default_install_root, "");
+        assert!(!parsed.protonup_include_prereleases);
+    }
+
+    #[test]
+    fn settings_roundtrip_protonup_manager_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = SettingsStore::with_base_path(dir.path().to_path_buf());
+        let settings = AppSettingsData {
+            protonup_default_provider: "proton-cachyos".to_string(),
+            protonup_default_install_root: "/home/user/.steam/root/compatibilitytools.d"
+                .to_string(),
+            protonup_include_prereleases: true,
+            ..Default::default()
+        };
+        store.save(&settings).unwrap();
+        let loaded = store.load().unwrap();
+        assert_eq!(loaded.protonup_default_provider, "proton-cachyos");
+        assert_eq!(
+            loaded.protonup_default_install_root,
+            "/home/user/.steam/root/compatibilitytools.d"
+        );
+        assert!(loaded.protonup_include_prereleases);
     }
 
     #[test]

--- a/src/crosshook-native/src-tauri/Cargo.toml
+++ b/src/crosshook-native/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 chrono = "0.4"
 tokio = { version = "1", features = ["fs", "io-util", "process", "time"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 

--- a/src/crosshook-native/src-tauri/src/commands/protonup.rs
+++ b/src/crosshook-native/src-tauri/src/commands/protonup.rs
@@ -1,11 +1,78 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
 use crosshook_core::metadata::MetadataStore;
+use crosshook_core::protonup::install_root::InstallRootCandidate;
 use crosshook_core::protonup::matching::match_community_version;
+use crosshook_core::protonup::providers::{describe_providers, ProtonUpProviderDescriptor};
 use crosshook_core::protonup::{
-    parse_protonup_provider, ProtonUpCatalogResponse, ProtonUpInstallErrorKind,
-    ProtonUpInstallRequest, ProtonUpInstallResult, ProtonUpSuggestion,
+    parse_protonup_provider, ProtonUpAvailableVersion, ProtonUpCatalogResponse,
+    ProtonUpInstallErrorKind, ProtonUpInstallRequest, ProtonUpInstallResult, ProtonUpSuggestion,
 };
 use crosshook_core::steam::{discover_compat_tools, discover_steam_root_candidates};
-use tauri::State;
+use tauri::{Emitter as _, State};
+use tokio_util::sync::CancellationToken;
+
+// ── ProtonInstallRegistry ─────────────────────────────────────────────────────
+
+/// Tracks in-flight async Proton installs so they can be cancelled by op_id.
+///
+/// Managed as `Arc<ProtonInstallRegistry>` so the inner value can be cloned
+/// into `tokio::spawn` closures without holding a Tauri `State` reference.
+#[derive(Default)]
+pub struct ProtonInstallRegistry {
+    inner: Mutex<HashMap<String, CancellationToken>>,
+}
+
+impl ProtonInstallRegistry {
+    pub fn register(&self, op_id: &str, token: CancellationToken) {
+        self.inner
+            .lock()
+            .expect("ProtonInstallRegistry mutex poisoned")
+            .insert(op_id.to_string(), token);
+    }
+
+    pub fn cancel(&self, op_id: &str) -> bool {
+        if let Some(token) = self
+            .inner
+            .lock()
+            .expect("ProtonInstallRegistry mutex poisoned")
+            .remove(op_id)
+        {
+            token.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn remove(&self, op_id: &str) {
+        let _ = self
+            .inner
+            .lock()
+            .expect("ProtonInstallRegistry mutex poisoned")
+            .remove(op_id);
+    }
+}
+
+// ── DTOs ──────────────────────────────────────────────────────────────────────
+
+/// Returned from `protonup_install_version_async` so the frontend can track
+/// the operation and subscribe to `protonup:install:progress` events.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProtonInstallHandle {
+    pub op_id: String,
+}
+
+/// Returned from `protonup_uninstall_version`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProtonUninstallResponse {
+    pub success: bool,
+    pub conflicting_app_ids: Vec<String>,
+    pub error_message: Option<String>,
+}
+
+// ── existing commands (preserved) ─────────────────────────────────────────────
 
 /// List available Proton versions from provider catalog.
 #[tauri::command]
@@ -23,7 +90,7 @@ pub async fn protonup_list_available_versions(
     .await)
 }
 
-/// Install a selected Proton version.
+/// Install a selected Proton version (synchronous/backward-compat variant).
 #[tauri::command]
 pub async fn protonup_install_version(
     metadata_store: State<'_, MetadataStore>,
@@ -73,4 +140,137 @@ pub fn protonup_get_suggestion(
     }
 
     Ok(match_community_version(&community_version, &installs))
+}
+
+// ── new commands (Batch 4, Steps 4.1 + 4.2) ──────────────────────────────────
+
+/// List all registered Proton release providers with their static metadata.
+#[tauri::command]
+pub fn protonup_list_providers() -> Result<Vec<ProtonUpProviderDescriptor>, String> {
+    Ok(describe_providers())
+}
+
+/// Enumerate candidate `compatibilitytools.d` install roots for the current
+/// environment, including writability status.
+///
+/// `steam_client_install_path` is the configured Steam client path from
+/// settings (used to derive an additional candidate directory). Pass `null`
+/// to rely on home-relative defaults only.
+#[tauri::command]
+pub async fn protonup_resolve_install_roots(
+    steam_client_install_path: Option<String>,
+) -> Result<Vec<InstallRootCandidate>, String> {
+    let path_buf = steam_client_install_path
+        .as_deref()
+        .map(std::path::PathBuf::from);
+    Ok(
+        crosshook_core::protonup::install_root::resolve_install_root_candidates(
+            path_buf.as_deref(),
+        ),
+    )
+}
+
+/// Spawn a Proton install in the background and return immediately with an
+/// `op_id` handle. Progress is streamed via `protonup:install:progress` events.
+/// The operation can be cancelled by passing the `op_id` to
+/// `protonup_cancel_install`.
+#[tauri::command]
+pub async fn protonup_install_version_async(
+    app: tauri::AppHandle,
+    request: ProtonUpInstallRequest,
+    version: ProtonUpAvailableVersion,
+    registry: State<'_, std::sync::Arc<ProtonInstallRegistry>>,
+) -> Result<ProtonInstallHandle, String> {
+    use crosshook_core::protonup::install::install_version_with_progress;
+    use crosshook_core::protonup::progress::ProgressEmitter;
+
+    let op_id = uuid::Uuid::new_v4().to_string();
+    let (emitter, mut rx) = ProgressEmitter::new(&op_id);
+    let cancel = CancellationToken::new();
+
+    // Register the token so it can be cancelled via protonup_cancel_install.
+    registry.register(&op_id, cancel.clone());
+
+    // Clone the Arc so we can move it into the install task.
+    let registry_arc = (*registry).clone();
+    let op_id_task = op_id.clone();
+
+    // Pump progress events from the broadcast channel into Tauri events.
+    let app_pump = app.clone();
+    let op_id_pump = op_id.clone();
+    tokio::spawn(async move {
+        while let Ok(progress) = rx.recv().await {
+            let _ = app_pump.emit("protonup:install:progress", &progress);
+        }
+        // Emit a sentinel so the frontend knows the channel is done.
+        let _ = app_pump.emit(
+            "protonup:install:progress",
+            serde_json::json!({
+                "op_id": op_id_pump,
+                "phase": "done-channel-closed"
+            }),
+        );
+    });
+
+    // Spawn the actual install task.
+    tokio::spawn(async move {
+        let _result =
+            install_version_with_progress(&request, &version, Some(emitter), Some(cancel)).await;
+        registry_arc.remove(&op_id_task);
+    });
+
+    Ok(ProtonInstallHandle { op_id })
+}
+
+/// Cancel a running Proton install by its `op_id`.
+///
+/// Returns `true` if the operation was found and cancelled, `false` if it was
+/// already complete or the `op_id` was not recognised.
+#[tauri::command]
+pub fn protonup_cancel_install(
+    op_id: String,
+    registry: State<'_, std::sync::Arc<ProtonInstallRegistry>>,
+) -> Result<bool, String> {
+    Ok(registry.cancel(&op_id))
+}
+
+/// Uninstall a Proton tool from disk.
+///
+/// Returns a structured response rather than a Tauri error so the UI can
+/// render plan warnings (e.g. conflicting App IDs) before or after removal.
+#[tauri::command]
+pub async fn protonup_uninstall_version(
+    tool_path: String,
+    steam_client_install_path: Option<String>,
+) -> Result<ProtonUninstallResponse, String> {
+    use crosshook_core::protonup::uninstall::{execute_uninstall, plan_uninstall};
+
+    let tool = std::path::Path::new(&tool_path);
+    let steam_buf = steam_client_install_path
+        .as_deref()
+        .map(std::path::PathBuf::from);
+    let steam = steam_buf.as_deref();
+
+    match plan_uninstall(tool, steam) {
+        Ok(plan) => {
+            let conflicts = plan.conflicting_app_ids.clone();
+            match execute_uninstall(plan) {
+                Ok(()) => Ok(ProtonUninstallResponse {
+                    success: true,
+                    conflicting_app_ids: conflicts,
+                    error_message: None,
+                }),
+                Err(e) => Ok(ProtonUninstallResponse {
+                    success: false,
+                    conflicting_app_ids: conflicts,
+                    error_message: Some(e.to_string()),
+                }),
+            }
+        }
+        Err(e) => Ok(ProtonUninstallResponse {
+            success: false,
+            conflicting_app_ids: vec![],
+            error_message: Some(e.to_string()),
+        }),
+    }
 }

--- a/src/crosshook-native/src-tauri/src/commands/protonup.rs
+++ b/src/crosshook-native/src-tauri/src/commands/protonup.rs
@@ -15,9 +15,8 @@ use tauri::{Emitter as _, State};
 use tokio_util::sync::CancellationToken;
 
 /// Default provider id used when the frontend omits the field. Unknown
-/// provider ids are passed through to the catalog (which returns empty
-/// when the registry doesn't recognise them) rather than silently
-/// downgrading to GE-Proton.
+/// provider ids still attempt cache-first reads; a failed live fetch falls
+/// back to stale cached rows when present instead of silently clearing them.
 const DEFAULT_PROVIDER_ID: &str = "ge-proton";
 
 // ── ProtonInstallRegistry ─────────────────────────────────────────────────────

--- a/src/crosshook-native/src-tauri/src/commands/protonup.rs
+++ b/src/crosshook-native/src-tauri/src/commands/protonup.rs
@@ -10,15 +10,15 @@ use crosshook_core::protonup::{
     ProtonUpInstallRequest, ProtonUpInstallResult, ProtonUpSuggestion,
 };
 use crosshook_core::settings::SettingsStore;
+use crosshook_core::steam::{discover_compat_tools, discover_steam_root_candidates};
+use tauri::{Emitter as _, State};
+use tokio_util::sync::CancellationToken;
 
 /// Default provider id used when the frontend omits the field. Unknown
 /// provider ids are passed through to the catalog (which returns empty
 /// when the registry doesn't recognise them) rather than silently
 /// downgrading to GE-Proton.
 const DEFAULT_PROVIDER_ID: &str = "ge-proton";
-use crosshook_core::steam::{discover_compat_tools, discover_steam_root_candidates};
-use tauri::{Emitter as _, State};
-use tokio_util::sync::CancellationToken;
 
 // ── ProtonInstallRegistry ─────────────────────────────────────────────────────
 

--- a/src/crosshook-native/src-tauri/src/commands/protonup.rs
+++ b/src/crosshook-native/src-tauri/src/commands/protonup.rs
@@ -9,6 +9,7 @@ use crosshook_core::protonup::{
     ProtonUpAvailableVersion, ProtonUpCatalogResponse, ProtonUpInstallErrorKind,
     ProtonUpInstallRequest, ProtonUpInstallResult, ProtonUpSuggestion,
 };
+use crosshook_core::settings::SettingsStore;
 
 /// Default provider id used when the frontend omits the field. Unknown
 /// provider ids are passed through to the catalog (which returns empty
@@ -78,6 +79,22 @@ pub struct ProtonUninstallResponse {
     pub error_message: Option<String>,
 }
 
+/// Returned from `protonup_plan_uninstall_version` so the UI can surface
+/// `conflicting_app_ids` before any deletion happens.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProtonUninstallPlanResponse {
+    pub success: bool,
+    pub conflicting_app_ids: Vec<String>,
+    pub error_message: Option<String>,
+}
+
+fn load_include_prereleases(settings_store: &SettingsStore) -> bool {
+    settings_store
+        .load()
+        .map(|s| s.protonup_include_prereleases)
+        .unwrap_or(false)
+}
+
 // ── existing commands (preserved) ─────────────────────────────────────────────
 
 /// List available Proton versions from provider catalog.
@@ -90,15 +107,18 @@ pub struct ProtonUninstallResponse {
 #[tauri::command]
 pub async fn protonup_list_available_versions(
     metadata_store: State<'_, MetadataStore>,
+    settings_store: State<'_, SettingsStore>,
     provider: Option<String>,
     force_refresh: Option<bool>,
 ) -> Result<ProtonUpCatalogResponse, String> {
     let provider_id = provider.as_deref().unwrap_or(DEFAULT_PROVIDER_ID);
+    let include_prereleases = load_include_prereleases(&settings_store);
     Ok(
         crosshook_core::protonup::catalog::list_available_versions_by_id(
             &metadata_store,
             force_refresh.unwrap_or(false),
             provider_id,
+            include_prereleases,
         )
         .await,
     )
@@ -108,13 +128,16 @@ pub async fn protonup_list_available_versions(
 #[tauri::command]
 pub async fn protonup_install_version(
     metadata_store: State<'_, MetadataStore>,
+    settings_store: State<'_, SettingsStore>,
     request: ProtonUpInstallRequest,
 ) -> Result<ProtonUpInstallResult, String> {
+    let include_prereleases = load_include_prereleases(&settings_store);
     // Look up version info from catalog using the request's exact provider id.
     let catalog = crosshook_core::protonup::catalog::list_available_versions_by_id(
         &metadata_store,
         false,
         request.provider.as_str(),
+        include_prereleases,
     )
     .await;
 
@@ -190,11 +213,45 @@ pub async fn protonup_resolve_install_roots(
 #[tauri::command]
 pub async fn protonup_install_version_async(
     app: tauri::AppHandle,
+    metadata_store: State<'_, MetadataStore>,
+    settings_store: State<'_, SettingsStore>,
     request: ProtonUpInstallRequest,
     version: ProtonUpAvailableVersion,
     registry: State<'_, std::sync::Arc<ProtonInstallRegistry>>,
 ) -> Result<ProtonInstallHandle, String> {
     use crosshook_core::protonup::install::install_version_with_progress;
+    let include_prereleases = load_include_prereleases(&settings_store);
+    let catalog = crosshook_core::protonup::catalog::list_available_versions_by_id(
+        &metadata_store,
+        false,
+        request.provider.as_str(),
+        include_prereleases,
+    )
+    .await;
+
+    let Some(resolved_version) = catalog
+        .versions
+        .iter()
+        .find(|v| v.version == request.version && v.provider == request.provider)
+        .cloned()
+    else {
+        return Err(format!(
+            "requested version '{}' for provider '{}' was not found in the server catalog",
+            request.version, request.provider
+        ));
+    };
+
+    if version.provider != resolved_version.provider || version.version != resolved_version.version
+    {
+        return Err("install request/version mismatch with server catalog identity".to_string());
+    }
+    if version.download_url != resolved_version.download_url
+        || version.checksum_url != resolved_version.checksum_url
+        || version.checksum_kind != resolved_version.checksum_kind
+    {
+        return Err("install metadata did not match server-resolved catalog entry".to_string());
+    }
+
     use crosshook_core::protonup::progress::ProgressEmitter;
 
     let op_id = uuid::Uuid::new_v4().to_string();
@@ -222,7 +279,8 @@ pub async fn protonup_install_version_async(
     // Spawn the actual install task.
     tokio::spawn(async move {
         let _result =
-            install_version_with_progress(&request, &version, Some(emitter), Some(cancel)).await;
+            install_version_with_progress(&request, &resolved_version, Some(emitter), Some(cancel))
+                .await;
         registry_arc.remove(&op_id_task);
     });
 
@@ -250,7 +308,35 @@ pub async fn protonup_uninstall_version(
     tool_path: String,
     steam_client_install_path: Option<String>,
 ) -> Result<ProtonUninstallResponse, String> {
-    use crosshook_core::protonup::uninstall::{execute_uninstall, plan_uninstall};
+    use crosshook_core::protonup::uninstall::execute_uninstall_for_path;
+
+    let tool = std::path::Path::new(&tool_path);
+    let steam_buf = steam_client_install_path
+        .as_deref()
+        .map(std::path::PathBuf::from);
+    let steam = steam_buf.as_deref();
+
+    match execute_uninstall_for_path(tool, steam) {
+        Ok(()) => Ok(ProtonUninstallResponse {
+            success: true,
+            conflicting_app_ids: vec![],
+            error_message: None,
+        }),
+        Err(e) => Ok(ProtonUninstallResponse {
+            success: false,
+            conflicting_app_ids: vec![],
+            error_message: Some(e.to_string()),
+        }),
+    }
+}
+
+/// Plan a Proton uninstall without mutating disk.
+#[tauri::command]
+pub async fn protonup_plan_uninstall_version(
+    tool_path: String,
+    steam_client_install_path: Option<String>,
+) -> Result<ProtonUninstallPlanResponse, String> {
+    use crosshook_core::protonup::uninstall::plan_uninstall;
 
     let tool = std::path::Path::new(&tool_path);
     let steam_buf = steam_client_install_path
@@ -259,22 +345,12 @@ pub async fn protonup_uninstall_version(
     let steam = steam_buf.as_deref();
 
     match plan_uninstall(tool, steam) {
-        Ok(plan) => {
-            let conflicts = plan.conflicting_app_ids.clone();
-            match execute_uninstall(plan) {
-                Ok(()) => Ok(ProtonUninstallResponse {
-                    success: true,
-                    conflicting_app_ids: conflicts,
-                    error_message: None,
-                }),
-                Err(e) => Ok(ProtonUninstallResponse {
-                    success: false,
-                    conflicting_app_ids: conflicts,
-                    error_message: Some(e.to_string()),
-                }),
-            }
-        }
-        Err(e) => Ok(ProtonUninstallResponse {
+        Ok(plan) => Ok(ProtonUninstallPlanResponse {
+            success: true,
+            conflicting_app_ids: plan.conflicting_app_ids,
+            error_message: None,
+        }),
+        Err(e) => Ok(ProtonUninstallPlanResponse {
             success: false,
             conflicting_app_ids: vec![],
             error_message: Some(e.to_string()),

--- a/src/crosshook-native/src-tauri/src/commands/protonup.rs
+++ b/src/crosshook-native/src-tauri/src/commands/protonup.rs
@@ -6,9 +6,15 @@ use crosshook_core::protonup::install_root::InstallRootCandidate;
 use crosshook_core::protonup::matching::match_community_version;
 use crosshook_core::protonup::providers::{describe_providers, ProtonUpProviderDescriptor};
 use crosshook_core::protonup::{
-    parse_protonup_provider, ProtonUpAvailableVersion, ProtonUpCatalogResponse,
-    ProtonUpInstallErrorKind, ProtonUpInstallRequest, ProtonUpInstallResult, ProtonUpSuggestion,
+    ProtonUpAvailableVersion, ProtonUpCatalogResponse, ProtonUpInstallErrorKind,
+    ProtonUpInstallRequest, ProtonUpInstallResult, ProtonUpSuggestion,
 };
+
+/// Default provider id used when the frontend omits the field. Unknown
+/// provider ids are passed through to the catalog (which returns empty
+/// when the registry doesn't recognise them) rather than silently
+/// downgrading to GE-Proton.
+const DEFAULT_PROVIDER_ID: &str = "ge-proton";
 use crosshook_core::steam::{discover_compat_tools, discover_steam_root_candidates};
 use tauri::{Emitter as _, State};
 use tokio_util::sync::CancellationToken;
@@ -75,19 +81,27 @@ pub struct ProtonUninstallResponse {
 // ── existing commands (preserved) ─────────────────────────────────────────────
 
 /// List available Proton versions from provider catalog.
+///
+/// Dispatch is id-based so the frontend can request any provider the
+/// registry knows about (GE-Proton, Proton-CachyOS, Proton-EM, …).
+/// Previously this went through the closed `ProtonUpProvider` enum, which
+/// silently mapped unknown ids to GE-Proton — hence `Proton-EM` appeared
+/// to alias GE-Proton in the UI.
 #[tauri::command]
 pub async fn protonup_list_available_versions(
     metadata_store: State<'_, MetadataStore>,
     provider: Option<String>,
     force_refresh: Option<bool>,
 ) -> Result<ProtonUpCatalogResponse, String> {
-    let provider = parse_protonup_provider(provider.as_deref());
-    Ok(crosshook_core::protonup::catalog::list_available_versions(
-        &metadata_store,
-        force_refresh.unwrap_or(false),
-        provider,
+    let provider_id = provider.as_deref().unwrap_or(DEFAULT_PROVIDER_ID);
+    Ok(
+        crosshook_core::protonup::catalog::list_available_versions_by_id(
+            &metadata_store,
+            force_refresh.unwrap_or(false),
+            provider_id,
+        )
+        .await,
     )
-    .await)
 }
 
 /// Install a selected Proton version (synchronous/backward-compat variant).
@@ -96,12 +110,11 @@ pub async fn protonup_install_version(
     metadata_store: State<'_, MetadataStore>,
     request: ProtonUpInstallRequest,
 ) -> Result<ProtonUpInstallResult, String> {
-    // Look up version info from catalog first (same provider as the install request).
-    let provider = parse_protonup_provider(Some(request.provider.as_str()));
-    let catalog = crosshook_core::protonup::catalog::list_available_versions(
+    // Look up version info from catalog using the request's exact provider id.
+    let catalog = crosshook_core::protonup::catalog::list_available_versions_by_id(
         &metadata_store,
         false,
-        provider,
+        request.provider.as_str(),
     )
     .await;
 
@@ -196,20 +209,14 @@ pub async fn protonup_install_version_async(
     let op_id_task = op_id.clone();
 
     // Pump progress events from the broadcast channel into Tauri events.
+    // No post-loop sentinel: the install orchestrator already emits a terminal
+    // Phase (Done / Failed / Cancelled) before dropping the sender, which is
+    // the signal the frontend uses to flip into a terminal state.
     let app_pump = app.clone();
-    let op_id_pump = op_id.clone();
     tokio::spawn(async move {
         while let Ok(progress) = rx.recv().await {
             let _ = app_pump.emit("protonup:install:progress", &progress);
         }
-        // Emit a sentinel so the frontend knows the channel is done.
-        let _ = app_pump.emit(
-            "protonup:install:progress",
-            serde_json::json!({
-                "op_id": op_id_pump,
-                "phase": "done-channel-closed"
-            }),
-        );
     });
 
     // Spawn the actual install task.

--- a/src/crosshook-native/src-tauri/src/commands/settings.rs
+++ b/src/crosshook-native/src-tauri/src/commands/settings.rs
@@ -149,6 +149,12 @@ pub struct SettingsSaveRequest {
     pub install_nag_dismissed_at: Option<Option<String>>,
     #[serde(default)]
     pub steam_deck_caveats_dismissed_at: Option<Option<String>>,
+    #[serde(default)]
+    pub protonup_default_provider: Option<String>,
+    #[serde(default)]
+    pub protonup_default_install_root: Option<String>,
+    #[serde(default)]
+    pub protonup_include_prereleases: Option<bool>,
 }
 
 fn merge_settings_from_request(
@@ -205,6 +211,15 @@ fn merge_settings_from_request(
         steam_deck_caveats_dismissed_at: data
             .steam_deck_caveats_dismissed_at
             .unwrap_or(current.steam_deck_caveats_dismissed_at),
+        protonup_default_provider: data
+            .protonup_default_provider
+            .unwrap_or(current.protonup_default_provider),
+        protonup_default_install_root: data
+            .protonup_default_install_root
+            .unwrap_or(current.protonup_default_install_root),
+        protonup_include_prereleases: data
+            .protonup_include_prereleases
+            .unwrap_or(current.protonup_include_prereleases),
     }
 }
 
@@ -336,6 +351,9 @@ mod tests {
             host_tool_dashboard_default_category_filter: None,
             install_nag_dismissed_at: None,
             steam_deck_caveats_dismissed_at: None,
+            protonup_default_provider: None,
+            protonup_default_install_root: None,
+            protonup_include_prereleases: None,
         }
     }
 

--- a/src/crosshook-native/src-tauri/src/commands/settings.rs
+++ b/src/crosshook-native/src-tauri/src/commands/settings.rs
@@ -48,6 +48,12 @@ pub struct AppSettingsIpcData {
     pub external_trainer_sources: Vec<ExternalTrainerSourceSubscription>,
     pub protonup_auto_suggest: bool,
     pub protonup_binary_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protonup_default_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protonup_default_install_root: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protonup_include_prereleases: Option<bool>,
     pub umu_preference: UmuPreference,
     /// RFC 3339 timestamp of when the user dismissed the umu install nag; `None` = not dismissed.
     pub install_nag_dismissed_at: Option<String>,
@@ -93,6 +99,9 @@ impl AppSettingsIpcData {
             external_trainer_sources: data.external_trainer_sources,
             protonup_auto_suggest: data.protonup_auto_suggest,
             protonup_binary_path: data.protonup_binary_path,
+            protonup_default_provider: Some(data.protonup_default_provider),
+            protonup_default_install_root: Some(data.protonup_default_install_root),
+            protonup_include_prereleases: Some(data.protonup_include_prereleases),
             umu_preference: data.umu_preference,
             install_nag_dismissed_at: data.install_nag_dismissed_at,
             steam_deck_caveats_dismissed_at: data.steam_deck_caveats_dismissed_at,

--- a/src/crosshook-native/src-tauri/src/lib.rs
+++ b/src/crosshook-native/src-tauri/src/lib.rs
@@ -502,6 +502,7 @@ pub fn run() {
             commands::protonup::protonup_resolve_install_roots,
             commands::protonup::protonup_install_version_async,
             commands::protonup::protonup_cancel_install,
+            commands::protonup::protonup_plan_uninstall_version,
             commands::protonup::protonup_uninstall_version,
             // UMU database
             commands::umu_database::refresh_umu_database,

--- a/src/crosshook-native/src-tauri/src/lib.rs
+++ b/src/crosshook-native/src-tauri/src/lib.rs
@@ -354,6 +354,7 @@ pub fn run() {
         .manage(commands::update::UpdateProcessState::new())
         .manage(commands::run_executable::RunExecutableProcessState::new())
         .manage(commands::prefix_deps::PrefixDepsInstallState::new())
+        .manage(std::sync::Arc::new(commands::protonup::ProtonInstallRegistry::default()))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
@@ -497,6 +498,11 @@ pub fn run() {
             commands::protonup::protonup_list_available_versions,
             commands::protonup::protonup_install_version,
             commands::protonup::protonup_get_suggestion,
+            commands::protonup::protonup_list_providers,
+            commands::protonup::protonup_resolve_install_roots,
+            commands::protonup::protonup_install_version_async,
+            commands::protonup::protonup_cancel_install,
+            commands::protonup::protonup_uninstall_version,
             // UMU database
             commands::umu_database::refresh_umu_database,
             commands::umu_database::check_umu_coverage,

--- a/src/crosshook-native/src/App.tsx
+++ b/src/crosshook-native/src/App.tsx
@@ -36,6 +36,7 @@ const VALID_APP_ROUTES: Record<AppRoute, true> = {
   settings: true,
   health: true,
   'host-tools': true,
+  'proton-manager': true,
 };
 
 function isAppRoute(value: string): value is AppRoute {

--- a/src/crosshook-native/src/components/SettingsPanel.tsx
+++ b/src/crosshook-native/src/components/SettingsPanel.tsx
@@ -886,32 +886,88 @@ function ProtonManagerDefaultsSection({
 }) {
   const [providers, setProviders] = useState<ProtonUpProviderDescriptor[]>([]);
   const [roots, setRoots] = useState<InstallRootDescriptor[]>([]);
+  const [providersDisabled, setProvidersDisabled] = useState(false);
+  const [rootsDisabled, setRootsDisabled] = useState(false);
 
   useEffect(() => {
     let active = true;
 
     void callCommand<ProtonUpProviderDescriptor[]>('protonup_list_providers')
       .then((result) => {
-        if (active) setProviders(result);
+        if (!active) return;
+        if (result.length === 0 && settings.protonup_default_provider) {
+          setProviders([
+            {
+              id: settings.protonup_default_provider,
+              display_name: settings.protonup_default_provider,
+              supports_install: true,
+              checksum_kind: 'none',
+            },
+          ]);
+          setProvidersDisabled(true);
+          return;
+        }
+        setProviders(result);
+        setProvidersDisabled(false);
       })
       .catch(() => {
-        if (active) setProviders([]);
+        if (!active) return;
+        if (settings.protonup_default_provider) {
+          setProviders([
+            {
+              id: settings.protonup_default_provider,
+              display_name: settings.protonup_default_provider,
+              supports_install: true,
+              checksum_kind: 'none',
+            },
+          ]);
+        } else {
+          setProviders([]);
+        }
+        setProvidersDisabled(true);
       });
 
     void callCommand<InstallRootDescriptor[]>('protonup_resolve_install_roots', {
       steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
     })
       .then((result) => {
-        if (active) setRoots(result);
+        if (!active) return;
+        if (result.length === 0 && settings.protonup_default_install_root) {
+          setRoots([
+            {
+              kind: 'native-steam',
+              path: settings.protonup_default_install_root,
+              writable: false,
+              reason: 'saved-but-unavailable',
+            },
+          ]);
+          setRootsDisabled(true);
+          return;
+        }
+        setRoots(result);
+        setRootsDisabled(false);
       })
       .catch(() => {
-        if (active) setRoots([]);
+        if (!active) return;
+        if (settings.protonup_default_install_root) {
+          setRoots([
+            {
+              kind: 'native-steam',
+              path: settings.protonup_default_install_root,
+              writable: false,
+              reason: 'saved-but-unavailable',
+            },
+          ]);
+        } else {
+          setRoots([]);
+        }
+        setRootsDisabled(true);
       });
 
     return () => {
       active = false;
     };
-  }, [steamClientInstallPath]);
+  }, [steamClientInstallPath, settings.protonup_default_provider, settings.protonup_default_install_root]);
 
   const installableProviders = useMemo(() => providers.filter((p) => p.supports_install), [providers]);
 
@@ -927,48 +983,57 @@ function ProtonManagerDefaultsSection({
         suggestions.
       </p>
 
-      {installableProviders.length > 0 ? (
-        <div className="crosshook-settings-field-row">
-          <label className="crosshook-label" htmlFor="protonup-default-provider">
-            Default provider
-          </label>
-          <select
-            id="protonup-default-provider"
-            className="crosshook-input"
-            value={settings.protonup_default_provider ?? ''}
-            onChange={(event) => void onPersistSettings({ protonup_default_provider: event.target.value })}
-          >
-            <option value="">Auto (first available)</option>
-            {installableProviders.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.display_name}
-              </option>
-            ))}
-          </select>
-        </div>
-      ) : null}
+      <div className="crosshook-settings-field-row">
+        <label className="crosshook-label" htmlFor="protonup-default-provider">
+          Default provider
+        </label>
+        <select
+          id="protonup-default-provider"
+          className="crosshook-input"
+          value={settings.protonup_default_provider ?? ''}
+          onChange={(event) => void onPersistSettings({ protonup_default_provider: event.target.value })}
+          disabled={providersDisabled || installableProviders.length === 0}
+        >
+          <option value="">Auto (first available)</option>
+          {installableProviders.map((p) => (
+            <option key={p.id} value={p.id}>
+              {providersDisabled ? `${p.display_name} (saved but unavailable)` : p.display_name}
+            </option>
+          ))}
+        </select>
+        {providersDisabled && settings.protonup_default_provider ? (
+          <p className="crosshook-muted crosshook-settings-note">
+            Saved default provider is currently unavailable. You can clear this setting once providers are reachable.
+          </p>
+        ) : null}
+      </div>
 
-      {roots.length > 0 ? (
-        <div className="crosshook-settings-field-row">
-          <label className="crosshook-label" htmlFor="protonup-default-install-root">
-            Default install root
-          </label>
-          <select
-            id="protonup-default-install-root"
-            className="crosshook-input"
-            value={settings.protonup_default_install_root ?? ''}
-            onChange={(event) => void onPersistSettings({ protonup_default_install_root: event.target.value })}
-          >
-            <option value="">Auto-pick (first writable)</option>
-            {roots.map((r) => (
-              <option key={r.path} value={r.path} disabled={!r.writable}>
-                {r.path}
-                {r.writable ? '' : ' (read-only)'}
-              </option>
-            ))}
-          </select>
-        </div>
-      ) : null}
+      <div className="crosshook-settings-field-row">
+        <label className="crosshook-label" htmlFor="protonup-default-install-root">
+          Default install root
+        </label>
+        <select
+          id="protonup-default-install-root"
+          className="crosshook-input"
+          value={settings.protonup_default_install_root ?? ''}
+          onChange={(event) => void onPersistSettings({ protonup_default_install_root: event.target.value })}
+          disabled={rootsDisabled || roots.length === 0}
+        >
+          <option value="">Auto-pick (first writable)</option>
+          {roots.map((r) => (
+            <option key={r.path} value={r.path} disabled={!r.writable}>
+              {r.path}
+              {r.writable ? '' : ' (read-only)'}
+            </option>
+          ))}
+        </select>
+        {rootsDisabled && settings.protonup_default_install_root ? (
+          <p className="crosshook-muted crosshook-settings-note">
+            Saved default install root is currently unavailable. You can clear this setting once install roots are
+            reachable.
+          </p>
+        ) : null}
+      </div>
 
       <label className="crosshook-settings-checkbox-row">
         <input

--- a/src/crosshook-native/src/components/SettingsPanel.tsx
+++ b/src/crosshook-native/src/components/SettingsPanel.tsx
@@ -13,6 +13,7 @@ import type {
   PrefixStorageEntry,
   StaleStagedTrainerEntry,
 } from '../types/prefix-storage';
+import type { InstallRootDescriptor, ProtonUpProviderDescriptor } from '../types/protonup';
 import { chooseDirectory, chooseFile } from '../utils/dialog';
 import { CollapsibleSection } from './ui/CollapsibleSection';
 import { ThemedSelect } from './ui/ThemedSelect';
@@ -874,6 +875,119 @@ function SteamGridDbSection({
   );
 }
 
+function ProtonManagerDefaultsSection({
+  settings,
+  steamClientInstallPath,
+  onPersistSettings,
+}: {
+  settings: AppSettingsData;
+  steamClientInstallPath: string;
+  onPersistSettings: (patch: Partial<AppSettingsData>) => Promise<void>;
+}) {
+  const [providers, setProviders] = useState<ProtonUpProviderDescriptor[]>([]);
+  const [roots, setRoots] = useState<InstallRootDescriptor[]>([]);
+
+  useEffect(() => {
+    let active = true;
+
+    void callCommand<ProtonUpProviderDescriptor[]>('protonup_list_providers')
+      .then((result) => {
+        if (active) setProviders(result);
+      })
+      .catch(() => {
+        if (active) setProviders([]);
+      });
+
+    void callCommand<InstallRootDescriptor[]>('protonup_resolve_install_roots', {
+      steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+    })
+      .then((result) => {
+        if (active) setRoots(result);
+      })
+      .catch(() => {
+        if (active) setRoots([]);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [steamClientInstallPath]);
+
+  const installableProviders = useMemo(() => providers.filter((p) => p.supports_install), [providers]);
+
+  return (
+    <CollapsibleSection
+      title="Proton manager defaults"
+      defaultOpen={false}
+      className="crosshook-panel crosshook-settings-section"
+      meta={<span className="crosshook-muted">Native Proton download manager</span>}
+    >
+      <p className="crosshook-muted crosshook-settings-help">
+        These settings control the native Proton download manager. They do not affect the legacy ProtonUp-Qt advisory
+        suggestions.
+      </p>
+
+      {installableProviders.length > 0 ? (
+        <div className="crosshook-settings-field-row">
+          <label className="crosshook-label" htmlFor="protonup-default-provider">
+            Default provider
+          </label>
+          <select
+            id="protonup-default-provider"
+            className="crosshook-input"
+            value={settings.protonup_default_provider ?? ''}
+            onChange={(event) => void onPersistSettings({ protonup_default_provider: event.target.value })}
+          >
+            <option value="">Auto (first available)</option>
+            {installableProviders.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+
+      {roots.length > 0 ? (
+        <div className="crosshook-settings-field-row">
+          <label className="crosshook-label" htmlFor="protonup-default-install-root">
+            Default install root
+          </label>
+          <select
+            id="protonup-default-install-root"
+            className="crosshook-input"
+            value={settings.protonup_default_install_root ?? ''}
+            onChange={(event) => void onPersistSettings({ protonup_default_install_root: event.target.value })}
+          >
+            <option value="">Auto-pick (first writable)</option>
+            {roots.map((r) => (
+              <option key={r.path} value={r.path} disabled={!r.writable}>
+                {r.path}
+                {r.writable ? '' : ' (read-only)'}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+
+      <label className="crosshook-settings-checkbox-row">
+        <input
+          type="checkbox"
+          checked={settings.protonup_include_prereleases ?? false}
+          onChange={(event) => void onPersistSettings({ protonup_include_prereleases: event.target.checked })}
+          className="crosshook-settings-checkbox"
+        />
+        <span>
+          <span className="crosshook-label">Include pre-release versions</span>
+          <p className="crosshook-muted crosshook-settings-note">
+            When enabled, the native Proton manager catalog will include release candidates and beta versions.
+          </p>
+        </span>
+      </label>
+    </CollapsibleSection>
+  );
+}
+
 export function SettingsPanel({
   settings,
   onPersistSettings,
@@ -1099,6 +1213,12 @@ export function SettingsPanel({
               </div>
             </div>
           </CollapsibleSection>
+
+          <ProtonManagerDefaultsSection
+            settings={settings}
+            steamClientInstallPath={steamClientInstallPath}
+            onPersistSettings={onPersistSettings}
+          />
 
           <CollapsibleSection
             title="Logging and UI"

--- a/src/crosshook-native/src/components/icons/SidebarIcons.tsx
+++ b/src/crosshook-native/src/components/icons/SidebarIcons.tsx
@@ -116,3 +116,16 @@ export function HostToolsIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function ProtonManagerIcon(props: IconProps) {
+  return (
+    <svg {...defaults} {...props} aria-hidden="true">
+      {/* Download tray */}
+      <rect x="2" y="13" width="16" height="5" rx="1.5" />
+      {/* Arrow */}
+      <path d="M10 2.5v8.5m0 0-3-3m3 3 3-3" />
+      {/* Version chip accent */}
+      <circle cx="16" cy="3.5" r="1.2" fill="currentColor" stroke="none" opacity={0.55} />
+    </svg>
+  );
+}

--- a/src/crosshook-native/src/components/layout/ContentArea.tsx
+++ b/src/crosshook-native/src/components/layout/ContentArea.tsx
@@ -9,6 +9,7 @@ import InstallPage from '../pages/InstallPage';
 import LaunchPage from '../pages/LaunchPage';
 import LibraryPage from '../pages/LibraryPage';
 import ProfilesPage from '../pages/ProfilesPage';
+import ProtonManagerPage from '../pages/ProtonManagerPage';
 import SettingsPage from '../pages/SettingsPage';
 import type { AppRoute } from './Sidebar';
 
@@ -53,6 +54,8 @@ export function ContentArea({ route, onNavigate }: ContentAreaProps) {
         return <HealthDashboardPage onNavigate={onNavigate} />;
       case 'host-tools':
         return <HostToolsPage />;
+      case 'proton-manager':
+        return <ProtonManagerPage />;
       case 'library':
         return <LibraryPage onNavigate={onNavigate} />;
       default: {

--- a/src/crosshook-native/src/components/layout/PageBanner.tsx
+++ b/src/crosshook-native/src/components/layout/PageBanner.tsx
@@ -193,3 +193,24 @@ export function HostToolsArt() {
     </svg>
   );
 }
+
+export function ProtonManagerArt() {
+  return (
+    <svg {...SVG_DEFAULTS} aria-hidden="true">
+      {/* Download tray */}
+      <rect x="10" y="38" width="44" height="14" rx="3" opacity={0.35} />
+      {/* Download arrow shaft */}
+      <line x1="32" y1="8" x2="32" y2="36" strokeWidth={2} opacity={0.45} />
+      {/* Arrow head */}
+      <path d="M23 27 L32 38 L41 27" strokeWidth={2} opacity={0.45} />
+      {/* Progress bar track + filled */}
+      <rect x="14" y="44" width="36" height="3" rx="1.5" opacity={0.18} />
+      <rect x="14" y="44" width="22" height="3" rx="1.5" fill="currentColor" opacity={0.32} stroke="none" />
+      {/* Proton "P" hint — version chip */}
+      <rect x="12" y="14" width="12" height="10" rx="2" opacity={0.22} />
+      <path d="M15 17 h4 a2 2 0 0 1 0 4 h-4" opacity={0.4} strokeWidth={1.5} />
+      {/* Accent dot */}
+      <circle cx="50" cy="14" r="2" fill="currentColor" opacity={0.22} stroke="none" />
+    </svg>
+  );
+}

--- a/src/crosshook-native/src/components/layout/Sidebar.tsx
+++ b/src/crosshook-native/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   LaunchIcon,
   LibraryIcon,
   ProfilesIcon,
+  ProtonManagerIcon,
   SettingsIcon,
 } from '../icons/SidebarIcons';
 import { ROUTE_NAV_LABEL } from './routeMetadata';
@@ -25,7 +26,8 @@ export type AppRoute =
   | 'compatibility'
   | 'settings'
   | 'health'
-  | 'host-tools';
+  | 'host-tools'
+  | 'proton-manager';
 
 export interface SidebarProps {
   activeRoute: AppRoute;
@@ -64,6 +66,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
     items: [
       { route: 'health', label: ROUTE_NAV_LABEL.health, icon: HealthIcon },
       { route: 'host-tools', label: ROUTE_NAV_LABEL['host-tools'], icon: HostToolsIcon },
+      { route: 'proton-manager', label: ROUTE_NAV_LABEL['proton-manager'], icon: ProtonManagerIcon },
     ],
   },
   {

--- a/src/crosshook-native/src/components/layout/routeMetadata.ts
+++ b/src/crosshook-native/src/components/layout/routeMetadata.ts
@@ -9,6 +9,7 @@ import {
   LaunchArt,
   LibraryArt,
   ProfilesArt,
+  ProtonManagerArt,
   SettingsArt,
 } from './PageBanner';
 import type { AppRoute } from './Sidebar';
@@ -96,6 +97,13 @@ export const ROUTE_METADATA: Record<AppRoute, RouteMetadataEntry> = {
       'Inspect detected host tools, capability state, and install guidance for everything CrossHook delegates to your host.',
     Art: HostToolsArt,
   },
+  'proton-manager': {
+    navLabel: 'Proton Manager',
+    sectionEyebrow: 'Dashboards',
+    bannerTitle: 'Proton Manager',
+    bannerSummary: 'Download, install, and manage Proton compatibility tool versions for your Steam library.',
+    Art: ProtonManagerArt,
+  },
 };
 
 /** Sidebar + status row labels (single source of truth). */
@@ -110,4 +118,5 @@ export const ROUTE_NAV_LABEL: Record<AppRoute, string> = {
   settings: ROUTE_METADATA.settings.navLabel,
   health: ROUTE_METADATA.health.navLabel,
   'host-tools': ROUTE_METADATA['host-tools'].navLabel,
+  'proton-manager': ROUTE_METADATA['proton-manager'].navLabel,
 };

--- a/src/crosshook-native/src/components/pages/ProtonManagerPage.tsx
+++ b/src/crosshook-native/src/components/pages/ProtonManagerPage.tsx
@@ -15,7 +15,7 @@ export function ProtonManagerPage({ steamClientInstallPath: steamPathProp }: Pro
   const { steamClientInstallPath: profileSteamPath } = useProfileContext();
 
   const effectiveSteamPath = useMemo(
-    () => steamPathProp ?? defaultSteamClientInstallPath ?? profileSteamPath ?? '',
+    () => steamPathProp || defaultSteamClientInstallPath || profileSteamPath || '',
     [steamPathProp, defaultSteamClientInstallPath, profileSteamPath]
   );
 

--- a/src/crosshook-native/src/components/pages/ProtonManagerPage.tsx
+++ b/src/crosshook-native/src/components/pages/ProtonManagerPage.tsx
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { usePreferencesContext } from '../../context/PreferencesContext';
+import { useProfileContext } from '../../context/ProfileContext';
+import { RouteBanner } from '../layout/RouteBanner';
+import { ProtonManagerPanel } from '../proton-manager/ProtonManagerPanel';
+
+import '../../styles/proton-manager.css';
+
+interface ProtonManagerPageProps {
+  steamClientInstallPath?: string;
+}
+
+export function ProtonManagerPage({ steamClientInstallPath: steamPathProp }: ProtonManagerPageProps) {
+  const { defaultSteamClientInstallPath } = usePreferencesContext();
+  const { steamClientInstallPath: profileSteamPath } = useProfileContext();
+
+  const effectiveSteamPath = useMemo(
+    () => steamPathProp ?? defaultSteamClientInstallPath ?? profileSteamPath ?? '',
+    [steamPathProp, defaultSteamClientInstallPath, profileSteamPath]
+  );
+
+  return (
+    <div className="crosshook-page-scroll-shell crosshook-page-scroll-shell--fill crosshook-page-scroll-shell--proton-manager">
+      <div className="crosshook-route-stack" data-crosshook-focus-zone="content">
+        <div className="crosshook-route-stack__body--scroll">
+          <RouteBanner route="proton-manager" />
+          <div className="crosshook-panel">
+            <ProtonManagerPanel
+              steamClientInstallPath={effectiveSteamPath.length > 0 ? effectiveSteamPath : undefined}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ProtonManagerPage;

--- a/src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx
+++ b/src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx
@@ -1,0 +1,83 @@
+import { useProtonInstallProgress } from '../../hooks/useProtonInstallProgress';
+import type { ProtonInstallPhase } from '../../types/protonup';
+
+interface InstallProgressBarProps {
+  opId: string;
+  onCancel: (opId: string) => void;
+}
+
+const TERMINAL_PHASES: Set<ProtonInstallPhase> = new Set(['done', 'failed', 'cancelled']);
+
+function phaseLabel(phase: ProtonInstallPhase, percent: number | null): string {
+  switch (phase) {
+    case 'resolving':
+      return 'Resolving…';
+    case 'downloading':
+      return percent !== null ? `Downloading ${percent}%` : 'Downloading…';
+    case 'verifying':
+      return 'Verifying…';
+    case 'extracting':
+      return 'Extracting…';
+    case 'finalizing':
+      return 'Finalizing…';
+    case 'done':
+      return 'Done';
+    case 'failed':
+      return 'Failed';
+    case 'cancelled':
+      return 'Cancelled';
+    default: {
+      const _exhaustive: never = phase;
+      return String(_exhaustive);
+    }
+  }
+}
+
+function phaseModifier(phase: ProtonInstallPhase): string {
+  if (phase === 'done') return ' crosshook-install-progress__phase--done';
+  if (phase === 'failed') return ' crosshook-install-progress__phase--failed';
+  if (phase === 'cancelled') return ' crosshook-install-progress__phase--cancelled';
+  return '';
+}
+
+function fillModifier(phase: ProtonInstallPhase): string {
+  if (phase === 'done') return ' crosshook-install-progress__fill--done';
+  if (phase === 'failed') return ' crosshook-install-progress__fill--failed';
+  return '';
+}
+
+export function InstallProgressBar({ opId, onCancel }: InstallProgressBarProps) {
+  const { progress, percent } = useProtonInstallProgress(opId);
+
+  // While no progress event has arrived yet show an indeterminate state.
+  const phase = progress?.phase ?? 'resolving';
+  const displayPercent = percent ?? (TERMINAL_PHASES.has(phase) ? 100 : 0);
+  const isTerminal = TERMINAL_PHASES.has(phase);
+
+  return (
+    <div className="crosshook-install-progress" role="status" aria-live="polite">
+      <div className="crosshook-install-progress__top">
+        <span className="crosshook-install-progress__label">Installing {opId.slice(0, 8)}…</span>
+        <span className={`crosshook-install-progress__phase${phaseModifier(phase)}`}>{phaseLabel(phase, percent)}</span>
+        {!isTerminal ? (
+          <button
+            type="button"
+            className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
+            onClick={() => onCancel(opId)}
+          >
+            Cancel
+          </button>
+        ) : null}
+      </div>
+
+      <div className="crosshook-install-progress__track" aria-hidden="true">
+        <div
+          className={`crosshook-install-progress__fill${fillModifier(phase)}`}
+          style={{ width: `${displayPercent}%` }}
+        />
+      </div>
+
+      {progress?.message ? <div className="crosshook-install-progress__message">{progress.message}</div> : null}
+    </div>
+  );
+}

--- a/src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx
+++ b/src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx
@@ -89,6 +89,7 @@ export function InstallProgressBar({ opId, onCancel, onDismiss }: InstallProgres
             type="button"
             className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
             onClick={() => onCancel(opId)}
+            aria-label={`Cancel install ${opId.slice(0, 8)}`}
           >
             Cancel
           </button>

--- a/src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx
+++ b/src/crosshook-native/src/components/proton-manager/InstallProgressBar.tsx
@@ -1,10 +1,15 @@
+import { useEffect } from 'react';
 import { useProtonInstallProgress } from '../../hooks/useProtonInstallProgress';
 import type { ProtonInstallPhase } from '../../types/protonup';
 
 interface InstallProgressBarProps {
   opId: string;
   onCancel: (opId: string) => void;
+  onDismiss: (opId: string) => void;
 }
+
+/** How long to keep a successful install visible before auto-dismissing. */
+const AUTO_DISMISS_DONE_MS = 4000;
 
 const TERMINAL_PHASES: Set<ProtonInstallPhase> = new Set(['done', 'failed', 'cancelled']);
 
@@ -21,7 +26,7 @@ function phaseLabel(phase: ProtonInstallPhase, percent: number | null): string {
     case 'finalizing':
       return 'Finalizing…';
     case 'done':
-      return 'Done';
+      return 'Completed';
     case 'failed':
       return 'Failed';
     case 'cancelled':
@@ -46,7 +51,7 @@ function fillModifier(phase: ProtonInstallPhase): string {
   return '';
 }
 
-export function InstallProgressBar({ opId, onCancel }: InstallProgressBarProps) {
+export function InstallProgressBar({ opId, onCancel, onDismiss }: InstallProgressBarProps) {
   const { progress, percent } = useProtonInstallProgress(opId);
 
   // While no progress event has arrived yet show an indeterminate state.
@@ -54,12 +59,32 @@ export function InstallProgressBar({ opId, onCancel }: InstallProgressBarProps) 
   const displayPercent = percent ?? (TERMINAL_PHASES.has(phase) ? 100 : 0);
   const isTerminal = TERMINAL_PHASES.has(phase);
 
+  // Auto-dismiss successful installs after a short grace period so the
+  // status container doesn't linger. Failures and cancellations stay until
+  // the user dismisses them explicitly.
+  useEffect(() => {
+    if (phase !== 'done') return;
+    const timeout = window.setTimeout(() => onDismiss(opId), AUTO_DISMISS_DONE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [phase, opId, onDismiss]);
+
+  const installLabel = progress?.message ?? `Installing ${opId.slice(0, 8)}…`;
+
   return (
     <div className="crosshook-install-progress" role="status" aria-live="polite">
       <div className="crosshook-install-progress__top">
-        <span className="crosshook-install-progress__label">Installing {opId.slice(0, 8)}…</span>
+        <span className="crosshook-install-progress__label">{installLabel}</span>
         <span className={`crosshook-install-progress__phase${phaseModifier(phase)}`}>{phaseLabel(phase, percent)}</span>
-        {!isTerminal ? (
+        {isTerminal ? (
+          <button
+            type="button"
+            className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
+            onClick={() => onDismiss(opId)}
+            aria-label="Dismiss install status"
+          >
+            Dismiss
+          </button>
+        ) : (
           <button
             type="button"
             className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
@@ -67,7 +92,7 @@ export function InstallProgressBar({ opId, onCancel }: InstallProgressBarProps) 
           >
             Cancel
           </button>
-        ) : null}
+        )}
       </div>
 
       <div className="crosshook-install-progress__track" aria-hidden="true">
@@ -76,8 +101,6 @@ export function InstallProgressBar({ opId, onCancel }: InstallProgressBarProps) 
           style={{ width: `${displayPercent}%` }}
         />
       </div>
-
-      {progress?.message ? <div className="crosshook-install-progress__message">{progress.message}</div> : null}
     </div>
   );
 }

--- a/src/crosshook-native/src/components/proton-manager/InstallRootBadge.tsx
+++ b/src/crosshook-native/src/components/proton-manager/InstallRootBadge.tsx
@@ -40,9 +40,13 @@ export function InstallRootBadge({ root, isDefault, isSelected, onSelect }: Inst
     <button
       type="button"
       className={classNames}
-      onClick={() => onSelect(root.path)}
+      onClick={() => {
+        if (root.writable) onSelect(root.path);
+      }}
       title={root.path}
       aria-pressed={isSelected}
+      disabled={!root.writable}
+      aria-disabled={!root.writable}
     >
       <span>{kindLabel(root.kind)}</span>
       <span className="crosshook-install-root-badge__path">{truncatePath(root.path)}</span>

--- a/src/crosshook-native/src/components/proton-manager/InstallRootBadge.tsx
+++ b/src/crosshook-native/src/components/proton-manager/InstallRootBadge.tsx
@@ -1,0 +1,57 @@
+import type { InstallRootDescriptor, InstallRootKind } from '../../types/protonup';
+
+interface InstallRootBadgeProps {
+  root: InstallRootDescriptor;
+  isDefault: boolean;
+  isSelected: boolean;
+  onSelect: (path: string) => void;
+}
+
+function kindLabel(kind: InstallRootKind): string {
+  switch (kind) {
+    case 'native-steam':
+      return 'Native Steam';
+    case 'flatpak-steam':
+      return 'Flatpak Steam';
+    default: {
+      const _exhaustive: never = kind;
+      return String(_exhaustive);
+    }
+  }
+}
+
+function truncatePath(path: string): string {
+  if (path.length <= 48) return path;
+  return `${path.slice(0, 20)}...${path.slice(-24)}`;
+}
+
+export function InstallRootBadge({ root, isDefault, isSelected, onSelect }: InstallRootBadgeProps) {
+  const muted = !root.writable;
+
+  const classNames = [
+    'crosshook-install-root-badge',
+    isSelected ? 'crosshook-install-root-badge--selected' : '',
+    muted ? 'crosshook-install-root-badge--muted' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      className={classNames}
+      onClick={() => onSelect(root.path)}
+      title={root.path}
+      aria-pressed={isSelected}
+    >
+      <span>{kindLabel(root.kind)}</span>
+      <span className="crosshook-install-root-badge__path">{truncatePath(root.path)}</span>
+      <span
+        className={`crosshook-install-root-badge__pill ${root.writable ? 'crosshook-install-root-badge__pill--writable' : 'crosshook-install-root-badge__pill--readonly'}`}
+      >
+        {root.writable ? 'writable' : 'read-only'}
+      </span>
+      {isDefault ? <span className="crosshook-install-root-badge__default-tag">Default</span> : null}
+    </button>
+  );
+}

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -1,0 +1,281 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useProtonManager } from '../../hooks/useProtonManager';
+import { classifyInstallProvider } from '../../lib/protonup/classifyInstall';
+import type { ProtonUpInstallRequest } from '../../types/protonup';
+import { InstallProgressBar } from './InstallProgressBar';
+import { InstallRootBadge } from './InstallRootBadge';
+import { ProviderPicker } from './ProviderPicker';
+import { VersionRow } from './VersionRow';
+
+interface ProtonManagerPanelProps {
+  steamClientInstallPath?: string;
+}
+
+export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPanelProps) {
+  const manager = useProtonManager({ steamClientInstallPath });
+
+  const [selectedRootPath, setSelectedRootPath] = useState<string | null>(null);
+  const [uninstallWarning, setUninstallWarning] = useState<string | null>(null);
+  const [uninstallError, setUninstallError] = useState<string | null>(null);
+
+  const effectiveRoot = useMemo(() => {
+    if (selectedRootPath !== null) {
+      return manager.roots.find((r) => r.path === selectedRootPath) ?? manager.defaultRoot;
+    }
+    return manager.defaultRoot;
+  }, [selectedRootPath, manager.roots, manager.defaultRoot]);
+
+  const hasWritableRoot = manager.roots.some((r) => r.writable);
+
+  const providersById = useMemo(() => new Map(manager.providers.map((p) => [p.id, p])), [manager.providers]);
+
+  // Track which versions are actively installing (keyed by `${provider}:${version}`
+  // so the same tag on two providers is tracked independently in All mode).
+  const [installingKeys, setInstallingKeys] = useState<Set<string>>(new Set());
+
+  const handleInstall = useCallback(
+    async (providerId: string, version: string) => {
+      if (!effectiveRoot) return;
+
+      const request: ProtonUpInstallRequest = {
+        provider: providerId,
+        version,
+        target_root: effectiveRoot.path,
+      };
+
+      const key = `${providerId}:${version}`;
+      setInstallingKeys((prev) => new Set(prev).add(key));
+      try {
+        await manager.install(request, version);
+      } finally {
+        setInstallingKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      }
+    },
+    [effectiveRoot, manager]
+  );
+
+  const handleCancel = useCallback(
+    (opId: string) => {
+      void manager.cancel(opId);
+    },
+    [manager]
+  );
+
+  const handleUninstall = useCallback(
+    async (toolPath: string) => {
+      setUninstallWarning(null);
+      setUninstallError(null);
+      try {
+        const result = await manager.uninstall(toolPath);
+        if (!result.success) {
+          setUninstallError(result.error_message ?? 'Uninstall failed.');
+        } else if (result.conflicting_app_ids.length > 0) {
+          setUninstallWarning(
+            `Uninstalled. The following apps referenced this version: ${result.conflicting_app_ids.join(', ')}`
+          );
+        }
+      } catch (err) {
+        setUninstallError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [manager]
+  );
+
+  // Filter installed list by selected provider. In All mode, show everything.
+  // `null` classification (tag doesn't match any known provider) is surfaced
+  // only in All mode so a user switching to a specific provider doesn't see
+  // unclassified installs erroneously attributed to that provider.
+  const filteredInstalls = useMemo(() => {
+    if (manager.selectedProviderId === null) {
+      return manager.installs.installs;
+    }
+    return manager.installs.installs.filter((i) => classifyInstallProvider(i.name) === manager.selectedProviderId);
+  }, [manager.installs.installs, manager.selectedProviderId]);
+
+  // Names of all installed tools (used to suppress duplicates in the
+  // available list regardless of provider filter).
+  const installedNames = useMemo(
+    () => new Set(manager.installs.installs.map((i) => i.name)),
+    [manager.installs.installs]
+  );
+
+  const availableVersions = useMemo(
+    () => manager.catalog.versions.filter((v) => !installedNames.has(v.version)),
+    [manager.catalog.versions, installedNames]
+  );
+
+  // Lookup table for enriching installed rows with catalog metadata
+  // (release date, archive size). Keyed by `${provider}:${version}` so same
+  // tag on two providers doesn't collide.
+  const catalogByKey = useMemo(() => {
+    const map = new Map<string, (typeof manager.catalog.versions)[number]>();
+    for (const v of manager.catalog.versions) {
+      map.set(`${v.provider}:${v.version}`, v);
+    }
+    return map;
+  }, [manager.catalog.versions]);
+
+  if (manager.loading) {
+    return (
+      <div className="crosshook-proton-manager" aria-busy="true">
+        <p className="crosshook-muted">Loading Proton manager…</p>
+      </div>
+    );
+  }
+
+  const cacheMeta = manager.catalog.cacheMeta;
+  const showStaleBanner = cacheMeta != null && (cacheMeta.stale || cacheMeta.offline);
+
+  return (
+    <div className="crosshook-proton-manager">
+      <div className="crosshook-proton-manager__header">
+        <ProviderPicker
+          providers={manager.providers}
+          selectedProviderId={manager.selectedProviderId}
+          onSelect={manager.setSelectedProviderId}
+        />
+
+        {manager.roots.length > 0 ? (
+          <fieldset className="crosshook-proton-manager__roots">
+            <legend className="crosshook-provider-picker__legend">Install root</legend>
+            {manager.roots.map((root) => (
+              <InstallRootBadge
+                key={root.path}
+                root={root}
+                isDefault={manager.defaultRoot?.path === root.path}
+                isSelected={(effectiveRoot?.path ?? '') === root.path}
+                onSelect={setSelectedRootPath}
+              />
+            ))}
+          </fieldset>
+        ) : null}
+      </div>
+
+      {showStaleBanner ? (
+        <div className="crosshook-proton-manager__stale-banner" role="status">
+          {cacheMeta?.offline
+            ? 'Offline — showing cached catalog. Connect to the internet to refresh.'
+            : 'Catalog data may be stale.'}
+          {!cacheMeta?.offline ? (
+            <button
+              type="button"
+              className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
+              style={{ marginLeft: 8 }}
+              onClick={() => manager.catalog.refreshCatalog()}
+            >
+              Refresh
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {!hasWritableRoot && manager.roots.length > 0 ? (
+        <div className="crosshook-proton-manager__readonly-banner" role="alert">
+          No writable compatibilitytools.d found. In Flatpak, this typically means the Steam data path is read-only.
+          Install actions are disabled.
+        </div>
+      ) : null}
+
+      {manager.activeOpIds.length > 0 ? (
+        <div className="crosshook-proton-manager__progress-list">
+          {manager.activeOpIds.map((opId) => (
+            <InstallProgressBar key={opId} opId={opId} onCancel={handleCancel} />
+          ))}
+        </div>
+      ) : null}
+
+      {uninstallWarning ? (
+        <div className="crosshook-proton-manager__stale-banner" role="status">
+          {uninstallWarning}
+        </div>
+      ) : null}
+
+      {uninstallError ? (
+        <div className="crosshook-proton-manager__error-banner" role="alert">
+          {uninstallError}
+        </div>
+      ) : null}
+
+      {manager.error ? (
+        <div className="crosshook-proton-manager__error-banner" role="alert">
+          {manager.error}
+        </div>
+      ) : null}
+
+      <ul className="crosshook-proton-manager__list" aria-label="Proton versions">
+        {filteredInstalls.length > 0 ? (
+          <>
+            <li className="crosshook-proton-manager__section-label" aria-hidden="true">
+              Installed
+            </li>
+            {filteredInstalls.map((install) => {
+              const classified = classifyInstallProvider(install.name);
+              const rowProvider = classified ?? 'unknown';
+              const catalogMatch = classified ? (catalogByKey.get(`${classified}:${install.name}`) ?? null) : null;
+              return (
+                <li key={install.name}>
+                  <VersionRow
+                    version={install.name}
+                    provider={rowProvider}
+                    installed={true}
+                    installing={false}
+                    canInstall={false}
+                    onInstall={() => undefined}
+                    onUninstall={() => void handleUninstall(install.path)}
+                    publishedAt={catalogMatch?.published_at ?? null}
+                    assetSize={catalogMatch?.asset_size ?? null}
+                  />
+                </li>
+              );
+            })}
+          </>
+        ) : null}
+
+        {manager.catalog.catalogLoading ? (
+          <li>
+            <p className="crosshook-proton-manager__empty crosshook-muted">Loading catalog…</p>
+          </li>
+        ) : availableVersions.length > 0 ? (
+          <>
+            <li className="crosshook-proton-manager__section-label" aria-hidden="true">
+              Available
+            </li>
+            {availableVersions.map((v) => {
+              const providerDescriptor = providersById.get(v.provider);
+              const providerSupportsInstall = providerDescriptor?.supports_install ?? false;
+              const rowCanInstall = hasWritableRoot && providerSupportsInstall;
+              const key = `${v.provider}:${v.version}`;
+              return (
+                <li key={key}>
+                  <VersionRow
+                    version={v.version}
+                    provider={v.provider}
+                    installed={false}
+                    installing={installingKeys.has(key)}
+                    canInstall={rowCanInstall}
+                    onInstall={() => void handleInstall(v.provider, v.version)}
+                    onUninstall={() => undefined}
+                    publishedAt={v.published_at ?? null}
+                    assetSize={v.asset_size ?? null}
+                  />
+                </li>
+              );
+            })}
+          </>
+        ) : !manager.catalog.catalogLoading && availableVersions.length === 0 && filteredInstalls.length === 0 ? (
+          <li>
+            <p className="crosshook-proton-manager__empty crosshook-muted">
+              {manager.selectedProviderId === null
+                ? 'No Proton versions found.'
+                : 'No versions found for this provider.'}
+            </p>
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useProtonManager } from '../../hooks/useProtonManager';
 import { classifyInstallProvider, normalizeInstallToTag } from '../../lib/protonup/classifyInstall';
 import type { ProtonUpAvailableVersion, ProtonUpInstallRequest } from '../../types/protonup';
@@ -45,9 +45,34 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
 
   const providersById = useMemo(() => new Map(manager.providers.map((p) => [p.id, p])), [manager.providers]);
 
-  // Track which versions are actively installing (keyed by `${provider}:${version}`
-  // so the same tag on two providers is tracked independently in All mode).
-  const [installingKeys, setInstallingKeys] = useState<Set<string>>(new Set());
+  // Track in-flight installs until IPC returns (`pendingKeys`) and until the op is
+  // dismissed from `activeOpIds` (`keyToOpId`). `manager.install` resolves early with
+  // a handle — do not clear the row state in `finally` or the user can double-install.
+  const [pendingKeys, setPendingKeys] = useState<Set<string>>(new Set());
+  const [keyToOpId, setKeyToOpId] = useState<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    const active = new Set(manager.activeOpIds);
+    setKeyToOpId((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const [k, opId] of prev) {
+        if (!active.has(opId)) {
+          next.delete(k);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [manager.activeOpIds]);
+
+  const installingKeys = useMemo(() => {
+    const out = new Set<string>(pendingKeys);
+    for (const k of keyToOpId.keys()) {
+      out.add(k);
+    }
+    return out;
+  }, [pendingKeys, keyToOpId]);
 
   const handleInstall = useCallback(
     async (versionDto: ProtonUpAvailableVersion) => {
@@ -64,13 +89,26 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
       };
 
       const key = `${versionDto.provider}:${versionDto.version}`;
-      setInstallingKeys((prev) => new Set(prev).add(key));
+      setPendingKeys((prev) => new Set(prev).add(key));
       try {
-        await manager.install(request, versionDto);
+        const handle = await manager.install(request, versionDto);
+        setKeyToOpId((prev) => {
+          const next = new Map(prev);
+          next.set(key, handle.op_id);
+          return next;
+        });
       } catch (err) {
         setInstallError(err instanceof Error ? err.message : String(err));
+        setKeyToOpId((prev) => {
+          if (!prev.has(key)) {
+            return prev;
+          }
+          const next = new Map(prev);
+          next.delete(key);
+          return next;
+        });
       } finally {
-        setInstallingKeys((prev) => {
+        setPendingKeys((prev) => {
           const next = new Set(prev);
           next.delete(key);
           return next;
@@ -401,7 +439,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
             {displayedInstalls.map(({ install, classified, catalogMatch }) => {
               const rowProvider = classified ?? 'unknown';
               return (
-                <li key={install.name}>
+                <li key={install.path}>
                   <VersionRow
                     version={install.name}
                     provider={rowProvider}

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -17,6 +17,13 @@ interface PendingUninstallConfirmation {
   conflictingAppIds: string[];
 }
 
+function sortVersionLabelsDesc(left: string, right: string): number {
+  return right.localeCompare(left, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
 export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPanelProps) {
   const manager = useProtonManager({ steamClientInstallPath });
 
@@ -199,6 +206,46 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
     return map;
   }, [manager.catalog.versions]);
 
+  const displayedInstalls = useMemo(() => {
+    const installsWithCatalog = filteredInstalls.map((install) => {
+      const classified = classifyInstallProvider(install.name);
+      const catalogMatch = classified
+        ? (catalogByKey.get(`${classified}:${normalizeInstallToTag(install.name, classified)}`) ?? null)
+        : null;
+
+      return {
+        install,
+        classified,
+        catalogMatch,
+      };
+    });
+
+    installsWithCatalog.sort((left, right) => {
+      if (left.install.is_official !== right.install.is_official) {
+        return left.install.is_official ? -1 : 1;
+      }
+
+      const leftPublished = left.catalogMatch?.published_at ?? '';
+      const rightPublished = right.catalogMatch?.published_at ?? '';
+
+      if (leftPublished && rightPublished && leftPublished !== rightPublished) {
+        return rightPublished.localeCompare(leftPublished);
+      }
+      if (leftPublished && !rightPublished) {
+        return -1;
+      }
+      if (!leftPublished && rightPublished) {
+        return 1;
+      }
+
+      return (
+        sortVersionLabelsDesc(left.install.name, right.install.name) || left.install.path.localeCompare(right.install.path)
+      );
+    });
+
+    return installsWithCatalog;
+  }, [catalogByKey, filteredInstalls]);
+
   if (manager.loading) {
     return (
       <div className="crosshook-proton-manager" aria-busy="true">
@@ -345,17 +392,13 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
       ) : null}
 
       <ul className="crosshook-proton-manager__list" aria-label="Proton versions">
-        {filteredInstalls.length > 0 ? (
+        {displayedInstalls.length > 0 ? (
           <>
             <li className="crosshook-proton-manager__section-label" aria-hidden="true">
               Installed
             </li>
-            {filteredInstalls.map((install) => {
-              const classified = classifyInstallProvider(install.name);
+            {displayedInstalls.map(({ install, classified, catalogMatch }) => {
               const rowProvider = classified ?? 'unknown';
-              const catalogMatch = classified
-                ? (catalogByKey.get(`${classified}:${normalizeInstallToTag(install.name, classified)}`) ?? null)
-                : null;
               return (
                 <li key={install.name}>
                   <VersionRow
@@ -406,7 +449,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
               );
             })}
           </>
-        ) : !manager.catalog.catalogLoading && availableVersions.length === 0 && filteredInstalls.length === 0 ? (
+        ) : !manager.catalog.catalogLoading && availableVersions.length === 0 && displayedInstalls.length === 0 ? (
           <li>
             <p className="crosshook-proton-manager__empty crosshook-muted">
               {manager.selectedProviderId === null

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useProtonManager } from '../../hooks/useProtonManager';
-import { classifyInstallProvider } from '../../lib/protonup/classifyInstall';
-import type { ProtonUpInstallRequest } from '../../types/protonup';
+import { classifyInstallProvider, normalizeInstallToTag } from '../../lib/protonup/classifyInstall';
+import type { ProtonUpAvailableVersion, ProtonUpInstallRequest } from '../../types/protonup';
 import { InstallProgressBar } from './InstallProgressBar';
 import { InstallRootBadge } from './InstallRootBadge';
 import { ProviderPicker } from './ProviderPicker';
@@ -17,6 +17,8 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
   const [selectedRootPath, setSelectedRootPath] = useState<string | null>(null);
   const [uninstallWarning, setUninstallWarning] = useState<string | null>(null);
   const [uninstallError, setUninstallError] = useState<string | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [cancelError, setCancelError] = useState<string | null>(null);
 
   const effectiveRoot = useMemo(() => {
     if (selectedRootPath !== null) {
@@ -34,19 +36,25 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
   const [installingKeys, setInstallingKeys] = useState<Set<string>>(new Set());
 
   const handleInstall = useCallback(
-    async (providerId: string, version: string) => {
-      if (!effectiveRoot) return;
+    async (versionDto: ProtonUpAvailableVersion) => {
+      setInstallError(null);
+      if (!effectiveRoot) {
+        setInstallError('No writable install root available.');
+        return;
+      }
 
       const request: ProtonUpInstallRequest = {
-        provider: providerId,
-        version,
+        provider: versionDto.provider,
+        version: versionDto.version,
         target_root: effectiveRoot.path,
       };
 
-      const key = `${providerId}:${version}`;
+      const key = `${versionDto.provider}:${versionDto.version}`;
       setInstallingKeys((prev) => new Set(prev).add(key));
       try {
-        await manager.install(request, version);
+        await manager.install(request, versionDto);
+      } catch (err) {
+        setInstallError(err instanceof Error ? err.message : String(err));
       } finally {
         setInstallingKeys((prev) => {
           const next = new Set(prev);
@@ -59,8 +67,26 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
   );
 
   const handleCancel = useCallback(
+    async (opId: string) => {
+      setCancelError(null);
+      try {
+        const cancelled = await manager.cancel(opId);
+        if (!cancelled) {
+          setCancelError('Cancel request was not accepted. The install may have already completed.');
+        }
+      } catch (err) {
+        setCancelError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [manager]
+  );
+
+  const handleDismissOp = useCallback(
     (opId: string) => {
-      void manager.cancel(opId);
+      manager.dismissOp(opId);
+      // A terminal op may have produced a new install; rescan so the row
+      // migrates from Available → Installed without requiring a page reload.
+      manager.installs.reload();
     },
     [manager]
   );
@@ -96,16 +122,22 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
     return manager.installs.installs.filter((i) => classifyInstallProvider(i.name) === manager.selectedProviderId);
   }, [manager.installs.installs, manager.selectedProviderId]);
 
-  // Names of all installed tools (used to suppress duplicates in the
-  // available list regardless of provider filter).
-  const installedNames = useMemo(
-    () => new Set(manager.installs.installs.map((i) => i.name)),
-    [manager.installs.installs]
-  );
+  // Set of keys identifying installed tools, normalized so Proton-CachyOS's
+  // directory name (e.g. `proton-cachyos-<tag>-x86_64`) matches its catalog
+  // tag (e.g. `cachyos-<tag>`). Key shape: `${providerId}:${normalizedTag}`.
+  const installedKeySet = useMemo(() => {
+    const keys = new Set<string>();
+    for (const install of manager.installs.installs) {
+      const pid = classifyInstallProvider(install.name);
+      if (pid === null) continue;
+      keys.add(`${pid}:${normalizeInstallToTag(install.name, pid)}`);
+    }
+    return keys;
+  }, [manager.installs.installs]);
 
   const availableVersions = useMemo(
-    () => manager.catalog.versions.filter((v) => !installedNames.has(v.version)),
-    [manager.catalog.versions, installedNames]
+    () => manager.catalog.versions.filter((v) => !installedKeySet.has(`${v.provider}:${v.version}`)),
+    [manager.catalog.versions, installedKeySet]
   );
 
   // Lookup table for enriching installed rows with catalog metadata
@@ -183,7 +215,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
       {manager.activeOpIds.length > 0 ? (
         <div className="crosshook-proton-manager__progress-list">
           {manager.activeOpIds.map((opId) => (
-            <InstallProgressBar key={opId} opId={opId} onCancel={handleCancel} />
+            <InstallProgressBar key={opId} opId={opId} onCancel={handleCancel} onDismiss={handleDismissOp} />
           ))}
         </div>
       ) : null}
@@ -197,6 +229,18 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
       {uninstallError ? (
         <div className="crosshook-proton-manager__error-banner" role="alert">
           {uninstallError}
+        </div>
+      ) : null}
+
+      {installError ? (
+        <div className="crosshook-proton-manager__error-banner" role="alert">
+          Install failed: {installError}
+        </div>
+      ) : null}
+
+      {cancelError ? (
+        <div className="crosshook-proton-manager__error-banner" role="alert">
+          Cancel failed: {cancelError}
         </div>
       ) : null}
 
@@ -215,7 +259,9 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
             {filteredInstalls.map((install) => {
               const classified = classifyInstallProvider(install.name);
               const rowProvider = classified ?? 'unknown';
-              const catalogMatch = classified ? (catalogByKey.get(`${classified}:${install.name}`) ?? null) : null;
+              const catalogMatch = classified
+                ? (catalogByKey.get(`${classified}:${normalizeInstallToTag(install.name, classified)}`) ?? null)
+                : null;
               return (
                 <li key={install.name}>
                   <VersionRow
@@ -257,7 +303,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
                     installed={false}
                     installing={installingKeys.has(key)}
                     canInstall={rowCanInstall}
-                    onInstall={() => void handleInstall(v.provider, v.version)}
+                    onInstall={() => void handleInstall(v)}
                     onUninstall={() => undefined}
                     publishedAt={v.published_at ?? null}
                     assetSize={v.asset_size ?? null}

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -11,6 +11,12 @@ interface ProtonManagerPanelProps {
   steamClientInstallPath?: string;
 }
 
+interface PendingUninstallConfirmation {
+  toolPath: string;
+  versionLabel: string;
+  conflictingAppIds: string[];
+}
+
 export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPanelProps) {
   const manager = useProtonManager({ steamClientInstallPath });
 
@@ -19,6 +25,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
   const [uninstallError, setUninstallError] = useState<string | null>(null);
   const [installError, setInstallError] = useState<string | null>(null);
   const [cancelError, setCancelError] = useState<string | null>(null);
+  const [pendingUninstall, setPendingUninstall] = useState<PendingUninstallConfirmation | null>(null);
 
   const effectiveRoot = useMemo(() => {
     if (selectedRootPath !== null) {
@@ -91,30 +98,18 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
     [manager]
   );
 
-  const handleUninstall = useCallback(
-    async (toolPath: string) => {
+  const performUninstall = useCallback(
+    async (toolPath: string, versionLabel: string, conflictingAppIds: string[]) => {
       setUninstallWarning(null);
       setUninstallError(null);
+      setPendingUninstall(null);
       try {
-        const plan = await manager.planUninstall(toolPath);
-        if (!plan.success) {
-          setUninstallError(plan.error_message ?? 'Uninstall plan failed.');
-          return;
-        }
-
-        if (plan.conflicting_app_ids.length > 0) {
-          const confirmed = window.confirm(
-            `This Proton version is referenced by these Steam app IDs: ${plan.conflicting_app_ids.join(', ')}.\n\nProceed with uninstall?`
-          );
-          if (!confirmed) return;
-        }
-
         const result = await manager.uninstall(toolPath);
         if (!result.success) {
           setUninstallError(result.error_message ?? 'Uninstall failed.');
-        } else if (plan.conflicting_app_ids.length > 0) {
+        } else if (conflictingAppIds.length > 0) {
           setUninstallWarning(
-            `Uninstalled. The following apps referenced this version: ${plan.conflicting_app_ids.join(', ')}`
+            `${versionLabel} was uninstalled. The following Steam app IDs referenced it: ${conflictingAppIds.join(', ')}`
           );
         }
       } catch (err) {
@@ -123,6 +118,46 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
     },
     [manager]
   );
+
+  const handleUninstall = useCallback(
+    async (toolPath: string, versionLabel: string) => {
+      setUninstallWarning(null);
+      setUninstallError(null);
+      setPendingUninstall(null);
+      try {
+        const plan = await manager.planUninstall(toolPath);
+        if (!plan.success) {
+          setUninstallError(plan.error_message ?? 'Uninstall plan failed.');
+          return;
+        }
+
+        if (plan.conflicting_app_ids.length > 0) {
+          setPendingUninstall({
+            toolPath,
+            versionLabel,
+            conflictingAppIds: plan.conflicting_app_ids,
+          });
+          return;
+        }
+
+        await performUninstall(toolPath, versionLabel, []);
+      } catch (err) {
+        setUninstallError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [performUninstall, manager]
+  );
+
+  const handleConfirmUninstall = useCallback(() => {
+    if (pendingUninstall === null) {
+      return;
+    }
+    void performUninstall(pendingUninstall.toolPath, pendingUninstall.versionLabel, pendingUninstall.conflictingAppIds);
+  }, [pendingUninstall, performUninstall]);
+
+  const handleCancelUninstallConfirmation = useCallback(() => {
+    setPendingUninstall(null);
+  }, []);
 
   // Filter installed list by selected provider. In All mode, show everything.
   // `null` classification (tag doesn't match any known provider) is surfaced
@@ -177,6 +212,12 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
 
   return (
     <div className="crosshook-proton-manager">
+      <div className="crosshook-visually-hidden" aria-live="assertive" aria-atomic="true">
+        {pendingUninstall
+          ? `${pendingUninstall.versionLabel} is still referenced by Steam app IDs ${pendingUninstall.conflictingAppIds.join(', ')}. Confirm uninstall to continue.`
+          : ''}
+      </div>
+
       <div className="crosshook-proton-manager__header">
         <ProviderPicker
           providers={manager.providers}
@@ -229,6 +270,40 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
         <div className="crosshook-proton-manager__readonly-banner" role="alert">
           The selected install root is read-only. Choose a writable root to install versions.
         </div>
+      ) : null}
+
+      {pendingUninstall ? (
+        <section
+          className="crosshook-proton-manager__confirm-banner"
+          aria-labelledby="proton-manager-uninstall-confirm-title"
+          aria-describedby="proton-manager-uninstall-confirm-body"
+        >
+          <div className="crosshook-proton-manager__confirm-copy">
+            <h3 id="proton-manager-uninstall-confirm-title" className="crosshook-proton-manager__confirm-title">
+              Confirm uninstall of {pendingUninstall.versionLabel}
+            </h3>
+            <p id="proton-manager-uninstall-confirm-body" className="crosshook-proton-manager__confirm-text">
+              This version is still referenced by Steam app IDs {pendingUninstall.conflictingAppIds.join(', ')}.
+              Uninstalling it may break launches for those apps until another Proton version is selected in Steam.
+            </p>
+          </div>
+          <div className="crosshook-proton-manager__confirm-actions">
+            <button
+              type="button"
+              className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
+              onClick={handleCancelUninstallConfirmation}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="crosshook-button crosshook-button--danger"
+              onClick={handleConfirmUninstall}
+            >
+              Uninstall anyway
+            </button>
+          </div>
+        </section>
       ) : null}
 
       {manager.activeOpIds.length > 0 ? (
@@ -290,7 +365,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
                     installing={false}
                     canInstall={false}
                     onInstall={() => undefined}
-                    onUninstall={() => void handleUninstall(install.path)}
+                    onUninstall={() => void handleUninstall(install.path, install.name)}
                     publishedAt={catalogMatch?.published_at ?? null}
                     assetSize={catalogMatch?.asset_size ?? null}
                   />

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -38,7 +38,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
   const handleInstall = useCallback(
     async (versionDto: ProtonUpAvailableVersion) => {
       setInstallError(null);
-      if (!effectiveRoot) {
+      if (!effectiveRoot?.writable) {
         setInstallError('No writable install root available.');
         return;
       }
@@ -96,12 +96,25 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
       setUninstallWarning(null);
       setUninstallError(null);
       try {
+        const plan = await manager.planUninstall(toolPath);
+        if (!plan.success) {
+          setUninstallError(plan.error_message ?? 'Uninstall plan failed.');
+          return;
+        }
+
+        if (plan.conflicting_app_ids.length > 0) {
+          const confirmed = window.confirm(
+            `This Proton version is referenced by these Steam app IDs: ${plan.conflicting_app_ids.join(', ')}.\n\nProceed with uninstall?`
+          );
+          if (!confirmed) return;
+        }
+
         const result = await manager.uninstall(toolPath);
         if (!result.success) {
           setUninstallError(result.error_message ?? 'Uninstall failed.');
-        } else if (result.conflicting_app_ids.length > 0) {
+        } else if (plan.conflicting_app_ids.length > 0) {
           setUninstallWarning(
-            `Uninstalled. The following apps referenced this version: ${result.conflicting_app_ids.join(', ')}`
+            `Uninstalled. The following apps referenced this version: ${plan.conflicting_app_ids.join(', ')}`
           );
         }
       } catch (err) {
@@ -212,6 +225,12 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
         </div>
       ) : null}
 
+      {effectiveRoot && !effectiveRoot.writable ? (
+        <div className="crosshook-proton-manager__readonly-banner" role="alert">
+          The selected install root is read-only. Choose a writable root to install versions.
+        </div>
+      ) : null}
+
       {manager.activeOpIds.length > 0 ? (
         <div className="crosshook-proton-manager__progress-list">
           {manager.activeOpIds.map((opId) => (
@@ -293,7 +312,7 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
             {availableVersions.map((v) => {
               const providerDescriptor = providersById.get(v.provider);
               const providerSupportsInstall = providerDescriptor?.supports_install ?? false;
-              const rowCanInstall = hasWritableRoot && providerSupportsInstall;
+              const rowCanInstall = Boolean(effectiveRoot?.writable) && providerSupportsInstall;
               const key = `${v.provider}:${v.version}`;
               return (
                 <li key={key}>

--- a/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProtonManagerPanel.tsx
@@ -239,7 +239,8 @@ export function ProtonManagerPanel({ steamClientInstallPath }: ProtonManagerPane
       }
 
       return (
-        sortVersionLabelsDesc(left.install.name, right.install.name) || left.install.path.localeCompare(right.install.path)
+        sortVersionLabelsDesc(left.install.name, right.install.name) ||
+        left.install.path.localeCompare(right.install.path)
       );
     });
 

--- a/src/crosshook-native/src/components/proton-manager/ProviderPicker.tsx
+++ b/src/crosshook-native/src/components/proton-manager/ProviderPicker.tsx
@@ -1,0 +1,79 @@
+import type { ProtonUpProviderDescriptor } from '../../types/protonup';
+
+interface ProviderPickerProps {
+  providers: ProtonUpProviderDescriptor[];
+  /** `null` means the "All" option is selected. */
+  selectedProviderId: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+function checksumLabel(kind: ProtonUpProviderDescriptor['checksum_kind']): string {
+  switch (kind) {
+    case 'sha512-sidecar':
+      return 'SHA-512';
+    case 'sha256-manifest':
+      return 'SHA-256';
+    case 'none':
+      return 'no checksum';
+    default: {
+      const _exhaustive: never = kind;
+      return String(_exhaustive);
+    }
+  }
+}
+
+export function ProviderPicker({ providers, selectedProviderId, onSelect }: ProviderPickerProps) {
+  if (providers.length === 0) {
+    return null;
+  }
+
+  const isAllSelected = selectedProviderId === null;
+
+  return (
+    <fieldset className="crosshook-provider-picker">
+      <legend className="crosshook-provider-picker__legend">Provider</legend>
+      <div className="crosshook-provider-picker__options" role="radiogroup">
+        <label className="crosshook-provider-picker__option crosshook-provider-picker__option--all">
+          <input
+            type="radio"
+            className="crosshook-provider-picker__radio"
+            name="proton-provider"
+            value="__all__"
+            checked={isAllSelected}
+            onChange={() => onSelect(null)}
+            aria-label="All providers"
+          />
+          <span>All</span>
+        </label>
+
+        <span className="crosshook-provider-picker__divider" aria-hidden="true" />
+
+        {providers.map((provider) => {
+          const isSelected = selectedProviderId === provider.id;
+          const isCatalogOnly = !provider.supports_install;
+
+          return (
+            <label key={provider.id} className="crosshook-provider-picker__option">
+              <input
+                type="radio"
+                className="crosshook-provider-picker__radio"
+                name="proton-provider"
+                value={provider.id}
+                checked={isSelected}
+                onChange={() => onSelect(provider.id)}
+                aria-label={provider.display_name}
+              />
+              <span>{provider.display_name}</span>
+              <span className="crosshook-provider-picker__badge">{checksumLabel(provider.checksum_kind)}</span>
+              {isCatalogOnly ? (
+                <span className="crosshook-provider-picker__badge crosshook-provider-picker__badge--catalog-only">
+                  catalog-only
+                </span>
+              ) : null}
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/crosshook-native/src/components/proton-manager/VersionRow.tsx
+++ b/src/crosshook-native/src/components/proton-manager/VersionRow.tsx
@@ -1,0 +1,78 @@
+import { formatBytes, formatReleaseDate } from '../../lib/protonup/format';
+
+interface VersionRowProps {
+  version: string;
+  provider: string;
+  installed: boolean;
+  installing: boolean;
+  canInstall: boolean;
+  onInstall: () => void;
+  onUninstall: () => void;
+  /** ISO-8601 release date (available rows only). */
+  publishedAt?: string | null;
+  /** Asset size in bytes (available rows only). */
+  assetSize?: number | null;
+}
+
+export function VersionRow({
+  version,
+  provider,
+  installed,
+  installing,
+  canInstall,
+  onInstall,
+  onUninstall,
+  publishedAt = null,
+  assetSize = null,
+}: VersionRowProps) {
+  const rowClass = `crosshook-version-row${installed ? ' crosshook-version-row--installed' : ''}`;
+  const dateLabel = formatReleaseDate(publishedAt);
+  const sizeLabel = formatBytes(assetSize);
+  const showMeta = dateLabel !== null || sizeLabel !== null;
+
+  return (
+    <div className={rowClass}>
+      <div className="crosshook-version-row__left">
+        <div className="crosshook-version-row__headline">
+          <span className="crosshook-version-row__tag">{version}</span>
+          <span className="crosshook-version-row__provider">{provider}</span>
+          <span
+            className={`crosshook-version-row__status-pill crosshook-version-row__status-pill--${installed ? 'installed' : 'available'}`}
+          >
+            {installed ? 'Installed' : 'Available'}
+          </span>
+        </div>
+        {showMeta ? (
+          <div className="crosshook-version-row__meta">
+            {dateLabel ? <span>Released {dateLabel}</span> : null}
+            {dateLabel && sizeLabel ? <span className="crosshook-version-row__meta-sep">·</span> : null}
+            {sizeLabel ? <span>{sizeLabel}</span> : null}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="crosshook-version-row__right">
+        {installed ? (
+          <button
+            type="button"
+            className="crosshook-button crosshook-button--ghost crosshook-button--ghost--small"
+            disabled={installing}
+            onClick={onUninstall}
+          >
+            Uninstall
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="crosshook-button crosshook-button--secondary"
+            disabled={installing || !canInstall}
+            onClick={onInstall}
+            title={!canInstall ? 'No writable install root available' : undefined}
+          >
+            {installing ? 'Installing…' : 'Install'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/crosshook-native/src/hooks/useProtonInstallProgress.ts
+++ b/src/crosshook-native/src/hooks/useProtonInstallProgress.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { subscribeEvent } from '@/lib/events';
+import type { ProtonInstallProgress } from '../types/protonup';
+
+/**
+ * Subscribes to `protonup:install:progress` events and tracks progress for a
+ * specific install operation identified by `opId`.
+ *
+ * Returns `null` for both `progress` and `percent` while no `opId` is active.
+ */
+export function useProtonInstallProgress(opId: string | null) {
+  const [progress, setProgress] = useState<ProtonInstallProgress | null>(null);
+
+  useEffect(() => {
+    if (!opId) {
+      setProgress(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const unlistenPromise = subscribeEvent<ProtonInstallProgress>('protonup:install:progress', (event) => {
+      if (cancelled) return;
+      const payload = event.payload;
+      if (payload.op_id === opId) {
+        setProgress(payload);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [opId]);
+
+  const percent =
+    progress?.bytes_total && progress.bytes_total > 0
+      ? Math.min(100, Math.floor(((progress.bytes_done ?? 0) / progress.bytes_total) * 100))
+      : null;
+
+  return { progress, percent };
+}

--- a/src/crosshook-native/src/hooks/useProtonInstallProgress.ts
+++ b/src/crosshook-native/src/hooks/useProtonInstallProgress.ts
@@ -31,8 +31,8 @@ export function useProtonInstallProgress(opId: string | null) {
   const [progress, setProgress] = useState<ProtonInstallProgress | null>(null);
 
   useEffect(() => {
+    setProgress(null);
     if (!opId) {
-      setProgress(null);
       return;
     }
 

--- a/src/crosshook-native/src/hooks/useProtonInstallProgress.ts
+++ b/src/crosshook-native/src/hooks/useProtonInstallProgress.ts
@@ -1,10 +1,29 @@
 import { useEffect, useState } from 'react';
 import { subscribeEvent } from '@/lib/events';
-import type { ProtonInstallProgress } from '../types/protonup';
+import type { ProtonInstallPhase, ProtonInstallProgress } from '../types/protonup';
+
+const KNOWN_PHASES: ReadonlySet<ProtonInstallPhase> = new Set([
+  'resolving',
+  'downloading',
+  'verifying',
+  'extracting',
+  'finalizing',
+  'done',
+  'failed',
+  'cancelled',
+]);
+
+function isKnownPhase(value: string): value is ProtonInstallPhase {
+  return KNOWN_PHASES.has(value as ProtonInstallPhase);
+}
 
 /**
  * Subscribes to `protonup:install:progress` events and tracks progress for a
  * specific install operation identified by `opId`.
+ *
+ * Unknown phase values are dropped rather than assigned to state — this
+ * defensively guards against future Rust-side sentinels leaking through and
+ * clobbering a valid terminal state.
  *
  * Returns `null` for both `progress` and `percent` while no `opId` is active.
  */
@@ -22,9 +41,9 @@ export function useProtonInstallProgress(opId: string | null) {
     const unlistenPromise = subscribeEvent<ProtonInstallProgress>('protonup:install:progress', (event) => {
       if (cancelled) return;
       const payload = event.payload;
-      if (payload.op_id === opId) {
-        setProgress(payload);
-      }
+      if (payload.op_id !== opId) return;
+      if (!isKnownPhase(payload.phase)) return;
+      setProgress(payload);
     });
 
     return () => {

--- a/src/crosshook-native/src/hooks/useProtonInstalls.ts
+++ b/src/crosshook-native/src/hooks/useProtonInstalls.ts
@@ -30,13 +30,18 @@ function sortProtonInstalls(installs: ProtonInstallOption[]): ProtonInstallOptio
 export function useProtonInstalls(options: UseProtonInstallsOptions = {}): UseProtonInstallsResult {
   const [installs, setInstalls] = useState<ProtonInstallOption[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [_reloadVersion, setReloadVersion] = useState(0);
+  const [reloadVersion, setReloadVersion] = useState(0);
   const steamClientInstallPath = options.steamClientInstallPath?.trim() ?? '';
 
   const reload = useCallback(() => {
     setReloadVersion((current) => current + 1);
   }, []);
 
+  // `reloadVersion` is a pure trigger: not referenced inside the effect
+  // body, but calling `reload()` bumps it to re-run the fetch. Without it
+  // in the deps, `reload()` mutates state silently and the installed list
+  // stays stale after a new install completes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only dep
   useEffect(() => {
     let active = true;
 
@@ -67,7 +72,7 @@ export function useProtonInstalls(options: UseProtonInstallsOptions = {}): UsePr
     return () => {
       active = false;
     };
-  }, [steamClientInstallPath]);
+  }, [steamClientInstallPath, reloadVersion]);
 
   return {
     installs,

--- a/src/crosshook-native/src/hooks/useProtonManager.ts
+++ b/src/crosshook-native/src/hooks/useProtonManager.ts
@@ -4,6 +4,7 @@ import { callCommand } from '@/lib/ipc';
 import type {
   InstallRootDescriptor,
   ProtonInstallHandle,
+  ProtonUninstallPlanResult,
   ProtonUninstallResult,
   ProtonUpAvailableVersion,
   ProtonUpCacheMeta,
@@ -48,6 +49,7 @@ export interface UseProtonManagerResult {
    */
   install: (request: ProtonUpInstallRequest, version: ProtonUpAvailableVersion) => Promise<ProtonInstallHandle>;
   cancel: (opId: string) => Promise<boolean>;
+  planUninstall: (toolPath: string) => Promise<ProtonUninstallPlanResult>;
   uninstall: (toolPath: string) => Promise<ProtonUninstallResult>;
   loading: boolean;
   error: string | null;
@@ -136,7 +138,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
         const [resolvedProviders, resolvedRoots] = await Promise.all([
           callCommand<ProtonUpProviderDescriptor[]>('protonup_list_providers'),
           callCommand<InstallRootDescriptor[]>('protonup_resolve_install_roots', {
-            steamClientInstallPath: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+            steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
           }),
         ]);
 
@@ -179,7 +181,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
           ids.map((id) =>
             callCommand<ProtonUpCatalogResponse>('protonup_list_available_versions', {
               provider: id,
-              forceRefresh: allFetchVersion > 0,
+              force_refresh: allFetchVersion > 0,
             }).catch((err: unknown): ProtonUpCatalogResponse => {
               console.warn(`[useProtonManager] catalog fetch failed for ${id}:`, err);
               return {
@@ -266,6 +268,16 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
     [steamClientInstallPath, installs]
   );
 
+  const planUninstall = useCallback(
+    async (toolPath: string): Promise<ProtonUninstallPlanResult> => {
+      return await callCommand<ProtonUninstallPlanResult>('protonup_plan_uninstall_version', {
+        toolPath,
+        steamClientInstallPath: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+      });
+    },
+    [steamClientInstallPath]
+  );
+
   const defaultRoot = useMemo(() => roots.find((r) => r.writable) ?? null, [roots]);
 
   const catalog = useMemo(() => {
@@ -313,6 +325,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
     dismissOp,
     install,
     cancel,
+    planUninstall,
     uninstall,
     loading,
     error,

--- a/src/crosshook-native/src/hooks/useProtonManager.ts
+++ b/src/crosshook-native/src/hooks/useProtonManager.ts
@@ -95,8 +95,6 @@ function minIso(a: string | undefined, b: string | undefined): string | undefine
   return a < b ? a : b;
 }
 
-const ALL_MODE_SENTINEL = null;
-
 /**
  * Composite hook for the native Proton download manager UI.
  *
@@ -111,7 +109,7 @@ const ALL_MODE_SENTINEL = null;
 export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonManagerResult {
   const [providers, setProviders] = useState<ProtonUpProviderDescriptor[]>([]);
   const [roots, setRoots] = useState<InstallRootDescriptor[]>([]);
-  const [selectedProviderId, setSelectedProviderId] = useState<string | null>(ALL_MODE_SENTINEL);
+  const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null); // null => "All" mode
   const [activeOpIds, setActiveOpIds] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -124,7 +122,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
 
   const steamClientInstallPath = opts.steamClientInstallPath?.trim() ?? '';
 
-  const inAllMode = selectedProviderId === ALL_MODE_SENTINEL;
+  const inAllMode = selectedProviderId === null; // null => "All" mode
 
   // Single-provider catalog (delegates to the legacy useProtonUp). Always
   // called to preserve hook-order invariants; auto-fetch is gated on a

--- a/src/crosshook-native/src/hooks/useProtonManager.ts
+++ b/src/crosshook-native/src/hooks/useProtonManager.ts
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { callCommand } from '@/lib/ipc';
+
+import type {
+  InstallRootDescriptor,
+  ProtonInstallHandle,
+  ProtonUninstallResult,
+  ProtonUpAvailableVersion,
+  ProtonUpCacheMeta,
+  ProtonUpCatalogResponse,
+  ProtonUpInstallRequest,
+  ProtonUpProvider,
+  ProtonUpProviderDescriptor,
+} from '../types/protonup';
+import { useProtonInstalls } from './useProtonInstalls';
+import { useProtonUp } from './useProtonUp';
+
+export interface UseProtonManagerOptions {
+  steamClientInstallPath?: string;
+}
+
+export interface UseProtonManagerResult {
+  providers: ProtonUpProviderDescriptor[];
+  roots: InstallRootDescriptor[];
+  defaultRoot: InstallRootDescriptor | null;
+  /** `null` means "All providers" (merged catalog). */
+  selectedProviderId: string | null;
+  setSelectedProviderId: (id: string | null) => void;
+  /** Versions + cacheMeta. In All mode this is merged across providers; always sorted by release date desc. */
+  catalog: {
+    versions: ProtonUpAvailableVersion[];
+    cacheMeta: ProtonUpCacheMeta | null;
+    catalogLoading: boolean;
+    catalogError: string | null;
+    refreshCatalog: () => void;
+  };
+  /** Installed Proton tools (rescan-is-truth). */
+  installs: ReturnType<typeof useProtonInstalls>;
+  activeOpIds: string[];
+  install: (request: ProtonUpInstallRequest, version: string) => Promise<ProtonInstallHandle>;
+  cancel: (opId: string) => Promise<boolean>;
+  uninstall: (toolPath: string) => Promise<ProtonUninstallResult>;
+  loading: boolean;
+  error: string | null;
+  offline: boolean;
+}
+
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Sort by `published_at` descending (newest first). ISO-8601 sorts
+ * lexicographically, so string compare is sufficient. Undated entries
+ * sink to the end; tag-name desc is the final tiebreaker.
+ */
+function sortByPublishedDesc<T extends { published_at?: string | null; version: string }>(versions: T[]): T[] {
+  return [...versions].sort((a, b) => {
+    const ap = a.published_at ?? '';
+    const bp = b.published_at ?? '';
+    if (ap && bp && ap !== bp) return bp.localeCompare(ap);
+    if (ap && !bp) return -1;
+    if (!ap && bp) return 1;
+    return b.version.localeCompare(a.version);
+  });
+}
+
+function minIso(a: string | undefined, b: string | undefined): string | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return a < b ? a : b;
+}
+
+const ALL_MODE_SENTINEL = null;
+
+/**
+ * Composite hook for the native Proton download manager UI.
+ *
+ * Loads available providers and install roots on mount, tracks active install
+ * operation IDs, and exposes install/cancel/uninstall actions.
+ *
+ * When `selectedProviderId === null` ("All" mode), fans out
+ * `protonup_list_available_versions` across every registered provider and
+ * merges the results. Otherwise delegates to the single-provider
+ * `useProtonUp` hook.
+ */
+export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonManagerResult {
+  const [providers, setProviders] = useState<ProtonUpProviderDescriptor[]>([]);
+  const [roots, setRoots] = useState<InstallRootDescriptor[]>([]);
+  const [selectedProviderId, setSelectedProviderId] = useState<string | null>(ALL_MODE_SENTINEL);
+  const [activeOpIds, setActiveOpIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [allVersions, setAllVersions] = useState<ProtonUpAvailableVersion[]>([]);
+  const [allCacheMeta, setAllCacheMeta] = useState<ProtonUpCacheMeta | null>(null);
+  const [allLoading, setAllLoading] = useState(false);
+  const [allError, setAllError] = useState<string | null>(null);
+  const [allFetchVersion, setAllFetchVersion] = useState(0);
+
+  const steamClientInstallPath = opts.steamClientInstallPath?.trim() ?? '';
+
+  const inAllMode = selectedProviderId === ALL_MODE_SENTINEL;
+
+  // Single-provider catalog (delegates to the legacy useProtonUp). Always
+  // called to preserve hook-order invariants; auto-fetch is gated on a
+  // concrete provider selection.
+  const catalogProvider = (selectedProviderId ?? 'ge-proton') as ProtonUpProvider;
+  const protonUp = useProtonUp({
+    autoFetchCatalog: !inAllMode,
+    catalogProvider,
+    steamClientInstallPath: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+  });
+
+  const installs = useProtonInstalls({
+    steamClientInstallPath: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+  });
+
+  // Load providers and install roots on mount (and whenever the Steam path changes).
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    async function loadProviderData() {
+      try {
+        const [resolvedProviders, resolvedRoots] = await Promise.all([
+          callCommand<ProtonUpProviderDescriptor[]>('protonup_list_providers'),
+          callCommand<InstallRootDescriptor[]>('protonup_resolve_install_roots', {
+            steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+          }),
+        ]);
+
+        if (!active) return;
+
+        setProviders(resolvedProviders);
+        setRoots(resolvedRoots);
+        setError(null);
+      } catch (err) {
+        if (!active) return;
+        setProviders([]);
+        setRoots([]);
+        setError(normalizeError(err));
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    void loadProviderData();
+
+    return () => {
+      active = false;
+    };
+  }, [steamClientInstallPath]);
+
+  // All-mode fan-out: fetch every provider catalog in parallel and merge.
+  useEffect(() => {
+    if (!inAllMode || providers.length === 0) {
+      return;
+    }
+
+    let active = true;
+    setAllLoading(true);
+
+    const ids = providers.map((p) => p.id);
+
+    (async () => {
+      try {
+        const responses = await Promise.all(
+          ids.map((id) =>
+            callCommand<ProtonUpCatalogResponse>('protonup_list_available_versions', {
+              provider: id,
+              forceRefresh: allFetchVersion > 0,
+            }).catch((err: unknown): ProtonUpCatalogResponse => {
+              console.warn(`[useProtonManager] catalog fetch failed for ${id}:`, err);
+              return {
+                versions: [],
+                cache: { stale: false, offline: true, fetched_at: undefined, expires_at: undefined },
+              };
+            })
+          )
+        );
+
+        if (!active) return;
+
+        const merged = responses.flatMap((r) => r.versions);
+        const cache: ProtonUpCacheMeta = responses.reduce<ProtonUpCacheMeta>(
+          (acc, r) => ({
+            stale: acc.stale || r.cache.stale,
+            offline: acc.offline && r.cache.offline,
+            fetched_at: minIso(acc.fetched_at, r.cache.fetched_at ?? undefined),
+            expires_at: minIso(acc.expires_at, r.cache.expires_at ?? undefined),
+          }),
+          { stale: false, offline: true, fetched_at: undefined, expires_at: undefined }
+        );
+
+        setAllVersions(merged);
+        setAllCacheMeta(cache);
+        setAllError(null);
+      } catch (err) {
+        if (!active) return;
+        setAllVersions([]);
+        setAllCacheMeta(null);
+        setAllError(normalizeError(err));
+      } finally {
+        if (active) setAllLoading(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [inAllMode, providers, allFetchVersion]);
+
+  const refreshAll = useCallback(() => {
+    setAllFetchVersion((current) => current + 1);
+  }, []);
+
+  const install = useCallback(
+    async (request: ProtonUpInstallRequest, version: string): Promise<ProtonInstallHandle> => {
+      const handle = await callCommand<ProtonInstallHandle>('protonup_install_version_async', {
+        request,
+        version,
+      });
+      setActiveOpIds((ids) => [...ids, handle.op_id]);
+      return handle;
+    },
+    []
+  );
+
+  const cancel = useCallback(async (opId: string): Promise<boolean> => {
+    const ok = await callCommand<boolean>('protonup_cancel_install', { op_id: opId });
+    setActiveOpIds((ids) => ids.filter((id) => id !== opId));
+    return ok;
+  }, []);
+
+  const uninstall = useCallback(
+    async (toolPath: string): Promise<ProtonUninstallResult> => {
+      const result = await callCommand<ProtonUninstallResult>('protonup_uninstall_version', {
+        tool_path: toolPath,
+        steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+      });
+      if (result.success) {
+        installs.reload();
+      }
+      return result;
+    },
+    [steamClientInstallPath, installs]
+  );
+
+  const defaultRoot = useMemo(() => roots.find((r) => r.writable) ?? null, [roots]);
+
+  const catalog = useMemo(() => {
+    if (inAllMode) {
+      return {
+        versions: sortByPublishedDesc(allVersions),
+        cacheMeta: allCacheMeta,
+        catalogLoading: allLoading,
+        catalogError: allError,
+        refreshCatalog: refreshAll,
+      };
+    }
+    return {
+      versions: sortByPublishedDesc(protonUp.versions),
+      cacheMeta: protonUp.cacheMeta,
+      catalogLoading: protonUp.catalogLoading,
+      catalogError: protonUp.catalogError,
+      refreshCatalog: protonUp.refreshCatalog,
+    };
+  }, [
+    inAllMode,
+    allVersions,
+    allCacheMeta,
+    allLoading,
+    allError,
+    refreshAll,
+    protonUp.versions,
+    protonUp.cacheMeta,
+    protonUp.catalogLoading,
+    protonUp.catalogError,
+    protonUp.refreshCatalog,
+  ]);
+
+  const offline = catalog.cacheMeta?.offline ?? false;
+
+  return {
+    providers,
+    roots,
+    defaultRoot,
+    selectedProviderId,
+    setSelectedProviderId,
+    catalog,
+    installs,
+    activeOpIds,
+    install,
+    cancel,
+    uninstall,
+    loading,
+    error,
+    offline,
+  };
+}

--- a/src/crosshook-native/src/hooks/useProtonManager.ts
+++ b/src/crosshook-native/src/hooks/useProtonManager.ts
@@ -37,7 +37,16 @@ export interface UseProtonManagerResult {
   /** Installed Proton tools (rescan-is-truth). */
   installs: ReturnType<typeof useProtonInstalls>;
   activeOpIds: string[];
-  install: (request: ProtonUpInstallRequest, version: string) => Promise<ProtonInstallHandle>;
+  /** Remove a terminal op from the active list (called when the user dismisses). */
+  dismissOp: (opId: string) => void;
+  /**
+   * Start an async install. `version` must be the full catalog DTO — the Rust
+   * handler (`protonup_install_version_async`) deserializes it to
+   * `ProtonUpAvailableVersion` and uses its checksum URL / asset size during
+   * the download. Passing only the tag string causes Tauri to reject the
+   * IPC payload as malformed.
+   */
+  install: (request: ProtonUpInstallRequest, version: ProtonUpAvailableVersion) => Promise<ProtonInstallHandle>;
   cancel: (opId: string) => Promise<boolean>;
   uninstall: (toolPath: string) => Promise<ProtonUninstallResult>;
   loading: boolean;
@@ -127,7 +136,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
         const [resolvedProviders, resolvedRoots] = await Promise.all([
           callCommand<ProtonUpProviderDescriptor[]>('protonup_list_providers'),
           callCommand<InstallRootDescriptor[]>('protonup_resolve_install_roots', {
-            steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+            steamClientInstallPath: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
           }),
         ]);
 
@@ -217,7 +226,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
   }, []);
 
   const install = useCallback(
-    async (request: ProtonUpInstallRequest, version: string): Promise<ProtonInstallHandle> => {
+    async (request: ProtonUpInstallRequest, version: ProtonUpAvailableVersion): Promise<ProtonInstallHandle> => {
       const handle = await callCommand<ProtonInstallHandle>('protonup_install_version_async', {
         request,
         version,
@@ -229,16 +238,25 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
   );
 
   const cancel = useCallback(async (opId: string): Promise<boolean> => {
-    const ok = await callCommand<boolean>('protonup_cancel_install', { op_id: opId });
+    // Don't touch activeOpIds here — the Rust install task will emit
+    // `Phase::Cancelled` when the token fires, which flips the
+    // InstallProgressBar into its terminal state (Dismiss button,
+    // red fill). Removing the opId now would unmount the progress
+    // card before that event arrives and the user would see "nothing
+    // happened". The dismiss handler removes the opId on user action
+    // (or the auto-dismiss timer for successful installs).
+    return await callCommand<boolean>('protonup_cancel_install', { opId });
+  }, []);
+
+  const dismissOp = useCallback((opId: string) => {
     setActiveOpIds((ids) => ids.filter((id) => id !== opId));
-    return ok;
   }, []);
 
   const uninstall = useCallback(
     async (toolPath: string): Promise<ProtonUninstallResult> => {
       const result = await callCommand<ProtonUninstallResult>('protonup_uninstall_version', {
-        tool_path: toolPath,
-        steam_client_install_path: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
+        toolPath,
+        steamClientInstallPath: steamClientInstallPath.length > 0 ? steamClientInstallPath : undefined,
       });
       if (result.success) {
         installs.reload();
@@ -292,6 +310,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
     catalog,
     installs,
     activeOpIds,
+    dismissOp,
     install,
     cancel,
     uninstall,

--- a/src/crosshook-native/src/hooks/useProtonManager.ts
+++ b/src/crosshook-native/src/hooks/useProtonManager.ts
@@ -60,6 +60,19 @@ function normalizeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+const KNOWN_PROVIDER_IDS = new Set<ProtonUpProvider>([
+  'ge-proton',
+  'proton-cachyos',
+  'proton-em',
+  'boxtron',
+  'luxtorpeda',
+]);
+
+function asProvider(id: string | null | undefined): ProtonUpProvider {
+  if (id && (KNOWN_PROVIDER_IDS as Set<string>).has(id)) return id as ProtonUpProvider;
+  return 'ge-proton';
+}
+
 /**
  * Sort by `published_at` descending (newest first). ISO-8601 sorts
  * lexicographically, so string compare is sufficient. Undated entries
@@ -116,7 +129,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
   // Single-provider catalog (delegates to the legacy useProtonUp). Always
   // called to preserve hook-order invariants; auto-fetch is gated on a
   // concrete provider selection.
-  const catalogProvider = (selectedProviderId ?? 'ge-proton') as ProtonUpProvider;
+  const catalogProvider = asProvider(selectedProviderId);
   const protonUp = useProtonUp({
     autoFetchCatalog: !inAllMode,
     catalogProvider,
@@ -182,8 +195,7 @@ export function useProtonManager(opts: UseProtonManagerOptions = {}): UseProtonM
             callCommand<ProtonUpCatalogResponse>('protonup_list_available_versions', {
               provider: id,
               force_refresh: allFetchVersion > 0,
-            }).catch((err: unknown): ProtonUpCatalogResponse => {
-              console.warn(`[useProtonManager] catalog fetch failed for ${id}:`, err);
+            }).catch((_err: unknown): ProtonUpCatalogResponse => {
               return {
                 versions: [],
                 cache: { stale: false, offline: true, fetched_at: undefined, expires_at: undefined },

--- a/src/crosshook-native/src/hooks/useProtonUp.ts
+++ b/src/crosshook-native/src/hooks/useProtonUp.ts
@@ -43,7 +43,7 @@ function normalizeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-const CATALOG_PROVIDERS: ProtonUpProvider[] = ['ge-proton', 'proton-cachyos'];
+const CATALOG_PROVIDERS: ProtonUpProvider[] = ['ge-proton', 'proton-cachyos', 'proton-em'];
 
 /**
  * Find which catalog contains `version` (checks GE first, then Proton-CachyOS).
@@ -59,7 +59,7 @@ export async function resolveProtonUpProviderForVersion(version: string): Promis
     try {
       const response = await callCommand<ProtonUpCatalogResponse>('protonup_list_available_versions', {
         provider,
-        forceRefresh: false,
+        force_refresh: false,
       });
       if (response.versions.some((v) => v.version === trimmed)) {
         return provider;
@@ -96,7 +96,7 @@ export function useProtonUp(options: UseProtonUpOptions = {}): UseProtonUpResult
       try {
         const response = await callCommand<ProtonUpCatalogResponse>('protonup_list_available_versions', {
           provider: catalogProvider,
-          forceRefresh: fetchVersion > 0,
+          force_refresh: fetchVersion > 0,
         });
 
         if (!active) {

--- a/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
@@ -240,21 +240,21 @@ export function registerProtonUp(map: Map<string, Handler>): void {
   });
 
   map.set('protonup_cancel_install', (args) => {
-    const { op_id } = (args ?? {}) as { op_id: string };
-    if (!activeInstalls.has(op_id)) return false;
-    activeInstalls.delete(op_id);
-    emitMockEvent('protonup:install:progress', { op_id, phase: 'cancelled' });
+    const { opId } = (args ?? {}) as { opId: string };
+    if (!activeInstalls.has(opId)) return false;
+    activeInstalls.delete(opId);
+    emitMockEvent('protonup:install:progress', { op_id: opId, phase: 'cancelled' });
     return true;
   });
 
   map.set('protonup_uninstall_version', (args) => {
-    const { tool_path } = (args ?? {}) as { tool_path: string; steam_client_install_path?: string };
+    const { toolPath } = (args ?? {}) as { toolPath: string };
 
-    if (tool_path.includes('usr/share') || tool_path.startsWith('/usr/')) {
+    if (toolPath.includes('usr/share') || toolPath.startsWith('/usr/')) {
       return { success: false, conflicting_app_ids: [], error_message: 'refusing to delete system path' };
     }
 
-    if (tool_path.includes('conflict')) {
+    if (toolPath.includes('conflict')) {
       return { success: true, conflicting_app_ids: ['12345', '67890'], error_message: null };
     }
 

--- a/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
@@ -106,7 +106,7 @@ function getMockCacheMeta(): {
 
 export function registerProtonUp(map: Map<string, Handler>): void {
   map.set('protonup_list_available_versions', async (args): Promise<ProtonUpCatalogResponse> => {
-    const { provider } = (args ?? {}) as { provider?: string; forceRefresh?: boolean };
+    const { provider } = (args ?? {}) as { provider?: string; force_refresh?: boolean };
 
     return {
       versions: mockCatalogFor(provider),
@@ -247,7 +247,7 @@ export function registerProtonUp(map: Map<string, Handler>): void {
     return true;
   });
 
-  map.set('protonup_uninstall_version', (args) => {
+  map.set('protonup_plan_uninstall_version', (args) => {
     const { toolPath } = (args ?? {}) as { toolPath: string };
 
     if (toolPath.includes('usr/share') || toolPath.startsWith('/usr/')) {
@@ -256,6 +256,16 @@ export function registerProtonUp(map: Map<string, Handler>): void {
 
     if (toolPath.includes('conflict')) {
       return { success: true, conflicting_app_ids: ['12345', '67890'], error_message: null };
+    }
+
+    return { success: true, conflicting_app_ids: [], error_message: null };
+  });
+
+  map.set('protonup_uninstall_version', (args) => {
+    const { toolPath } = (args ?? {}) as { toolPath: string };
+
+    if (toolPath.includes('usr/share') || toolPath.startsWith('/usr/')) {
+      return { success: false, conflicting_app_ids: [], error_message: 'refusing to delete system path' };
     }
 
     return { success: true, conflicting_app_ids: [], error_message: null };

--- a/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
@@ -1,3 +1,4 @@
+// Proton manager mocks for browser dev mode (see #274).
 import type {
   ProtonUpAvailableVersion,
   ProtonUpCatalogResponse,
@@ -5,6 +6,7 @@ import type {
   ProtonUpInstallResult,
   ProtonUpSuggestion,
 } from '../../../types/protonup';
+import { emitMockEvent } from '../eventBus';
 import type { Handler } from './types';
 
 const GE_PROTON_VERSIONS: ProtonUpAvailableVersion[] = [
@@ -14,6 +16,7 @@ const GE_PROTON_VERSIONS: ProtonUpAvailableVersion[] = [
     release_url: 'https://example.invalid/GE-Proton9-27',
     download_url: 'https://example.invalid/GE-Proton9-27.tar.gz',
     asset_size: 530_000_000,
+    published_at: '2026-03-12T18:00:00Z',
   },
   {
     provider: 'ge-proton',
@@ -21,6 +24,7 @@ const GE_PROTON_VERSIONS: ProtonUpAvailableVersion[] = [
     release_url: 'https://example.invalid/GE-Proton9-26',
     download_url: 'https://example.invalid/GE-Proton9-26.tar.gz',
     asset_size: 528_000_000,
+    published_at: '2026-01-20T12:00:00Z',
   },
   {
     provider: 'ge-proton',
@@ -28,6 +32,7 @@ const GE_PROTON_VERSIONS: ProtonUpAvailableVersion[] = [
     release_url: 'https://example.invalid/GE-Proton9-25',
     download_url: 'https://example.invalid/GE-Proton9-25.tar.gz',
     asset_size: 524_288_000,
+    published_at: '2025-11-05T09:00:00Z',
   },
 ];
 
@@ -38,6 +43,7 @@ const CACHYOS_VERSIONS: ProtonUpAvailableVersion[] = [
     release_url: 'https://example.invalid/proton-cachyos-9.0-1',
     download_url: 'https://example.invalid/proton-cachyos-9.0-1.tar.zst',
     asset_size: 540_000_000,
+    published_at: '2026-04-01T10:00:00Z',
   },
   {
     provider: 'proton-cachyos',
@@ -45,8 +51,44 @@ const CACHYOS_VERSIONS: ProtonUpAvailableVersion[] = [
     release_url: 'https://example.invalid/proton-cachyos-8.0-2',
     download_url: 'https://example.invalid/proton-cachyos-8.0-2.tar.zst',
     asset_size: 536_000_000,
+    published_at: '2025-12-10T14:30:00Z',
   },
 ];
+
+const PROTON_EM_VERSIONS: ProtonUpAvailableVersion[] = [
+  {
+    provider: 'proton-em',
+    version: 'proton-em-10-rev2',
+    release_url: 'https://example.invalid/proton-em-10-rev2',
+    download_url: 'https://example.invalid/proton-em-10-rev2.tar.gz',
+    asset_size: 510_000_000,
+    published_at: '2026-02-28T16:00:00Z',
+  },
+  {
+    provider: 'proton-em',
+    version: 'proton-em-10',
+    release_url: 'https://example.invalid/proton-em-10',
+    download_url: 'https://example.invalid/proton-em-10.tar.gz',
+    asset_size: 504_000_000,
+    published_at: '2025-10-15T08:00:00Z',
+  },
+];
+
+function mockCatalogFor(provider: string | undefined): ProtonUpAvailableVersion[] {
+  switch (provider) {
+    case 'proton-cachyos':
+      return CACHYOS_VERSIONS;
+    case 'proton-em':
+      return PROTON_EM_VERSIONS;
+    case 'ge-proton':
+      return GE_PROTON_VERSIONS;
+    default:
+      return [];
+  }
+}
+
+/** Tracks in-flight mock installs so protonup_cancel_install can drop remaining emissions. */
+const activeInstalls = new Set<string>();
 
 function getMockCacheMeta(): {
   stale: boolean;
@@ -66,10 +108,8 @@ export function registerProtonUp(map: Map<string, Handler>): void {
   map.set('protonup_list_available_versions', async (args): Promise<ProtonUpCatalogResponse> => {
     const { provider } = (args ?? {}) as { provider?: string; forceRefresh?: boolean };
 
-    const versions = provider === 'proton-cachyos' ? CACHYOS_VERSIONS : GE_PROTON_VERSIONS;
-
     return {
-      versions,
+      versions: mockCatalogFor(provider),
       cache: getMockCacheMeta(),
     };
   });
@@ -81,7 +121,7 @@ export function registerProtonUp(map: Map<string, Handler>): void {
       throw new Error('[dev-mock] protonup_install_version: missing required request fields');
     }
 
-    const catalog = request.provider === 'proton-cachyos' ? CACHYOS_VERSIONS : GE_PROTON_VERSIONS;
+    const catalog = mockCatalogFor(request.provider);
 
     const found = catalog.some((v) => v.version === request.version && v.provider === request.provider);
 
@@ -136,5 +176,88 @@ export function registerProtonUp(map: Map<string, Handler>): void {
       community_version: version,
       recommended_version: GE_PROTON_VERSIONS[0]?.version,
     };
+  });
+
+  // ── Batch 4 commands ──────────────────────────────────────────────────────
+
+  map.set('protonup_list_providers', (_args) => {
+    return [
+      { id: 'ge-proton', display_name: 'GE-Proton', supports_install: true, checksum_kind: 'sha512-sidecar' },
+      { id: 'proton-cachyos', display_name: 'Proton-CachyOS', supports_install: true, checksum_kind: 'sha512-sidecar' },
+      { id: 'proton-em', display_name: 'Proton-EM', supports_install: true, checksum_kind: 'none' },
+    ];
+  });
+
+  map.set('protonup_resolve_install_roots', (_args) => {
+    return [
+      {
+        kind: 'native-steam',
+        path: '/mock/home/.local/share/Steam/compatibilitytools.d',
+        writable: true,
+        reason: null,
+      },
+      {
+        kind: 'flatpak-steam',
+        path: '/mock/home/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d',
+        writable: false,
+        reason: 'flatpak-steam-path-read-only',
+      },
+    ];
+  });
+
+  map.set('protonup_install_version_async', async (_args) => {
+    const opId = `mock-op-${Date.now()}`;
+    activeInstalls.add(opId);
+
+    const schedule = (delayMs: number, payload: Record<string, unknown>) => {
+      window.setTimeout(() => {
+        if (!activeInstalls.has(opId)) return;
+        emitMockEvent('protonup:install:progress', { op_id: opId, ...payload });
+      }, delayMs);
+    };
+
+    schedule(0, { phase: 'resolving', bytes_done: 0, bytes_total: null });
+    schedule(100, { phase: 'downloading', bytes_done: 0, bytes_total: 100_000_000 });
+    schedule(200, { phase: 'downloading', bytes_done: 25_000_000, bytes_total: 100_000_000 });
+    schedule(400, { phase: 'downloading', bytes_done: 75_000_000, bytes_total: 100_000_000 });
+    schedule(600, { phase: 'downloading', bytes_done: 100_000_000, bytes_total: 100_000_000 });
+    schedule(700, { phase: 'verifying', bytes_done: 100_000_000, bytes_total: 100_000_000 });
+    schedule(900, { phase: 'extracting', bytes_done: 100_000_000, bytes_total: 100_000_000 });
+    schedule(1100, { phase: 'finalizing', bytes_done: 100_000_000, bytes_total: 100_000_000 });
+
+    window.setTimeout(() => {
+      if (!activeInstalls.has(opId)) return;
+      activeInstalls.delete(opId);
+      emitMockEvent('protonup:install:progress', {
+        op_id: opId,
+        phase: 'done',
+        bytes_done: 100_000_000,
+        bytes_total: 100_000_000,
+      });
+    }, 1200);
+
+    return { op_id: opId };
+  });
+
+  map.set('protonup_cancel_install', (args) => {
+    const { op_id } = (args ?? {}) as { op_id: string };
+    if (!activeInstalls.has(op_id)) return false;
+    activeInstalls.delete(op_id);
+    emitMockEvent('protonup:install:progress', { op_id, phase: 'cancelled' });
+    return true;
+  });
+
+  map.set('protonup_uninstall_version', (args) => {
+    const { tool_path } = (args ?? {}) as { tool_path: string; steam_client_install_path?: string };
+
+    if (tool_path.includes('usr/share') || tool_path.startsWith('/usr/')) {
+      return { success: false, conflicting_app_ids: [], error_message: 'refusing to delete system path' };
+    }
+
+    if (tool_path.includes('conflict')) {
+      return { success: true, conflicting_app_ids: ['12345', '67890'], error_message: null };
+    }
+
+    return { success: true, conflicting_app_ids: [], error_message: null };
   });
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
@@ -82,6 +82,9 @@ function mockCatalogFor(provider: string | undefined): ProtonUpAvailableVersion[
       return PROTON_EM_VERSIONS;
     case 'ge-proton':
       return GE_PROTON_VERSIONS;
+    case 'all':
+    case undefined:
+      return [...GE_PROTON_VERSIONS, ...CACHYOS_VERSIONS, ...PROTON_EM_VERSIONS];
     default:
       return [];
   }

--- a/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
@@ -192,13 +192,13 @@ export function registerProtonUp(map: Map<string, Handler>): void {
     return [
       {
         kind: 'native-steam',
-        path: '/mock/home/.local/share/Steam/compatibilitytools.d',
+        path: '/home/devuser/.local/share/Steam/compatibilitytools.d',
         writable: true,
         reason: null,
       },
       {
         kind: 'flatpak-steam',
-        path: '/mock/home/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d',
+        path: '/home/devuser/.var/app/com.valvesoftware.Steam/data/Steam/compatibilitytools.d',
         writable: false,
         reason: 'flatpak-steam-path-read-only',
       },

--- a/src/crosshook-native/src/lib/protonup/classifyInstall.ts
+++ b/src/crosshook-native/src/lib/protonup/classifyInstall.ts
@@ -1,0 +1,25 @@
+/**
+ * Classify an installed Proton tool by its directory name, returning the
+ * stable provider id it most likely belongs to.
+ *
+ * Installed inventory is rescan-derived runtime state (per AGENTS.md), so
+ * this mapping is pure and not persisted. Add a new entry when a new
+ * provider is registered in `crosshook-core::protonup::providers`.
+ *
+ * Returns `null` for unknown names; the UI treats those as "ungrouped" and
+ * only shows them under the "All" filter.
+ */
+const PROVIDER_PREFIXES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^GE-Proton/i, 'ge-proton'],
+  [/^proton-?cachyos/i, 'proton-cachyos'],
+  [/^Proton-EM/i, 'proton-em'],
+  [/^Luxtorpeda/i, 'luxtorpeda'],
+  [/^Boxtron/i, 'boxtron'],
+];
+
+export function classifyInstallProvider(name: string): string | null {
+  for (const [re, id] of PROVIDER_PREFIXES) {
+    if (re.test(name)) return id;
+  }
+  return null;
+}

--- a/src/crosshook-native/src/lib/protonup/classifyInstall.ts
+++ b/src/crosshook-native/src/lib/protonup/classifyInstall.ts
@@ -23,3 +23,28 @@ export function classifyInstallProvider(name: string): string | null {
   }
   return null;
 }
+
+/**
+ * Normalize an installed directory name to a key comparable with the
+ * provider's GitHub release tag.
+ *
+ * Proton-CachyOS publishes releases with tags like `cachyos-10.0-20260410-slr`
+ * but ships archives whose extracted directory name is
+ * `proton-cachyos-10.0-20260410-slr-x86_64`. Exact-string matching would
+ * perpetually mark CachyOS installs as "Available"; this helper strips the
+ * `proton-` prefix and the `-x86_64[_v3]` arch suffix so the key aligns with
+ * the tag.
+ *
+ * GE-Proton and Proton-EM directory names already equal their tags.
+ */
+export function normalizeInstallToTag(installName: string, providerId: string | null): string {
+  if (providerId === 'proton-cachyos') {
+    // `proton-cachyos-<tag>-x86_64` → `<tag>` (strip `proton-` prefix and arch suffix).
+    return installName.replace(/^proton-/, '').replace(/-x86_64(?:_v3)?$/, '');
+  }
+  if (providerId === 'proton-em') {
+    // `proton-<tag>` (e.g. `proton-EM-10.0-37-HDR`) → `<tag>` (e.g. `EM-10.0-37-HDR`).
+    return installName.replace(/^proton-/, '');
+  }
+  return installName;
+}

--- a/src/crosshook-native/src/lib/protonup/format.ts
+++ b/src/crosshook-native/src/lib/protonup/format.ts
@@ -1,0 +1,32 @@
+/**
+ * Formatting helpers for the Proton manager row metadata caption.
+ *
+ * Kept co-located with `classifyInstall.ts` to minimize import sprawl. If we
+ * later need a bytes formatter elsewhere in the UI, promote it to a shared
+ * `lib/format.ts`.
+ */
+
+export function formatBytes(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(value) || value <= 0) return null;
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let current = value;
+  let unitIndex = 0;
+  while (current >= 1024 && unitIndex < units.length - 1) {
+    current /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = current >= 100 ? 0 : current >= 10 ? 1 : 2;
+  return `${current.toFixed(decimals)} ${units[unitIndex]}`;
+}
+
+/** Format an ISO-8601 timestamp as a short local date, e.g. "Apr 10, 2025". */
+export function formatReleaseDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/src/crosshook-native/src/lib/protonup/format.ts
+++ b/src/crosshook-native/src/lib/protonup/format.ts
@@ -28,5 +28,6 @@ export function formatReleaseDate(iso: string | null | undefined): string | null
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 }

--- a/src/crosshook-native/src/styles/proton-manager.css
+++ b/src/crosshook-native/src/styles/proton-manager.css
@@ -355,6 +355,12 @@
   white-space: nowrap;
 }
 
+/* WCAG AA audit (2026-04-17): on `--crosshook-color-surface` (#12172a),
+ * installed `--crosshook-color-capability-available` = 10.20:1 and
+ * available `--crosshook-color-accent-strong` = 6.60:1. `variables.css`
+ * currently defines only the dark root palette, so re-audit if a light
+ * surface override is introduced.
+ */
 .crosshook-version-row__status-pill--installed {
   background: var(--crosshook-color-capability-available-bg);
   border: 1px solid var(--crosshook-color-capability-available-border);

--- a/src/crosshook-native/src/styles/proton-manager.css
+++ b/src/crosshook-native/src/styles/proton-manager.css
@@ -1,0 +1,405 @@
+/* ── Proton Manager ─────────────────────────────────────────────────────────
+ * BEM-like classes for the ProtonManagerPanel and child components.
+ * Uses design tokens from variables.css; does not override global styles.
+ */
+
+.crosshook-proton-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────── */
+
+.crosshook-proton-manager__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.crosshook-proton-manager__roots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  border: none;
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+}
+
+/* ── Banners ────────────────────────────────────────────────────────────── */
+
+.crosshook-proton-manager__stale-banner {
+  padding: 10px 14px;
+  background: var(--crosshook-autosave-warning-bg);
+  border: 1px solid var(--crosshook-autosave-warning-border);
+  border-radius: var(--crosshook-radius-sm);
+  color: var(--crosshook-color-warning);
+  font-size: 0.85rem;
+}
+
+.crosshook-proton-manager__readonly-banner {
+  padding: 12px 16px;
+  background: var(--crosshook-color-danger-bg);
+  border: 1px solid var(--crosshook-color-danger);
+  border-radius: var(--crosshook-radius-sm);
+  color: var(--crosshook-color-danger);
+  font-size: 0.9rem;
+}
+
+.crosshook-proton-manager__error-banner {
+  padding: 10px 14px;
+  background: var(--crosshook-color-danger-bg);
+  border: 1px solid var(--crosshook-color-danger);
+  border-radius: var(--crosshook-radius-sm);
+  color: var(--crosshook-color-danger);
+  font-size: 0.85rem;
+}
+
+/* ── Active progress bars ───────────────────────────────────────────────── */
+
+.crosshook-proton-manager__progress-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Version list ───────────────────────────────────────────────────────── */
+
+.crosshook-proton-manager__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.crosshook-proton-manager__section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--crosshook-color-text-subtle);
+  padding: 8px 4px 4px;
+}
+
+.crosshook-proton-manager__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--crosshook-color-text-muted);
+  font-size: 0.9rem;
+}
+
+/* ── Provider picker (segmented radio group) ─────────────────────────────── */
+
+.crosshook-provider-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.crosshook-provider-picker__legend {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--crosshook-color-text-subtle);
+  margin-bottom: 4px;
+}
+
+.crosshook-provider-picker__options {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.crosshook-provider-picker__divider {
+  display: inline-block;
+  width: 1px;
+  height: 18px;
+  background: var(--crosshook-color-border-strong);
+  margin: 0 2px;
+}
+
+.crosshook-provider-picker__option--all:has(input:checked) {
+  border-color: var(--crosshook-color-accent-strong);
+  font-weight: 600;
+}
+
+.crosshook-provider-picker__option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--crosshook-color-border-strong);
+  border-radius: var(--crosshook-radius-sm);
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--crosshook-color-text-muted);
+  background: transparent;
+  transition: border-color var(--crosshook-transition-fast), background var(--crosshook-transition-fast);
+}
+
+.crosshook-provider-picker__option:has(input:checked) {
+  border-color: var(--crosshook-color-accent);
+  background: var(--crosshook-color-accent-soft);
+  color: var(--crosshook-color-text);
+}
+
+.crosshook-provider-picker__option:has(input:disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.crosshook-provider-picker__radio {
+  /* visually hidden but still accessible */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.crosshook-provider-picker__badge {
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--crosshook-color-border-muted);
+  color: var(--crosshook-color-text-subtle);
+}
+
+.crosshook-provider-picker__badge--catalog-only {
+  background: var(--crosshook-color-warning);
+  color: #000;
+  opacity: 0.8;
+}
+
+/* ── Install root badge ─────────────────────────────────────────────────── */
+
+.crosshook-install-root-badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--crosshook-color-border-strong);
+  border-radius: var(--crosshook-radius-sm);
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: var(--crosshook-color-text-muted);
+  background: transparent;
+  transition: border-color var(--crosshook-transition-fast), background var(--crosshook-transition-fast);
+  user-select: none;
+}
+
+.crosshook-install-root-badge--selected {
+  border-color: var(--crosshook-color-accent);
+  background: var(--crosshook-color-accent-soft);
+  color: var(--crosshook-color-text);
+}
+
+.crosshook-install-root-badge--muted {
+  opacity: 0.55;
+}
+
+.crosshook-install-root-badge__path {
+  font-family: var(--crosshook-font-mono);
+  font-size: 0.75rem;
+  color: var(--crosshook-color-text-subtle);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crosshook-install-root-badge__pill {
+  font-size: 0.68rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.crosshook-install-root-badge__pill--writable {
+  background: var(--crosshook-color-capability-available-bg);
+  border: 1px solid var(--crosshook-color-capability-available-border);
+  color: var(--crosshook-color-capability-available);
+}
+
+.crosshook-install-root-badge__pill--readonly {
+  background: var(--crosshook-color-danger-bg);
+  border: 1px solid var(--crosshook-color-danger);
+  color: var(--crosshook-color-danger);
+}
+
+.crosshook-install-root-badge__default-tag {
+  font-size: 0.68rem;
+  color: var(--crosshook-color-accent-strong);
+  font-weight: 600;
+}
+
+/* ── Version row ────────────────────────────────────────────────────────── */
+
+.crosshook-version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-radius: var(--crosshook-radius-sm);
+  border: 1px solid var(--crosshook-color-border);
+  background: var(--crosshook-color-surface);
+  gap: 12px;
+  min-height: 44px;
+}
+
+.crosshook-version-row--installed {
+  border-color: var(--crosshook-color-border-strong);
+  background: var(--crosshook-color-bg-elevated);
+}
+
+.crosshook-version-row__left {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.crosshook-version-row__headline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.crosshook-version-row__tag {
+  font-family: var(--crosshook-font-mono);
+  font-size: 0.85rem;
+  color: var(--crosshook-color-text);
+  font-weight: 600;
+}
+
+.crosshook-version-row__provider {
+  font-size: 0.75rem;
+  color: var(--crosshook-color-text-subtle);
+}
+
+.crosshook-version-row__meta {
+  font-size: 0.72rem;
+  color: var(--crosshook-color-text-subtle);
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-variant-numeric: tabular-nums;
+}
+
+.crosshook-version-row__meta-sep {
+  opacity: 0.6;
+}
+
+.crosshook-version-row__status-pill {
+  font-size: 0.68rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.crosshook-version-row__status-pill--installed {
+  background: var(--crosshook-color-capability-available-bg);
+  border: 1px solid var(--crosshook-color-capability-available-border);
+  color: var(--crosshook-color-capability-available);
+}
+
+.crosshook-version-row__status-pill--available {
+  background: var(--crosshook-color-accent-soft);
+  border: 1px solid var(--crosshook-protondb-accent-border);
+  color: var(--crosshook-color-accent-strong);
+}
+
+.crosshook-version-row__right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* ── Install progress bar ───────────────────────────────────────────────── */
+
+.crosshook-install-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 14px;
+  border: 1px solid var(--crosshook-color-border-strong);
+  border-radius: var(--crosshook-radius-sm);
+  background: var(--crosshook-color-bg-elevated);
+}
+
+.crosshook-install-progress__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.crosshook-install-progress__label {
+  font-size: 0.82rem;
+  color: var(--crosshook-color-text-muted);
+}
+
+.crosshook-install-progress__phase {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--crosshook-color-text);
+}
+
+.crosshook-install-progress__phase--done {
+  color: var(--crosshook-color-success);
+}
+
+.crosshook-install-progress__phase--failed {
+  color: var(--crosshook-color-danger);
+}
+
+.crosshook-install-progress__phase--cancelled {
+  color: var(--crosshook-color-text-subtle);
+}
+
+.crosshook-install-progress__track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--crosshook-color-border-strong);
+  overflow: hidden;
+}
+
+.crosshook-install-progress__fill {
+  height: 100%;
+  background: var(--crosshook-color-accent);
+  border-radius: 3px;
+  transition: width 200ms linear;
+}
+
+.crosshook-install-progress__fill--done {
+  background: var(--crosshook-color-success);
+}
+
+.crosshook-install-progress__fill--failed {
+  background: var(--crosshook-color-danger);
+}
+
+.crosshook-install-progress__message {
+  font-size: 0.75rem;
+  color: var(--crosshook-color-text-subtle);
+  font-family: var(--crosshook-font-mono);
+}

--- a/src/crosshook-native/src/styles/proton-manager.css
+++ b/src/crosshook-native/src/styles/proton-manager.css
@@ -56,6 +56,46 @@
   font-size: 0.85rem;
 }
 
+.crosshook-proton-manager__confirm-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--crosshook-color-danger-bg);
+  border: 1px solid var(--crosshook-color-danger);
+  border-radius: var(--crosshook-radius-sm);
+}
+
+.crosshook-proton-manager__confirm-copy {
+  display: flex;
+  flex: 1 1 320px;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.crosshook-proton-manager__confirm-title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--crosshook-color-text);
+}
+
+.crosshook-proton-manager__confirm-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--crosshook-color-text-muted);
+}
+
+.crosshook-proton-manager__confirm-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 /* ── Active progress bars ───────────────────────────────────────────────── */
 
 .crosshook-proton-manager__progress-list {

--- a/src/crosshook-native/src/styles/proton-manager.css
+++ b/src/crosshook-native/src/styles/proton-manager.css
@@ -161,7 +161,7 @@
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/src/crosshook-native/src/types/protonup.ts
+++ b/src/crosshook-native/src/types/protonup.ts
@@ -10,6 +10,8 @@ export interface ProtonUpAvailableVersion {
   checksum_url?: string;
   checksum_kind?: string;
   asset_size?: number;
+  /** ISO-8601 UTC release timestamp from upstream GitHub. */
+  published_at?: string | null;
 }
 
 export interface ProtonUpCacheMeta {
@@ -54,4 +56,51 @@ export interface ProtonUpSuggestion {
   community_version?: string;
   matched_install_name?: string;
   recommended_version?: string;
+}
+
+// Types for the native Proton download manager (Issue #274).
+// Mirror the Rust DTOs from the protonup::manager / protonup::resolver modules.
+
+export interface ProtonUpProviderDescriptor {
+  id: string;
+  display_name: string;
+  supports_install: boolean;
+  checksum_kind: 'sha512-sidecar' | 'sha256-manifest' | 'none';
+}
+
+export type InstallRootKind = 'native-steam' | 'flatpak-steam';
+
+export interface InstallRootDescriptor {
+  kind: InstallRootKind;
+  path: string;
+  writable: boolean;
+  reason?: string | null;
+}
+
+export interface ProtonInstallHandle {
+  op_id: string;
+}
+
+export type ProtonInstallPhase =
+  | 'resolving'
+  | 'downloading'
+  | 'verifying'
+  | 'extracting'
+  | 'finalizing'
+  | 'done'
+  | 'failed'
+  | 'cancelled';
+
+export interface ProtonInstallProgress {
+  op_id: string;
+  phase: ProtonInstallPhase;
+  bytes_done: number;
+  bytes_total?: number | null;
+  message?: string | null;
+}
+
+export interface ProtonUninstallResult {
+  success: boolean;
+  conflicting_app_ids: string[];
+  error_message?: string | null;
 }

--- a/src/crosshook-native/src/types/protonup.ts
+++ b/src/crosshook-native/src/types/protonup.ts
@@ -40,6 +40,7 @@ export type ProtonUpInstallErrorKind =
   | 'network_error'
   | 'invalid_path'
   | 'already_installed'
+  | 'cancelled'
   | 'unknown';
 
 export interface ProtonUpInstallResult {

--- a/src/crosshook-native/src/types/protonup.ts
+++ b/src/crosshook-native/src/types/protonup.ts
@@ -1,6 +1,6 @@
 // These types mirror the Rust DTOs in crosshook-core/src/protonup/mod.rs
 
-export type ProtonUpProvider = 'ge-proton' | 'proton-cachyos' | 'proton-em';
+export type ProtonUpProvider = 'ge-proton' | 'proton-cachyos' | 'proton-em' | 'boxtron' | 'luxtorpeda';
 
 export interface ProtonUpAvailableVersion {
   provider: string;

--- a/src/crosshook-native/src/types/protonup.ts
+++ b/src/crosshook-native/src/types/protonup.ts
@@ -1,6 +1,6 @@
 // These types mirror the Rust DTOs in crosshook-core/src/protonup/mod.rs
 
-export type ProtonUpProvider = 'ge-proton' | 'proton-cachyos';
+export type ProtonUpProvider = 'ge-proton' | 'proton-cachyos' | 'proton-em';
 
 export interface ProtonUpAvailableVersion {
   provider: string;
@@ -100,6 +100,12 @@ export interface ProtonInstallProgress {
 }
 
 export interface ProtonUninstallResult {
+  success: boolean;
+  conflicting_app_ids: string[];
+  error_message?: string | null;
+}
+
+export interface ProtonUninstallPlanResult {
   success: boolean;
   conflicting_app_ids: string[];
   error_message?: string | null;

--- a/src/crosshook-native/src/types/settings.ts
+++ b/src/crosshook-native/src/types/settings.ts
@@ -34,6 +34,12 @@ export interface SettingsSaveRequest {
   protonup_auto_suggest?: boolean;
   /** Optional path override for the ProtonUp binary; empty = auto-detect. */
   protonup_binary_path?: string;
+  /** Default provider id used by the native Proton manager; empty = first available. */
+  protonup_default_provider?: string;
+  /** Default install root path for the native Proton manager; empty = auto-pick writable root. */
+  protonup_default_install_root?: string;
+  /** When true, include pre-release versions in the native Proton manager catalog. */
+  protonup_include_prereleases?: boolean;
   /** Non-Steam launch preference: `auto` (umu when available, else Proton), `umu` (always umu-run), `proton` (always direct Proton). */
   umu_preference: UmuPreference;
   /** Capability-level hint dismissals for the host-tool dashboard. */
@@ -76,6 +82,9 @@ export function toSettingsSaveRequest(s: AppSettingsData): SettingsSaveRequest {
     external_trainer_sources: s.external_trainer_sources,
     protonup_auto_suggest: s.protonup_auto_suggest,
     protonup_binary_path: s.protonup_binary_path,
+    protonup_default_provider: s.protonup_default_provider,
+    protonup_default_install_root: s.protonup_default_install_root,
+    protonup_include_prereleases: s.protonup_include_prereleases,
     umu_preference: s.umu_preference,
     host_tool_dashboard_dismissed_hints: s.host_tool_dashboard_dismissed_hints,
     host_tool_dashboard_default_category_filter: s.host_tool_dashboard_default_category_filter,
@@ -117,6 +126,9 @@ export const DEFAULT_APP_SETTINGS: AppSettingsData = {
   external_trainer_sources: [],
   protonup_auto_suggest: true,
   protonup_binary_path: '',
+  protonup_default_provider: '',
+  protonup_default_install_root: '',
+  protonup_include_prereleases: false,
   umu_preference: 'auto',
   host_tool_dashboard_dismissed_hints: [],
   host_tool_dashboard_default_category_filter: null,


### PR DESCRIPTION
## Summary

Ship a native Proton version manager that replaces external ProtonUp-Qt orchestration with in-app catalog fetch, install, and uninstall flows that work consistently under AppImage and Flatpak — without a sandbox-bundled helper, and without creating a parallel Proton selection model.

Closes #274

## Changes

- **Backend** (`crosshook-core`): `ProtonReleaseProvider` trait + registry (GE-Proton, Proton-CachyOS, Proton-EM unconditional; Luxtorpeda + Boxtron behind the `experimental-providers` crate feature); streaming install orchestrator with progress events, `CancellationToken`, and `ChecksumKind` dispatch (SHA-512 sidecar / SHA-256 manifest / none); environment-aware install-root resolver that probes Flatpak `:ro` paths as a first-class degraded mode; mapping-aware uninstall with system-path refusal.
- **Schema**: SQLite v22 adds `proton_release_catalog` table + index; v23 evicts stale cache rows so additive DTO fields (`published_at`) repopulate on next fetch.
- **IPC** (`src-tauri`): snake_case `#[tauri::command]` handlers (`protonup_list_providers`, `protonup_resolve_install_roots`, `protonup_install_version_async`, `protonup_cancel_install`, `protonup_uninstall_version`); `Arc<ProtonInstallRegistry>` for cancel-token tracking; Tauri event `protonup:install:progress`.
- **UI**: New `/proton-manager` route under Dashboards; `ProviderPicker` with leading "All" option; per-provider filtering of the installed list (tag-prefix classification); release-date sort (newest first); row metadata caption (release date + archive size) for both installed and available rows; `SettingsPanel` "Proton manager defaults" section.
- **Settings**: Three new TOML fields — `protonup_default_provider`, `protonup_default_install_root`, `protonup_include_prereleases`.
- **Docs**: ADR-0003 documenting the architecture and Flatpak degraded-mode contract; `AGENTS.md` + `CLAUDE.md` bumped to schema v23.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## Testing

### Environment

- **Platform**: Linux (CachyOS 6.19)
- **Proton Versions tested**: GE-Proton10-1 install/uninstall round-trip via Tauri; GE-Proton + Proton-CachyOS + Proton-EM catalog fan-out via `protonup_list_available_versions`
- **Game / Trainer**: N/A (Proton inventory feature)

### Checklist

- [x] `./scripts/lint.sh` passes (rustfmt, clippy `-D warnings`, biome, tsc, shellcheck)
- [x] `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core` passes — 1032 tests green
- [x] `./scripts/check-host-gateway.sh` passes (no new denylisted invocations; extraction stays in-sandbox per ADR-0001)
- [x] Browser dev mode (`./scripts/dev-native.sh --browser`) renders the Proton Manager page with mock providers + install progress stream
- [x] **src/components/ or src/hooks/**: UI verified — filtering, "All" tab, release-date sort, metadata caption, scroll behavior all visually confirmed
- [ ] `./scripts/build-native.sh --binary-only` (will run in CI)
- [ ] `./scripts/build-native.sh` produces valid AppImage (will run in release CI)
- [ ] Flatpak verification against `:ro` Steam compat-tools path (requires Flatpak build; reviewer may want to exercise on Steam Deck)

## Reviewer Notes

- **Schema v23 is cache-only**: the migration deletes `proton_release_catalog` rows so the next fetch rebuilds them with `published_at`. No user data affected.
- **Scope clarification** (per the plan): Proton-EM ships install-capable. Luxtorpeda + Boxtron are catalog-only behind `experimental-providers` cargo feature because their folder-name-vs-tag invariants have not been verified for safe extraction. Enable the feature to smoke-test them locally.
- **Host-gateway contract**: all download/extract code is in-sandbox (`reqwest` + `tar`/`flate2`/`xz2`) and is explicitly exempted from ADR-0001's denylist. No host-tool invocations added.
- **Flatpak `:ro` path**: when `~/.var/app/com.valvesoftware.Steam/...` is read-only, the resolver surfaces a `read-only` badge and routes installs to the native-Steam fallback (matches the research recommendation). Install is refused — never silently succeeds — when no writable root exists.
- **Browser dev mode**: mocks now return distinct Proton-EM fixtures (previously aliased GE-Proton, masking a filter bug). `verify:no-mocks` sentinel remains green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proton Manager UI for browsing, installing, and uninstalling Proton versions across multiple providers (GE‑Proton, Proton‑CachyOS, Proton‑EM, Boxtron, Luxtorpeda).
  * Provider catalog caching with multi-row storage, migration/eviction behavior, and provider registry.
  * Install-root discovery/selection with writability probing and Flatpak-aware defaults.
  * Async installs with progress events, cancellation, checksum verification, and uninstall planning/execution.
  * Settings UI and defaults for provider, install root, and prerelease inclusion.

* **Documentation**
  * Added architecture decision record for the Proton download manager.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->