### PR TITLE
test(frontend): add vitest and rtl seed suite

### DIFF
--- a/src/crosshook-native/package-lock.json
+++ b/src/crosshook-native/package-lock.json
@@ -21,13 +21,27 @@
         "@biomejs/biome": "^2.0.0",
         "@playwright/test": "^1.59.0",
         "@tauri-apps/cli": "^2.0.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^5.2.0",
+        "@vitest/coverage-v8": "^4.1.4",
+        "happy-dom": "^20.9.0",
         "prettier": "^3.5.0",
         "typescript": "^5.6.3",
-        "vite": "^8.0.5"
+        "vite": "^8.0.5",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -263,6 +277,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -309,6 +333,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1533,6 +1567,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -1787,6 +1828,95 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1797,6 +1927,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1843,6 +1980,41 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1871,6 +2043,23 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
@@ -1892,6 +2081,173 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -1903,6 +2259,45 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
@@ -1972,10 +2367,27 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2004,6 +2416,16 @@
         }
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2020,12 +2442,39 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.321",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2035,6 +2484,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2087,6 +2556,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/js-tokens": {
@@ -2404,6 +2957,77 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2434,6 +3058,24 @@
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2549,6 +3191,21 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -2573,6 +3230,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -2663,6 +3327,20 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
@@ -2723,6 +3401,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2731,6 +3416,63 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -2748,6 +3490,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2769,6 +3521,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -2918,6 +3677,145 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }

--- a/src/crosshook-native/package.json
+++ b/src/crosshook-native/package.json
@@ -10,6 +10,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:smoke": "playwright test",
     "test:smoke:update": "playwright test --update-snapshots",
     "test:smoke:install": "playwright install chromium",
@@ -17,7 +20,7 @@
     "lint:fix": "biome check --fix src/",
     "format": "biome format --write src/",
     "format:check": "biome format src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.2.6",
@@ -35,11 +38,18 @@
     "@biomejs/biome": "^2.0.0",
     "@playwright/test": "^1.59.0",
     "@tauri-apps/cli": "^2.0.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.4",
+    "happy-dom": "^20.9.0",
     "prettier": "^3.5.0",
     "typescript": "^5.6.3",
-    "vite": "^8.0.5"
+    "vite": "^8.0.5",
+    "vitest": "^4.1.4"
   }
 }

--- a/src/crosshook-native/package.json
+++ b/src/crosshook-native/package.json
@@ -2,6 +2,9 @@
   "name": "crosshook-native",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "x-tauri-deps-versioning": "caret ^2.x on all @tauri-apps/* packages for semver-aligned minor/patch updates with the Tauri 2.x stack (Rust: tauri 2 in src-tauri/Cargo.toml).",
   "scripts": {
     "dev": "vite",

--- a/src/crosshook-native/src/components/ProtonDbLookupCard.tsx
+++ b/src/crosshook-native/src/components/ProtonDbLookupCard.tsx
@@ -77,13 +77,13 @@ export function ProtonDbLookupCard({
 }: ProtonDbLookupCardProps) {
   const titleId = useId();
   const [copyLabels, setCopyLabels] = useState<Record<string, string>>({});
-  const copyTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const copyTimeouts = useRef<Map<string, number>>(new Map());
   const lookup = useProtonDbLookup(appId);
 
   useEffect(() => {
     return () => {
       copyTimeouts.current.forEach((id) => {
-        clearTimeout(id);
+        window.clearTimeout(id);
       });
     };
   }, []);
@@ -134,7 +134,7 @@ export function ProtonDbLookupCard({
     }
 
     const existing = copyTimeouts.current.get(copyKey);
-    if (existing) clearTimeout(existing);
+    if (existing) window.clearTimeout(existing);
     const id = window.setTimeout(() => {
       setCopyLabels((current) => ({ ...current, [copyKey]: 'Copy' }));
       copyTimeouts.current.delete(copyKey);

--- a/src/crosshook-native/src/components/__tests__/OnboardingWizard.test.tsx
+++ b/src/crosshook-native/src/components/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeProfileDraft } from '@/test/fixtures';
+import { OnboardingWizard } from '../OnboardingWizard';
+
+const useOnboardingMock = vi.fn();
+const usePreferencesContextMock = vi.fn();
+const useProfileContextMock = vi.fn();
+const useProtonInstallsMock = vi.fn();
+const evaluateWizardRequiredFieldsMock = vi.fn();
+
+vi.mock('@/hooks/useOnboarding', () => ({
+  useOnboarding: () => useOnboardingMock(),
+}));
+
+vi.mock('@/context/PreferencesContext', () => ({
+  usePreferencesContext: () => usePreferencesContextMock(),
+}));
+
+vi.mock('@/context/ProfileContext', () => ({
+  useProfileContext: () => useProfileContextMock(),
+}));
+
+vi.mock('@/hooks/useProtonInstalls', () => ({
+  useProtonInstalls: () => useProtonInstallsMock(),
+}));
+
+vi.mock('@/components/profile-sections/ProfileIdentitySection', () => ({
+  ProfileIdentitySection: () => <div>Identity Section</div>,
+}));
+vi.mock('@/components/profile-sections/GameSection', () => ({
+  GameSection: () => <div>Game Section</div>,
+}));
+vi.mock('@/components/profile-sections/RunnerMethodSection', () => ({
+  RunnerMethodSection: () => <div>Runner Section</div>,
+}));
+vi.mock('@/components/profile-sections/RuntimeSection', () => ({
+  RuntimeSection: () => <div>Runtime Section</div>,
+}));
+vi.mock('@/components/profile-sections/TrainerSection', () => ({
+  TrainerSection: () => <div>Trainer Section</div>,
+}));
+vi.mock('@/components/profile-sections/MediaSection', () => ({
+  MediaSection: () => <div>Media Section</div>,
+}));
+vi.mock('@/components/host-readiness/HostToolDashboardHandoff', () => ({
+  HostToolDashboardHandoff: () => <div>Host Tools Handoff</div>,
+}));
+vi.mock('@/components/layout/ControllerPrompts', () => ({
+  ControllerPrompts: () => <div>Controller Prompts</div>,
+}));
+vi.mock('@/components/CustomEnvironmentVariablesSection', () => ({
+  CustomEnvironmentVariablesSection: () => <div>Custom Env Section</div>,
+}));
+vi.mock('@/components/wizard/WizardPresetPicker', () => ({
+  WizardPresetPicker: () => <div>Preset Picker</div>,
+}));
+vi.mock('@/components/wizard/WizardReviewSummary', () => ({
+  WizardReviewSummary: () => <div>Review Summary</div>,
+}));
+vi.mock('@/components/wizard/wizardValidation', () => ({
+  evaluateWizardRequiredFields: (...args: unknown[]) => evaluateWizardRequiredFieldsMock(...args),
+}));
+
+function buildOnboardingState(overrides: Record<string, unknown> = {}) {
+  return {
+    stage: 'identity_game',
+    readinessResult: null,
+    checkError: null,
+    isRunningChecks: false,
+    lastCheckedAt: null,
+    umuInstallGuidance: null,
+    steamDeckCaveats: null,
+    isIdentityGame: true,
+    isRuntime: false,
+    isTrainer: false,
+    isMedia: false,
+    isReview: false,
+    isCompleted: false,
+    runChecks: vi.fn(),
+    advanceOrSkip: vi.fn(),
+    goBack: vi.fn(),
+    dismiss: vi.fn().mockResolvedValue(undefined),
+    dismissUmuInstallNag: vi.fn().mockResolvedValue(undefined),
+    dismissSteamDeckCaveats: vi.fn().mockResolvedValue(undefined),
+    dismissReadinessNag: vi.fn().mockResolvedValue(undefined),
+    setCompletedProfileName: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('OnboardingWizard', () => {
+  beforeEach(() => {
+    useOnboardingMock.mockReturnValue(buildOnboardingState());
+    usePreferencesContextMock.mockReturnValue({
+      defaultSteamClientInstallPath: '/home/devuser/.steam/steam',
+    });
+    useProfileContextMock.mockReturnValue({
+      profileName: 'Synthetic Quest',
+      profile: makeProfileDraft(),
+      saving: false,
+      error: null,
+      setProfileName: vi.fn(),
+      updateProfile: vi.fn(),
+      persistProfileDraft: vi.fn().mockResolvedValue({ ok: true }),
+      selectProfile: vi.fn().mockResolvedValue(undefined),
+      steamClientInstallPath: '/home/devuser/.steam/steam',
+      bundledOptimizationPresets: [],
+      applyBundledOptimizationPreset: vi.fn().mockResolvedValue(undefined),
+      switchLaunchOptimizationPreset: vi.fn().mockResolvedValue(undefined),
+      optimizationPresetActionBusy: false,
+    });
+    useProtonInstallsMock.mockReturnValue({
+      installs: [],
+      error: null,
+    });
+    evaluateWizardRequiredFieldsMock.mockReturnValue({
+      isReady: true,
+      firstMissingId: null,
+    });
+  });
+
+  it('mounts in a portal and focuses the heading when opened', async () => {
+    render(<OnboardingWizard open onComplete={vi.fn()} onDismiss={vi.fn()} />);
+
+    const heading = await screen.findByRole('heading', { name: 'Identity & Game' });
+
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
+    expect(screen.getByRole('button', { name: 'Skip Setup' })).toBeInTheDocument();
+  });
+
+  it('shows native review progress and disables save when validation fails', () => {
+    useOnboardingMock.mockReturnValue(
+      buildOnboardingState({
+        stage: 'review',
+        isIdentityGame: false,
+        isReview: true,
+      })
+    );
+    useProfileContextMock.mockReturnValue({
+      ...useProfileContextMock(),
+      profile: makeProfileDraft({
+        launch: {
+          ...makeProfileDraft().launch,
+          method: 'native',
+        },
+      }),
+    });
+    evaluateWizardRequiredFieldsMock.mockReturnValue({
+      isReady: false,
+      firstMissingId: 'profile_name',
+    });
+
+    render(<OnboardingWizard open onComplete={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(screen.getByText('Step 4 of 4')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Profile' })).toBeDisabled();
+  });
+
+  it('dismisses onboarding before invoking onDismiss from Skip Setup', async () => {
+    const dismiss = vi.fn().mockResolvedValue(undefined);
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+
+    useOnboardingMock.mockReturnValue(
+      buildOnboardingState({
+        dismiss,
+      })
+    );
+
+    render(<OnboardingWizard open onComplete={vi.fn()} onDismiss={onDismiss} />);
+
+    await user.click(screen.getByRole('button', { name: 'Skip Setup' }));
+
+    expect(dismiss).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/crosshook-native/src/components/library/__tests__/LibraryCard.test.tsx
+++ b/src/crosshook-native/src/components/library/__tests__/LibraryCard.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeLibraryCardData } from '@/test/fixtures';
+import { mockCallCommand, renderWithMocks } from '@/test/render';
+import { triggerIntersection } from '@/test/setup';
+import { LibraryCard } from '../LibraryCard';
+
+vi.mock('@/lib/ipc', () => ({
+  callCommand: mockCallCommand,
+}));
+
+describe('LibraryCard', () => {
+  const defaultProps = {
+    profile: makeLibraryCardData(),
+    onOpenDetails: vi.fn(),
+    onLaunch: vi.fn(),
+    onEdit: vi.fn(),
+    onToggleFavorite: vi.fn(),
+    onContextMenu: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads cover art after the card enters the viewport', async () => {
+    const profile = makeLibraryCardData({ customPortraitArtPath: '' });
+
+    renderWithMocks(<LibraryCard {...defaultProps} profile={profile} />, {
+      handlerOverrides: {
+        fetch_game_cover_art: async () => '/mock/media/synthetic-quest.png',
+      },
+    });
+
+    const listItem = screen.getByRole('listitem');
+
+    triggerIntersection(listItem, true);
+
+    await waitFor(() => {
+      expect(screen.getByRole('img', { name: 'Synthetic Quest' })).toHaveAttribute(
+        'src',
+        '/mock/media/synthetic-quest.png'
+      );
+    });
+  });
+
+  it('opens the context menu from mouse and keyboard shortcuts', async () => {
+    const user = userEvent.setup();
+    const onContextMenu = vi.fn();
+
+    renderWithMocks(<LibraryCard {...defaultProps} onContextMenu={onContextMenu} />);
+
+    const listItem = screen.getByRole('listitem');
+    const detailsButton = screen.getByRole('button', { name: 'View details for Synthetic Quest' });
+
+    fireEvent.contextMenu(listItem, { clientX: 12, clientY: 18 });
+    expect(onContextMenu).toHaveBeenCalledWith({ x: 12, y: 18 }, 'Synthetic Quest', listItem);
+
+    detailsButton.focus();
+    await user.keyboard('{Shift>}{F10}{/Shift}');
+
+    expect(onContextMenu).toHaveBeenCalledTimes(2);
+    expect(onContextMenu.mock.calls[1]?.[1]).toBe('Synthetic Quest');
+  });
+
+  it('invokes launch, favorite, and edit callbacks from footer actions', async () => {
+    const user = userEvent.setup();
+    const onLaunch = vi.fn();
+    const onEdit = vi.fn();
+    const onToggleFavorite = vi.fn();
+
+    renderWithMocks(
+      <LibraryCard
+        {...defaultProps}
+        onLaunch={onLaunch}
+        onEdit={onEdit}
+        onToggleFavorite={onToggleFavorite}
+        profile={makeLibraryCardData({ isFavorite: true })}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Launch Synthetic Quest' }));
+    await user.click(screen.getByRole('button', { name: 'Unfavorite Synthetic Quest' }));
+    await user.click(screen.getByRole('button', { name: 'Edit Synthetic Quest' }));
+
+    expect(onLaunch).toHaveBeenCalledWith('Synthetic Quest');
+    expect(onToggleFavorite).toHaveBeenCalledWith('Synthetic Quest', true);
+    expect(onEdit).toHaveBeenCalledWith('Synthetic Quest');
+  });
+});

--- a/src/crosshook-native/src/components/library/__tests__/LibraryGrid.test.tsx
+++ b/src/crosshook-native/src/components/library/__tests__/LibraryGrid.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { makeLibraryCardData } from '@/test/fixtures';
+import { LibraryGrid } from '../LibraryGrid';
+
+vi.mock('../LibraryCard', () => ({
+  LibraryCard: ({
+    profile,
+    isSelected,
+    isLaunching,
+  }: {
+    profile: { name: string };
+    isSelected?: boolean;
+    isLaunching?: boolean;
+  }) => (
+    <li
+      data-testid={`card-${profile.name}`}
+      data-selected={String(Boolean(isSelected))}
+      data-launching={String(Boolean(isLaunching))}
+    >
+      {profile.name}
+    </li>
+  ),
+}));
+
+describe('LibraryGrid', () => {
+  it('renders an empty state and routes the CTA to profiles', async () => {
+    const onNavigate = vi.fn();
+
+    render(
+      <LibraryGrid
+        profiles={[]}
+        onNavigate={onNavigate}
+        onOpenDetails={vi.fn()}
+        onLaunch={vi.fn()}
+        onEdit={vi.fn()}
+        onToggleFavorite={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('No game profiles yet')).toBeInTheDocument();
+    await screen.getByRole('button', { name: 'Create a profile' }).click();
+    expect(onNavigate).toHaveBeenCalledWith('profiles');
+  });
+
+  it('renders one card per profile', () => {
+    render(
+      <LibraryGrid
+        profiles={[makeLibraryCardData(), makeLibraryCardData({ name: 'Dev Test Game', steamAppId: '9999002' })]}
+        onOpenDetails={vi.fn()}
+        onLaunch={vi.fn()}
+        onEdit={vi.fn()}
+        onToggleFavorite={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('card-Synthetic Quest')).toBeInTheDocument();
+    expect(screen.getByTestId('card-Dev Test Game')).toBeInTheDocument();
+  });
+
+  it('passes selected and launching state to child cards', () => {
+    render(
+      <LibraryGrid
+        profiles={[makeLibraryCardData(), makeLibraryCardData({ name: 'Dev Test Game', steamAppId: '9999002' })]}
+        selectedName="Synthetic Quest"
+        launchingName="Dev Test Game"
+        onOpenDetails={vi.fn()}
+        onLaunch={vi.fn()}
+        onEdit={vi.fn()}
+        onToggleFavorite={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('card-Synthetic Quest')).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByTestId('card-Dev Test Game')).toHaveAttribute('data-launching', 'true');
+  });
+});

--- a/src/crosshook-native/src/hooks/__tests__/useCapabilityGate.test.ts
+++ b/src/crosshook-native/src/hooks/__tests__/useCapabilityGate.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as readinessContext from '@/context/HostReadinessContext';
+import { makeCapability, makeHostToolCheck, makeInstallHint } from '@/test/fixtures';
+import * as clipboard from '@/utils/clipboard';
+import { useCapabilityGate } from '../useCapabilityGate';
+
+describe('useCapabilityGate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns unavailable defaults when the capability is missing', () => {
+    vi.spyOn(readinessContext, 'useHostReadinessContext').mockReturnValue({
+      snapshot: null,
+      capabilities: [],
+      isStale: false,
+      lastCheckedAt: null,
+      isRefreshing: false,
+      error: null,
+      refresh: vi.fn(),
+      probeTool: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useCapabilityGate('missing'));
+
+    expect(result.current.state).toBe('unavailable');
+    expect(result.current.missingRequired).toEqual([]);
+    expect(result.current.missingToolIds).toEqual([]);
+    expect(result.current.installHint).toBeNull();
+    expect(result.current.onCopyCommand).toBeUndefined();
+    expect(result.current.docsUrl).toBeNull();
+  });
+
+  it('derives missing tools and prefers docs from missing required tools', () => {
+    const required = makeHostToolCheck({
+      tool_id: 'gamescope',
+      docs_url: 'https://docs.example.invalid/gamescope',
+    });
+    const optional = makeHostToolCheck({
+      tool_id: 'mangohud',
+      is_required: false,
+      docs_url: 'https://docs.example.invalid/mangohud',
+    });
+
+    vi.spyOn(readinessContext, 'useHostReadinessContext').mockReturnValue({
+      snapshot: null,
+      capabilities: [
+        makeCapability({
+          id: 'gamescope',
+          missing_required: [required],
+          missing_optional: [optional],
+          install_hints: [makeInstallHint()],
+        }),
+      ],
+      isStale: false,
+      lastCheckedAt: null,
+      isRefreshing: false,
+      error: null,
+      refresh: vi.fn(),
+      probeTool: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useCapabilityGate('gamescope'));
+
+    expect(result.current.missingToolIds).toEqual(['gamescope', 'mangohud']);
+    expect(result.current.docsUrl).toBe('https://docs.example.invalid/gamescope');
+    expect(result.current.installHint?.command).toBe('sudo pacman -S gamescope');
+    expect(result.current.onCopyCommand).toBeTypeOf('function');
+  });
+
+  it('copies the install command when one is present', async () => {
+    const copyToClipboard = vi.spyOn(clipboard, 'copyToClipboard').mockResolvedValue();
+
+    vi.spyOn(readinessContext, 'useHostReadinessContext').mockReturnValue({
+      snapshot: null,
+      capabilities: [
+        makeCapability({
+          id: 'gamescope',
+          install_hints: [makeInstallHint({ command: 'sudo pacman -S gamescope' })],
+        }),
+      ],
+      isStale: false,
+      lastCheckedAt: null,
+      isRefreshing: false,
+      error: null,
+      refresh: vi.fn(),
+      probeTool: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useCapabilityGate('gamescope'));
+
+    await act(async () => {
+      await result.current.onCopyCommand?.();
+    });
+
+    expect(copyToClipboard).toHaveBeenCalledWith('sudo pacman -S gamescope');
+  });
+});

--- a/src/crosshook-native/src/hooks/__tests__/useGamepadNav.test.tsx
+++ b/src/crosshook-native/src/hooks/__tests__/useGamepadNav.test.tsx
@@ -1,0 +1,113 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type GamepadNavState, useGamepadNav } from '../useGamepadNav';
+
+interface HarnessProps {
+  enabled?: boolean;
+  onBack?: () => void;
+}
+
+let latestState: GamepadNavState | null = null;
+
+function GamepadNavHarness({ enabled = false, onBack }: HarnessProps) {
+  const nav = useGamepadNav({ enabled, onBack });
+  latestState = nav;
+
+  return (
+    <div ref={(node) => (nav.rootRef.current = node)} data-testid="nav-root">
+      <nav data-crosshook-focus-zone="sidebar">
+        <button type="button" value="library" data-state="active">
+          Library
+        </button>
+        <button type="button" value="profiles">
+          Profiles
+        </button>
+      </nav>
+      <main data-crosshook-focus-zone="content">
+        <button type="button">Launch</button>
+        <button type="button">Edit</button>
+      </main>
+    </div>
+  );
+}
+
+function makeGamepad(buttons: number[] = [], axes: number[] = [0, 0]): Gamepad {
+  const pressed = new Set(buttons);
+  return {
+    axes,
+    buttons: Array.from({ length: 16 }, (_, index) => ({
+      pressed: pressed.has(index),
+      touched: pressed.has(index),
+      value: pressed.has(index) ? 1 : 0,
+    })),
+    connected: true,
+    id: 'Mock Gamepad',
+    index: 0,
+    mapping: 'standard',
+    timestamp: Date.now(),
+    vibrationActuator: null,
+    hapticActuators: [],
+  } as unknown as Gamepad;
+}
+
+describe('useGamepadNav', () => {
+  beforeEach(() => {
+    latestState = null;
+  });
+
+  it('cycles focus with capture-phase keyboard handling', () => {
+    render(<GamepadNavHarness enabled={false} />);
+
+    const launchButton = screen.getByRole('button', { name: 'Launch' });
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+
+    launchButton.focus();
+    expect(launchButton).toHaveFocus();
+
+    act(() => {
+      launchButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }));
+    });
+    expect(editButton).toHaveFocus();
+  });
+
+  it('moves focus from gamepad polling when controller mode is enabled', () => {
+    vi.useFakeTimers();
+    vi.spyOn(navigator, 'getGamepads').mockReturnValue([makeGamepad([13])] as unknown as Gamepad[]);
+
+    render(<GamepadNavHarness enabled />);
+
+    const launchButton = screen.getByRole('button', { name: 'Launch' });
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    launchButton.focus();
+
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+
+    expect(editButton).toHaveFocus();
+  });
+
+  it('focuses the content zone when the active sidebar route changes', async () => {
+    render(<GamepadNavHarness enabled />);
+
+    const sidebarButtons = screen
+      .getAllByRole('button', { hidden: false })
+      .filter((button) => ['Library', 'Profiles'].includes(button.textContent ?? ''));
+    const libraryButton = sidebarButtons[0];
+    const profilesButton = sidebarButtons[1];
+    const contentRegion = screen.getByRole('main');
+
+    libraryButton.focus();
+    expect(libraryButton).toHaveFocus();
+
+    act(() => {
+      libraryButton.removeAttribute('data-state');
+      profilesButton.setAttribute('data-state', 'active');
+    });
+
+    await waitFor(() => {
+      expect(contentRegion.contains(document.activeElement)).toBe(true);
+    });
+    expect(contentRegion.contains(latestState?.activeElement ?? null)).toBe(true);
+  });
+});

--- a/src/crosshook-native/src/hooks/__tests__/useGamepadNav.test.tsx
+++ b/src/crosshook-native/src/hooks/__tests__/useGamepadNav.test.tsx
@@ -14,7 +14,12 @@ function GamepadNavHarness({ enabled = false, onBack }: HarnessProps) {
   latestState = nav;
 
   return (
-    <div ref={(node) => (nav.rootRef.current = node)} data-testid="nav-root">
+    <div
+      ref={(node) => {
+        nav.rootRef.current = node;
+      }}
+      data-testid="nav-root"
+    >
       <nav data-crosshook-focus-zone="sidebar">
         <button type="button" value="library" data-state="active">
           Library

--- a/src/crosshook-native/src/hooks/__tests__/useOnboarding.test.ts
+++ b/src/crosshook-native/src/hooks/__tests__/useOnboarding.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeReadinessResult } from '@/test/fixtures';
+import { configureMockHandlers, mockCallCommand } from '@/test/render';
+import { useOnboarding } from '../useOnboarding';
+
+vi.mock('@/lib/ipc', () => ({
+  callCommand: mockCallCommand,
+}));
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    configureMockHandlers();
+  });
+
+  it('stores readiness results after runChecks resolves', async () => {
+    const readinessResult = makeReadinessResult({
+      all_passed: true,
+      critical_failures: 0,
+    });
+    configureMockHandlers({
+      handlerOverrides: {
+        check_generalized_readiness: async () => readinessResult,
+      },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+
+    await act(async () => {
+      await result.current.runChecks();
+    });
+
+    await waitFor(() => {
+      expect(result.current.readinessResult).toEqual(readinessResult);
+    });
+    expect(result.current.checkError).toBeNull();
+    expect(result.current.lastCheckedAt).not.toBeNull();
+  });
+
+  it('skips the trainer stage for native launch methods', () => {
+    const { result } = renderHook(() => useOnboarding());
+
+    act(() => {
+      result.current.advanceOrSkip('native');
+    });
+    expect(result.current.stage).toBe('runtime');
+
+    act(() => {
+      result.current.advanceOrSkip('native');
+    });
+    expect(result.current.stage).toBe('media');
+  });
+
+  it('surfaces readiness dismissal errors via checkError', async () => {
+    configureMockHandlers({
+      handlerOverrides: {
+        dismiss_readiness_nag: async () => {
+          throw new Error('mock dismiss failure');
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useOnboarding());
+
+    await act(async () => {
+      await result.current.dismissReadinessNag('umu_run');
+    });
+
+    expect(result.current.checkError).toBe('mock dismiss failure');
+  });
+});

--- a/src/crosshook-native/src/lib/__tests__/ipc.test.ts
+++ b/src/crosshook-native/src/lib/__tests__/ipc.test.ts
@@ -7,16 +7,21 @@ describe('callCommand', () => {
 
   it('routes browser-mode commands through the webdev IPC bridge', async () => {
     vi.doUnmock('@/lib/ipc');
-    vi.doUnmock('@/lib/ipc.dev');
     vi.doMock('@/lib/runtime', () => ({
       isTauri: () => false,
       isBrowserDevUi: () => true,
+    }));
+    const runMockCommand = vi.fn(async () => ({ auto_load_last_profile: false }));
+    vi.doMock('@/lib/ipc.dev', () => ({
+      runMockCommand,
     }));
 
     const { callCommand } = await import('@/lib/ipc');
 
     const settings = await callCommand<Record<string, unknown>>('settings_load');
 
+    expect(runMockCommand).toHaveBeenCalledTimes(1);
+    expect(runMockCommand).toHaveBeenCalledWith('settings_load', undefined);
     expect(settings).toHaveProperty('auto_load_last_profile');
   });
 });

--- a/src/crosshook-native/src/lib/__tests__/ipc.test.ts
+++ b/src/crosshook-native/src/lib/__tests__/ipc.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('callCommand', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('routes browser-mode commands through the webdev IPC bridge', async () => {
+    vi.doUnmock('@/lib/ipc');
+    vi.doUnmock('@/lib/ipc.dev');
+    vi.doMock('@/lib/runtime', () => ({
+      isTauri: () => false,
+      isBrowserDevUi: () => true,
+    }));
+
+    const { callCommand } = await import('@/lib/ipc');
+
+    const settings = await callCommand<Record<string, unknown>>('settings_load');
+
+    expect(settings).toHaveProperty('auto_load_last_profile');
+  });
+});

--- a/src/crosshook-native/src/lib/events.ts
+++ b/src/crosshook-native/src/lib/events.ts
@@ -27,3 +27,7 @@ export function emitMockEvent(name: string, payload: unknown): boolean {
   }
   return true;
 }
+
+export function resetBrowserEventBus(): void {
+  browserBus.clear();
+}

--- a/src/crosshook-native/src/lib/mocks/handlers/collections.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/collections.ts
@@ -326,3 +326,19 @@ export function registerCollections(map: Map<string, Handler>): void {
     };
   });
 }
+
+export function resetCollectionsMockState(): void {
+  collections = [
+    {
+      collection_id: 'mock-collection-1',
+      name: 'Action / Adventure',
+      description: 'Seeded fixture collection for dev mode',
+      profile_count: 0,
+      created_at: new Date('2026-04-01T12:00:00Z').toISOString(),
+      updated_at: new Date('2026-04-01T12:00:00Z').toISOString(),
+    },
+  ];
+  membership.clear();
+  membership.set('mock-collection-1', new Set());
+  mockDefaults.clear();
+}

--- a/src/crosshook-native/src/lib/mocks/handlers/community.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/community.ts
@@ -194,3 +194,7 @@ export function registerCommunity(map: Map<string, Handler>): void {
     };
   });
 }
+
+export function resetCommunityMockState(): void {
+  taps = [{ ...MOCK_TAP }];
+}

--- a/src/crosshook-native/src/lib/mocks/handlers/health.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/health.ts
@@ -20,6 +20,7 @@ const healthSnapshots = new Map<string, EnrichedProfileHealthReport>();
 
 // Tracks which profile names have had their version changes acknowledged
 const acknowledgedVersions = new Set<string>();
+const pendingHealthTimers = new Set<number>();
 
 // ---------------------------------------------------------------------------
 // Synthetic data helpers
@@ -140,6 +141,14 @@ function buildVersionCheckResult(profileName: string): VersionCheckResult {
   };
 }
 
+function scheduleHealthEvent(delayMs: number, callback: () => void): void {
+  const id = window.setTimeout(() => {
+    pendingHealthTimers.delete(id);
+    callback();
+  }, delayMs);
+  pendingHealthTimers.add(id);
+}
+
 // ---------------------------------------------------------------------------
 // Handler registration
 // ---------------------------------------------------------------------------
@@ -150,9 +159,9 @@ export function registerHealth(map: Map<string, Handler>): void {
     const profiles = getSeededProfiles();
     const summary = buildBatchSummary(profiles);
     // Emit event after a short delay so the hook's event listener fires after mount
-    setTimeout(() => {
+    scheduleHealthEvent(400, () => {
       emitMockEvent('profile-health-batch-complete', summary);
-    }, 400);
+    });
     return summary;
   });
 
@@ -216,9 +225,9 @@ export function registerHealth(map: Map<string, Handler>): void {
     }
     const result = buildVersionCheckResult(name);
     // Emit version-scan-complete after a short delay
-    setTimeout(() => {
+    scheduleHealthEvent(300, () => {
       emitMockEvent('version-scan-complete', { scanned: 1, mismatches: 0 });
-    }, 300);
+    });
     return result;
   });
 
@@ -262,4 +271,13 @@ export function registerHealth(map: Map<string, Handler>): void {
     }
     return null;
   });
+}
+
+export function resetHealthMockState(): void {
+  healthSnapshots.clear();
+  acknowledgedVersions.clear();
+  for (const timerId of pendingHealthTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingHealthTimers.clear();
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/install.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/install.ts
@@ -5,6 +5,7 @@ import type { Handler } from './types';
 
 /** Tracks the profile name of the currently in-flight install, if any. */
 let installInFlight: string | null = null;
+const pendingInstallTimers = new Set<number>();
 
 function buildMockInstallResult(request: InstallGameRequest): InstallGameResult {
   const base = createDefaultProfile();
@@ -57,11 +58,20 @@ function buildMockInstallResult(request: InstallGameRequest): InstallGameResult 
   };
 }
 
+function scheduleInstallTimeout(callback: () => void, delayMs: number): number {
+  const id = window.setTimeout(() => {
+    pendingInstallTimers.delete(id);
+    callback();
+  }, delayMs);
+  pendingInstallTimers.add(id);
+  return id;
+}
+
 function scheduleInstallEvents(profileName: string): void {
   const started = { profileName, phase: 'started', progress: 0, message: 'Starting installer…' };
   emitMockEvent('install-started', started);
 
-  window.setTimeout(() => {
+  scheduleInstallTimeout(() => {
     emitMockEvent('install-progress', {
       profileName,
       phase: 'running_installer',
@@ -70,7 +80,7 @@ function scheduleInstallEvents(profileName: string): void {
     });
   }, 200);
 
-  window.setTimeout(() => {
+  scheduleInstallTimeout(() => {
     emitMockEvent('install-progress', {
       profileName,
       phase: 'running_installer',
@@ -79,7 +89,7 @@ function scheduleInstallEvents(profileName: string): void {
     });
   }, 500);
 
-  window.setTimeout(() => {
+  scheduleInstallTimeout(() => {
     emitMockEvent('install-progress', {
       profileName,
       phase: 'running_installer',
@@ -88,7 +98,7 @@ function scheduleInstallEvents(profileName: string): void {
     });
   }, 900);
 
-  window.setTimeout(() => {
+  scheduleInstallTimeout(() => {
     emitMockEvent('install-progress', {
       profileName,
       phase: 'running_installer',
@@ -141,7 +151,9 @@ export function registerInstall(map: Map<string, Handler>): void {
       scheduleInstallEvents(profileName);
 
       // Simulate install duration (~1.5 s total)
-      await new Promise<void>((resolve) => window.setTimeout(resolve, 1500));
+      await new Promise<void>((resolve) => {
+        scheduleInstallTimeout(resolve, 1500);
+      });
 
       const result = buildMockInstallResult(request);
 
@@ -160,4 +172,12 @@ export function registerInstall(map: Map<string, Handler>): void {
       }
     }
   });
+}
+
+export function resetInstallMockState(): void {
+  installInFlight = null;
+  for (const timerId of pendingInstallTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingInstallTimers.clear();
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/launch.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/launch.ts
@@ -12,6 +12,7 @@ import type { Handler } from './types';
 let lastLaunchHelperLogPath = '/mock/logs/game-launch-9999001.log';
 let lastTrainerHelperLogPath = '/mock/logs/trainer-launch-9999001.log';
 const runningGames: Set<string> = new Set();
+const pendingLaunchTimers = new Set<number>();
 
 // ---------------------------------------------------------------------------
 // Fixture helpers (BR-11)
@@ -90,6 +91,14 @@ function makePreviewEnvVars(): LaunchPreview['environment'] {
   ];
 }
 
+function scheduleLaunchTimeout(callback: () => void, delayMs: number): void {
+  const id = window.setTimeout(() => {
+    pendingLaunchTimers.delete(id);
+    callback();
+  }, delayMs);
+  pendingLaunchTimers.add(id);
+}
+
 // ---------------------------------------------------------------------------
 // Event scheduling after launch_game / launch_trainer
 // ---------------------------------------------------------------------------
@@ -101,7 +110,7 @@ function scheduleLaunchLogSequence(
   afterLogsDelayMs: number
 ): void {
   logLines.forEach((line, index) => {
-    setTimeout(
+    scheduleLaunchTimeout(
       () => {
         emitMockEvent('launch-log', line);
       },
@@ -110,13 +119,13 @@ function scheduleLaunchLogSequence(
   });
 
   const diagnosticDelay = delayBetweenMs * (logLines.length + 1) + afterLogsDelayMs;
-  setTimeout(() => {
+  scheduleLaunchTimeout(() => {
     const report = makeDiagnosticReport(helperLogPath);
     emitMockEvent('launch-diagnostic', report);
   }, diagnosticDelay);
 
   const completeDelay = diagnosticDelay + 200;
-  setTimeout(() => {
+  scheduleLaunchTimeout(() => {
     emitMockEvent('launch-complete', { code: 0, signal: null });
   }, completeDelay);
 }
@@ -425,4 +434,14 @@ export function registerLaunch(map: Map<string, Handler>): void {
   map.set('_mock_get_last_trainer_log_path', async (): Promise<string> => {
     return lastTrainerHelperLogPath;
   });
+}
+
+export function resetLaunchMockState(): void {
+  lastLaunchHelperLogPath = '/mock/logs/game-launch-9999001.log';
+  lastTrainerHelperLogPath = '/mock/logs/trainer-launch-9999001.log';
+  runningGames.clear();
+  for (const timerId of pendingLaunchTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingLaunchTimers.clear();
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/onboarding.ts
@@ -62,6 +62,7 @@ interface MockHostToolDefinition {
 }
 
 let cachedHostReadinessSnapshot: CachedHostReadinessSnapshot | null = null;
+const pendingOnboardingTimers = new Set<number>();
 
 const MOCK_CAPABILITY_DEFINITIONS: readonly MockCapabilityDefinition[] = [
   {
@@ -507,6 +508,14 @@ function maybeSynthesizeOnboardingEvent(): void {
 
   let attempts = 0;
 
+  const scheduleOnboardingTimeout = (callback: () => void, delayMs: number): void => {
+    const id = window.setTimeout(() => {
+      pendingOnboardingTimers.delete(id);
+      callback();
+    }, delayMs);
+    pendingOnboardingTimers.add(id);
+  };
+
   const tryEmit = (): void => {
     if (onboardingEventSynthesized) return;
     const store = getStore();
@@ -522,10 +531,10 @@ function maybeSynthesizeOnboardingEvent(): void {
     if (attempts >= ONBOARDING_EMIT_MAX_ATTEMPTS) {
       return;
     }
-    setTimeout(tryEmit, ONBOARDING_EMIT_RETRY_MS);
+    scheduleOnboardingTimeout(tryEmit, ONBOARDING_EMIT_RETRY_MS);
   };
 
-  setTimeout(tryEmit, ONBOARDING_EMIT_INITIAL_MS);
+  scheduleOnboardingTimeout(tryEmit, ONBOARDING_EMIT_INITIAL_MS);
 }
 
 /** Strip install guidance for dismissed tools (matches real IPC `get_cached_host_readiness_snapshot`). */
@@ -653,6 +662,17 @@ export function registerOnboarding(map: Map<string, Handler>): void {
       ],
     };
   });
+}
+
+export function resetOnboardingMockState(): void {
+  onboardingDismissed = false;
+  onboardingEventSynthesized = false;
+  onboardingSynthesisScheduled = false;
+  cachedHostReadinessSnapshot = null;
+  for (const timerId of pendingOnboardingTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingOnboardingTimers.clear();
 }
 
 export { onboardingDismissed };

--- a/src/crosshook-native/src/lib/mocks/handlers/profile.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/profile.ts
@@ -682,3 +682,9 @@ export function registerProfile(map: Map<string, Handler>): void {
     })
   );
 }
+
+export function resetProfileMockState(): void {
+  profileFavorites.clear();
+  profileConfigHistory.clear();
+  nextRevisionId = 1;
+}

--- a/src/crosshook-native/src/lib/mocks/handlers/protondb.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protondb.ts
@@ -211,3 +211,7 @@ export function registerProtonDb(map: Map<string, Handler>): void {
     return null;
   });
 }
+
+export function resetProtonDbMockState(): void {
+  dismissedSuggestions.clear();
+}

--- a/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/protonup.ts
@@ -92,6 +92,7 @@ function mockCatalogFor(provider: string | undefined): ProtonUpAvailableVersion[
 
 /** Tracks in-flight mock installs so protonup_cancel_install can drop remaining emissions. */
 const activeInstalls = new Set<string>();
+const pendingInstallTimers = new Set<number>();
 
 function getMockCacheMeta(): {
   stale: boolean;
@@ -105,6 +106,14 @@ function getMockCacheMeta(): {
     fetched_at: new Date().toISOString(),
     expires_at: new Date(Date.now() + 3_600_000).toISOString(),
   };
+}
+
+function scheduleInstallEvent(delayMs: number, callback: () => void): void {
+  const id = window.setTimeout(() => {
+    pendingInstallTimers.delete(id);
+    callback();
+  }, delayMs);
+  pendingInstallTimers.add(id);
 }
 
 export function registerProtonUp(map: Map<string, Handler>): void {
@@ -213,10 +222,10 @@ export function registerProtonUp(map: Map<string, Handler>): void {
     activeInstalls.add(opId);
 
     const schedule = (delayMs: number, payload: Record<string, unknown>) => {
-      window.setTimeout(() => {
+      scheduleInstallEvent(delayMs, () => {
         if (!activeInstalls.has(opId)) return;
         emitMockEvent('protonup:install:progress', { op_id: opId, ...payload });
-      }, delayMs);
+      });
     };
 
     schedule(0, { phase: 'resolving', bytes_done: 0, bytes_total: null });
@@ -228,7 +237,7 @@ export function registerProtonUp(map: Map<string, Handler>): void {
     schedule(900, { phase: 'extracting', bytes_done: 100_000_000, bytes_total: 100_000_000 });
     schedule(1100, { phase: 'finalizing', bytes_done: 100_000_000, bytes_total: 100_000_000 });
 
-    window.setTimeout(() => {
+    scheduleInstallEvent(1200, () => {
       if (!activeInstalls.has(opId)) return;
       activeInstalls.delete(opId);
       emitMockEvent('protonup:install:progress', {
@@ -237,7 +246,7 @@ export function registerProtonUp(map: Map<string, Handler>): void {
         bytes_done: 100_000_000,
         bytes_total: 100_000_000,
       });
-    }, 1200);
+    });
 
     return { op_id: opId };
   });
@@ -273,4 +282,12 @@ export function registerProtonUp(map: Map<string, Handler>): void {
 
     return { success: true, conflicting_app_ids: [], error_message: null };
   });
+}
+
+export function resetProtonUpMockState(): void {
+  activeInstalls.clear();
+  for (const timerId of pendingInstallTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingInstallTimers.clear();
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/system.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/system.ts
@@ -20,7 +20,7 @@ import type { Handler } from './types';
 
 // --- Module-scope state ---
 
-let externalSources: ExternalTrainerSourceSubscription[] = [
+const DEFAULT_EXTERNAL_SOURCES: ExternalTrainerSourceSubscription[] = [
   {
     sourceId: 'mock-source-1',
     displayName: 'Mock Trainer Index',
@@ -29,6 +29,8 @@ let externalSources: ExternalTrainerSourceSubscription[] = [
     enabled: true,
   },
 ];
+
+let externalSources: ExternalTrainerSourceSubscription[] = structuredClone(DEFAULT_EXTERNAL_SOURCES);
 
 // --- discovery ---
 
@@ -390,13 +392,5 @@ export function registerSystem(map: Map<string, Handler>): void {
 }
 
 export function resetSystemMockState(): void {
-  externalSources = [
-    {
-      sourceId: 'mock-source-1',
-      displayName: 'Mock Trainer Index',
-      baseUrl: 'https://mock.example.invalid/trainers',
-      sourceType: 'rss',
-      enabled: true,
-    },
-  ];
+  externalSources = structuredClone(DEFAULT_EXTERNAL_SOURCES);
 }

--- a/src/crosshook-native/src/lib/mocks/handlers/system.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/system.ts
@@ -388,3 +388,15 @@ export function registerSystem(map: Map<string, Handler>): void {
     return structuredClone(MOCK_TRAINER_TYPE_CATALOG);
   });
 }
+
+export function resetSystemMockState(): void {
+  externalSources = [
+    {
+      sourceId: 'mock-source-1',
+      displayName: 'Mock Trainer Index',
+      baseUrl: 'https://mock.example.invalid/trainers',
+      sourceType: 'rss',
+      enabled: true,
+    },
+  ];
+}

--- a/src/crosshook-native/src/lib/mocks/handlers/update.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/update.ts
@@ -6,6 +6,7 @@ import type { Handler } from './types';
 let updateInFlight: string | null = null;
 /** Set to true when cancel_update is called during a running update. */
 let updateCancelled = false;
+const pendingUpdateTimers = new Set<number>();
 
 function validateRequest(request: UpdateGameRequest): void {
   if (!request.updater_path || request.updater_path.trim().length === 0) {
@@ -17,6 +18,14 @@ function validateRequest(request: UpdateGameRequest): void {
   if (!request.prefix_path || request.prefix_path.trim().length === 0) {
     throw new Error('[dev-mock] A prefix path is required.');
   }
+}
+
+function scheduleUpdateTimeout(callback: () => void, delayMs: number): void {
+  const id = window.setTimeout(() => {
+    pendingUpdateTimers.delete(id);
+    callback();
+  }, delayMs);
+  pendingUpdateTimers.add(id);
 }
 
 export function registerUpdate(map: Map<string, Handler>): void {
@@ -45,7 +54,7 @@ export function registerUpdate(map: Map<string, Handler>): void {
     // The hook subscribes to update-complete to transition stage.
     // We do not emit update-started or update-progress because useUpdateGame.ts
     // does not subscribe to those events; only update-complete is consumed.
-    setTimeout(() => {
+    scheduleUpdateTimeout(() => {
       const exitCode: number | null = updateCancelled ? null : 0;
 
       emitMockEvent('update-complete', exitCode);
@@ -67,4 +76,13 @@ export function registerUpdate(map: Map<string, Handler>): void {
     }
     // Best-effort; no error if nothing is running
   });
+}
+
+export function resetUpdateMockState(): void {
+  updateInFlight = null;
+  updateCancelled = false;
+  for (const timerId of pendingUpdateTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingUpdateTimers.clear();
 }

--- a/src/crosshook-native/src/lib/mocks/index.ts
+++ b/src/crosshook-native/src/lib/mocks/index.ts
@@ -12,21 +12,26 @@ export { getActiveFixture } from '../fixture';
 export type { DebugToggles } from '../toggles';
 export { getActiveToggles, togglesToChipFragments } from '../toggles';
 
-import { registerCollections } from './handlers/collections';
-import { registerCommunity } from './handlers/community';
-import { registerHealth } from './handlers/health';
-import { registerInstall } from './handlers/install';
+import { resetBrowserEventBus } from '../events';
+
+import { registerCollections, resetCollectionsMockState } from './handlers/collections';
+import { registerCommunity, resetCommunityMockState } from './handlers/community';
+import { registerHealth, resetHealthMockState } from './handlers/health';
+import { registerInstall, resetInstallMockState } from './handlers/install';
+import { resetLaunchMockState } from './handlers/launch';
 import { registerLauncher } from './handlers/launcher';
 import { registerLibrary } from './handlers/library';
-import { registerOnboarding } from './handlers/onboarding';
+import { registerOnboarding, resetOnboardingMockState } from './handlers/onboarding';
+import { resetProfileMockState } from './handlers/profile';
 import { registerProton } from './handlers/proton';
-import { registerProtonDb } from './handlers/protondb';
-import { registerProtonUp } from './handlers/protonup';
-import { registerSystem } from './handlers/system';
+import { registerProtonDb, resetProtonDbMockState } from './handlers/protondb';
+import { registerProtonUp, resetProtonUpMockState } from './handlers/protonup';
+import { registerSystem, resetSystemMockState } from './handlers/system';
 import type { Handler } from './handlers/types';
 import { registerUmuDatabase } from './handlers/umu_database';
-import { registerUpdate } from './handlers/update';
-import { wrapAllHandlers } from './wrapHandler';
+import { registerUpdate, resetUpdateMockState } from './handlers/update';
+import { resetStore } from './store';
+import { resetWrappedHandlerState, wrapAllHandlers } from './wrapHandler';
 
 export type { Handler };
 
@@ -58,4 +63,21 @@ export function registerMocks(): Map<string, Handler> {
   // every entry in the map is wrapped exactly once. See `wrapHandler.ts` for
   // the BR-11 shell-critical read exemption rules.
   return wrapAllHandlers(map);
+}
+
+export function resetMockEnvironment(): void {
+  resetBrowserEventBus();
+  resetStore();
+  resetCollectionsMockState();
+  resetCommunityMockState();
+  resetHealthMockState();
+  resetInstallMockState();
+  resetLaunchMockState();
+  resetOnboardingMockState();
+  resetProfileMockState();
+  resetProtonDbMockState();
+  resetProtonUpMockState();
+  resetSystemMockState();
+  resetUpdateMockState();
+  resetWrappedHandlerState();
 }

--- a/src/crosshook-native/src/lib/mocks/wrapHandler.ts
+++ b/src/crosshook-native/src/lib/mocks/wrapHandler.ts
@@ -20,6 +20,8 @@
 import { getActiveToggles } from '../toggles';
 import type { Handler } from './handlers/types';
 
+const pendingDelayTimers = new Set<number>();
+
 /**
  * Shell-critical reads that MUST resolve under every fixture/toggle combination
  * per BR-11. These commands are exempt from `?errors=true` rejection so the
@@ -112,11 +114,24 @@ export function wrapHandler(name: string, handler: Handler): Handler {
     }
 
     if (toggles.delayMs > 0) {
-      await new Promise<void>((resolve) => setTimeout(resolve, toggles.delayMs));
+      await new Promise<void>((resolve) => {
+        const id = window.setTimeout(() => {
+          pendingDelayTimers.delete(id);
+          resolve();
+        }, toggles.delayMs);
+        pendingDelayTimers.add(id);
+      });
     }
 
     return handler(args);
   };
+}
+
+export function resetWrappedHandlerState(): void {
+  for (const timerId of pendingDelayTimers) {
+    window.clearTimeout(timerId);
+  }
+  pendingDelayTimers.clear();
 }
 
 /**

--- a/src/crosshook-native/src/test/fixtures.ts
+++ b/src/crosshook-native/src/test/fixtures.ts
@@ -1,0 +1,143 @@
+import type { LibraryCardData } from '@/types/library';
+import type { Capability, HostToolCheckResult, HostToolInstallCommand, ReadinessCheckResult } from '@/types/onboarding';
+import { createDefaultProfile, type GameProfile } from '@/types/profile';
+
+export function makeInstallHint(overrides: Partial<HostToolInstallCommand> = {}): HostToolInstallCommand {
+  return {
+    distro_family: 'Arch',
+    command: 'sudo pacman -S gamescope',
+    alternatives: 'Use distro docs if unavailable.',
+    ...overrides,
+  };
+}
+
+export function makeHostToolCheck(overrides: Partial<HostToolCheckResult> = {}): HostToolCheckResult {
+  return {
+    tool_id: 'gamescope',
+    display_name: 'Gamescope',
+    is_available: false,
+    is_required: true,
+    category: 'performance',
+    docs_url: 'https://example.invalid/gamescope',
+    tool_version: null,
+    resolved_path: null,
+    install_guidance: makeInstallHint(),
+    ...overrides,
+  };
+}
+
+export function makeCapability(overrides: Partial<Capability> = {}): Capability {
+  const missingRequired = overrides.missing_required ?? [makeHostToolCheck()];
+  const missingOptional = overrides.missing_optional ?? [];
+  return {
+    id: 'gamescope',
+    label: 'Gamescope',
+    category: 'performance',
+    state: 'degraded',
+    rationale: 'Gamescope is missing.',
+    required_tool_ids: missingRequired.map((tool) => tool.tool_id),
+    optional_tool_ids: missingOptional.map((tool) => tool.tool_id),
+    missing_required: missingRequired,
+    missing_optional: missingOptional,
+    install_hints:
+      overrides.install_hints ??
+      missingRequired.flatMap((tool) => (tool.install_guidance ? [tool.install_guidance] : [])),
+    ...overrides,
+  };
+}
+
+export function makeReadinessResult(overrides: Partial<ReadinessCheckResult> = {}): ReadinessCheckResult {
+  return {
+    checks: [],
+    all_passed: false,
+    critical_failures: 1,
+    warnings: 0,
+    umu_install_guidance: null,
+    steam_deck_caveats: null,
+    tool_checks: [makeHostToolCheck()],
+    detected_distro_family: 'Arch',
+    ...overrides,
+  };
+}
+
+export function makeLibraryCardData(overrides: Partial<LibraryCardData> = {}): LibraryCardData {
+  return {
+    name: 'Synthetic Quest',
+    gameName: 'Synthetic Quest',
+    steamAppId: '9999001',
+    customCoverArtPath: '',
+    customPortraitArtPath: '',
+    networkIsolation: false,
+    isFavorite: false,
+    ...overrides,
+  };
+}
+
+export function makeProfileDraft(overrides: Partial<GameProfile> = {}): GameProfile {
+  const base = createDefaultProfile();
+  const baseLocalOverride = base.local_override ?? {
+    game: {
+      executable_path: '',
+      custom_cover_art_path: '',
+      custom_portrait_art_path: '',
+      custom_background_art_path: '',
+    },
+    trainer: {
+      path: '',
+      extra_protontricks: [],
+    },
+    steam: {
+      compatdata_path: '',
+      proton_path: '',
+    },
+    runtime: {
+      prefix_path: '',
+      proton_path: '',
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    game: {
+      ...base.game,
+      ...(overrides.game ?? {}),
+    },
+    trainer: {
+      ...base.trainer,
+      ...(overrides.trainer ?? {}),
+    },
+    steam: {
+      ...base.steam,
+      ...(overrides.steam ?? {}),
+    },
+    runtime: {
+      ...base.runtime,
+      ...(overrides.runtime ?? {}),
+    },
+    launch: {
+      ...base.launch,
+      ...(overrides.launch ?? {}),
+    },
+    local_override: {
+      ...baseLocalOverride,
+      ...(overrides.local_override ?? {}),
+      game: {
+        ...baseLocalOverride.game,
+        ...(overrides.local_override?.game ?? {}),
+      },
+      trainer: {
+        ...baseLocalOverride.trainer,
+        ...(overrides.local_override?.trainer ?? {}),
+        extra_protontricks: [...(overrides.local_override?.trainer?.extra_protontricks ?? [])],
+      },
+      steam: {
+        ...baseLocalOverride.steam,
+        ...(overrides.local_override?.steam ?? {}),
+      },
+      runtime: {
+        ...baseLocalOverride.runtime,
+        ...(overrides.local_override?.runtime ?? {}),
+      },
+    },
+  };
+}

--- a/src/crosshook-native/src/test/fixtures.ts
+++ b/src/crosshook-native/src/test/fixtures.ts
@@ -95,7 +95,7 @@ export function makeProfileDraft(overrides: Partial<GameProfile> = {}): GameProf
       proton_path: '',
     },
   };
-  return {
+  const profile: GameProfile = {
     ...base,
     ...overrides,
     game: {
@@ -118,26 +118,31 @@ export function makeProfileDraft(overrides: Partial<GameProfile> = {}): GameProf
       ...base.launch,
       ...(overrides.launch ?? {}),
     },
-    local_override: {
+  };
+
+  if (overrides.local_override !== undefined) {
+    profile.local_override = {
       ...baseLocalOverride,
-      ...(overrides.local_override ?? {}),
+      ...overrides.local_override,
       game: {
         ...baseLocalOverride.game,
-        ...(overrides.local_override?.game ?? {}),
+        ...(overrides.local_override.game ?? {}),
       },
       trainer: {
         ...baseLocalOverride.trainer,
-        ...(overrides.local_override?.trainer ?? {}),
-        extra_protontricks: [...(overrides.local_override?.trainer?.extra_protontricks ?? [])],
+        ...(overrides.local_override.trainer ?? {}),
+        extra_protontricks: [...(overrides.local_override.trainer?.extra_protontricks ?? [])],
       },
       steam: {
         ...baseLocalOverride.steam,
-        ...(overrides.local_override?.steam ?? {}),
+        ...(overrides.local_override.steam ?? {}),
       },
       runtime: {
         ...baseLocalOverride.runtime,
-        ...(overrides.local_override?.runtime ?? {}),
+        ...(overrides.local_override.runtime ?? {}),
       },
-    },
-  };
+    };
+  }
+
+  return profile;
 }

--- a/src/crosshook-native/src/test/render.tsx
+++ b/src/crosshook-native/src/test/render.tsx
@@ -1,0 +1,48 @@
+import type { InvokeArgs } from '@tauri-apps/api/core';
+import { type RenderOptions, type RenderResult, render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { type Handler, registerMocks, resetMockEnvironment } from '@/lib/mocks';
+
+export interface MockRenderOptions extends Omit<RenderOptions, 'queries'> {
+  seed?: (handlers: Map<string, Handler>) => void;
+  handlerOverrides?: Record<string, Handler>;
+}
+
+let activeHandlers: Map<string, Handler> | null = null;
+
+function createHandlerMap(options: Pick<MockRenderOptions, 'seed' | 'handlerOverrides'> = {}): Map<string, Handler> {
+  resetMockEnvironment();
+  const handlers = registerMocks();
+  options.seed?.(handlers);
+  for (const [name, handler] of Object.entries(options.handlerOverrides ?? {})) {
+    handlers.set(name, handler);
+  }
+  activeHandlers = handlers;
+  return handlers;
+}
+
+export function configureMockHandlers(
+  options: Pick<MockRenderOptions, 'seed' | 'handlerOverrides'> = {}
+): Map<string, Handler> {
+  return createHandlerMap(options);
+}
+
+export function resetMockHandlers(): void {
+  activeHandlers = null;
+  resetMockEnvironment();
+}
+
+export async function mockCallCommand<T>(name: string, args?: InvokeArgs): Promise<T> {
+  const handlers = activeHandlers ?? createHandlerMap();
+  const handler = handlers.get(name);
+  if (!handler) {
+    throw new Error(`[test-mock] Unhandled command: ${name}`);
+  }
+  return (await handler(args ?? {})) as T;
+}
+
+export function renderWithMocks(ui: ReactElement, options: MockRenderOptions = {}): RenderResult {
+  const { seed, handlerOverrides, ...renderOptions } = options;
+  createHandlerMap({ seed, handlerOverrides });
+  return render(ui, renderOptions);
+}

--- a/src/crosshook-native/src/test/setup.ts
+++ b/src/crosshook-native/src/test/setup.ts
@@ -156,6 +156,7 @@ afterEach(() => {
   cleanup();
   resetMockHandlers();
   MockIntersectionObserver.reset();
+  matchMediaListeners.clear();
   for (const handle of animationFrameHandles.values()) {
     window.clearTimeout(handle);
   }

--- a/src/crosshook-native/src/test/setup.ts
+++ b/src/crosshook-native/src/test/setup.ts
@@ -1,0 +1,172 @@
+import '@testing-library/jest-dom/vitest';
+import { webcrypto } from 'node:crypto';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+import { resetMockHandlers } from './render';
+
+type MatchMediaResult = {
+  matches: boolean;
+  media: string;
+  onchange: ((event: MediaQueryListEvent) => void) | null;
+  addListener: (listener: (event: MediaQueryListEvent) => void) => void;
+  removeListener: (listener: (event: MediaQueryListEvent) => void) => void;
+  addEventListener: (type: string, listener: (event: MediaQueryListEvent) => void) => void;
+  removeEventListener: (type: string, listener: (event: MediaQueryListEvent) => void) => void;
+  dispatchEvent: (event: Event) => boolean;
+};
+
+declare global {
+  interface Window {
+    IntersectionObserver: typeof MockIntersectionObserver;
+  }
+}
+
+const matchMediaListeners = new Map<string, Set<(event: MediaQueryListEvent) => void>>();
+let nextAnimationFrameId = 1;
+const animationFrameHandles = new Map<number, number>();
+
+class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly root = null;
+  readonly rootMargin = '';
+  readonly thresholds = [0];
+  private readonly callback: IntersectionObserverCallback;
+  private observedTargets = new Set<Element>();
+
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  disconnect(): void {
+    this.observedTargets.clear();
+  }
+
+  observe(target: Element): void {
+    this.observedTargets.add(target);
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  unobserve(target: Element): void {
+    this.observedTargets.delete(target);
+  }
+
+  trigger(target: Element, isIntersecting = true): void {
+    if (!this.observedTargets.has(target)) {
+      return;
+    }
+    const rect = target.getBoundingClientRect();
+    this.callback(
+      [
+        {
+          boundingClientRect: rect,
+          intersectionRatio: isIntersecting ? 1 : 0,
+          intersectionRect: isIntersecting ? rect : new DOMRectReadOnly(),
+          isIntersecting,
+          rootBounds: null,
+          target,
+          time: Date.now(),
+        },
+      ],
+      this
+    );
+  }
+
+  static reset(): void {
+    MockIntersectionObserver.instances = [];
+  }
+}
+
+if (!globalThis.crypto) {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: webcrypto,
+    configurable: true,
+  });
+}
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string): MatchMediaResult => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: (listener: (event: MediaQueryListEvent) => void) => {
+        const listeners = matchMediaListeners.get(query) ?? new Set();
+        listeners.add(listener);
+        matchMediaListeners.set(query, listeners);
+      },
+      removeListener: (listener: (event: MediaQueryListEvent) => void) => {
+        matchMediaListeners.get(query)?.delete(listener);
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        const listeners = matchMediaListeners.get(query) ?? new Set();
+        listeners.add(listener);
+        matchMediaListeners.set(query, listeners);
+      },
+      removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        matchMediaListeners.get(query)?.delete(listener);
+      },
+      dispatchEvent: () => true,
+    }),
+  });
+}
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  configurable: true,
+  value: MockIntersectionObserver,
+});
+
+Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+  configurable: true,
+  value: vi.fn(),
+});
+
+if (!navigator.getGamepads) {
+  Object.defineProperty(navigator, 'getGamepads', {
+    configurable: true,
+    value: () => [],
+  });
+}
+
+window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+  const id = nextAnimationFrameId++;
+  const handle = window.setTimeout(() => {
+    animationFrameHandles.delete(id);
+    callback(Date.now());
+  }, 16);
+  animationFrameHandles.set(id, handle);
+  return id;
+};
+
+window.cancelAnimationFrame = (id: number): void => {
+  const handle = animationFrameHandles.get(id);
+  if (handle !== undefined) {
+    window.clearTimeout(handle);
+    animationFrameHandles.delete(id);
+  }
+};
+
+afterEach(() => {
+  cleanup();
+  resetMockHandlers();
+  MockIntersectionObserver.reset();
+  for (const handle of animationFrameHandles.values()) {
+    window.clearTimeout(handle);
+  }
+  animationFrameHandles.clear();
+  document.documentElement.removeAttribute('data-crosshook-controller-mode');
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+export function triggerIntersection(target: Element, isIntersecting = true): void {
+  for (const observer of MockIntersectionObserver.instances) {
+    observer.trigger(target, isIntersecting);
+  }
+}

--- a/src/crosshook-native/tsconfig.test.json
+++ b/src/crosshook-native/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "types": ["node", "vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "noEmit": true
+  },
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "src/**/*.d.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test/**/*.ts",
+    "src/test/**/*.tsx"
+  ]
+}

--- a/src/crosshook-native/vitest.config.ts
+++ b/src/crosshook-native/vitest.config.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    __WEB_DEV_MODE__: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
+    exclude: ['tests/**', 'src-tauri/**', 'dist/**', 'node_modules/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.spec.{ts,tsx}',
+        'src/test/**',
+        'src/lib/mocks/**',
+        'src/types/**',
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Add Phase 1 frontend test infrastructure for `src/crosshook-native/` using Vitest, happy-dom, and React Testing Library, plus an initial seed suite for the target IPC, hook, and component surfaces.

Closes #283

## Changes

- Add `vitest`, `@vitest/coverage-v8`, `happy-dom`, and React Testing Library dev dependencies plus `test`, `test:watch`, `test:coverage`, and expanded `typecheck` scripts.
- Add [`vitest.config.ts`](https://github.com/yandy-r/crosshook/blob/feat/issue-283-vitest-suite/src/crosshook-native/vitest.config.ts) and [`tsconfig.test.json`](https://github.com/yandy-r/crosshook/blob/feat/issue-283-vitest-suite/src/crosshook-native/tsconfig.test.json) to typecheck and run the new frontend test project.
- Add shared test helpers under `src/crosshook-native/src/test/` for setup, fixture builders, and Pattern B mock-backed rendering.
- Add a seed suite covering the IPC adapter, `useCapabilityGate`, `useOnboarding`, `useGamepadNav`, `LibraryGrid`, `LibraryCard`, and `OnboardingWizard`.
- Harden browser-dev mock reset behavior by clearing handler-owned state, pending timers, delayed wrapper timers, and the browser event bus between tests.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [x] Build / CI
- [ ] Compatibility (new game/trainer/platform support)

## Testing

### Environment

- **Platform**: Linux workspace
- **Proton Version** (if applicable): N/A
- **Game / Trainer** (if applicable): N/A

### Checklist

- [ ] `./scripts/lint.sh` passes (or run `./scripts/format.sh` / `./scripts/lint.sh --fix`; same-repo PRs may get a formatting bot commit from `lint-autofix.yml`)
- [ ] `./scripts/build-native.sh --binary-only` builds without errors
- [ ] `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core` passes
- [ ] `./scripts/build-native.sh` produces a valid AppImage (if touching build/packaging)
- [ ] Tested on target platform (Linux desktop or Steam Deck)
- [ ] **If touching crates/crosshook-core/src/launch/**: Verified game and trainer launch works
- [ ] **If touching crates/crosshook-core/src/steam/**: Verified Steam auto-populate and Proton discovery
- [ ] **If touching crates/crosshook-core/src/profile/**: Verified profile save/load/import
- [ ] **If touching src/components/ or src/hooks/**: Verified UI renders correctly
- [ ] **If touching runtime-helpers/**: Verified shell scripts work under Proton

Additional verification completed:

- [x] `cd src/crosshook-native && npm test`
- [x] `cd src/crosshook-native && npm run typecheck`

## Reviewer Notes

This PR intentionally stops at the Phase 1 infrastructure and seed-suite boundary from `#283`. It does not include the contributor-facing testing docs tracked in `#285`, and it does not wire the new suite into CI yet.

The non-test code changes are limited to frontend mock/test plumbing and one small timer typing cleanup in `ProtonDbLookupCard.tsx` so the expanded typecheck passes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed clipboard copy timeout handling to reliably schedule and clear browser timeouts.

* **Tests**
  * Added broad Vitest-based unit and component tests, test setup/utilities, reusable fixtures, mock handler infrastructure, and coverage reporting.

* **Chores**
  * Added Node engine constraint and test scripts; introduced test-related dev dependencies and a dedicated test TypeScript/Vitest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->