### PR TITLE
ci: normalize Conventional Commit prefix in PR title autofix

### DIFF
--- a/.github/workflows/pr-title-autofix.yml
+++ b/.github/workflows/pr-title-autofix.yml
@@ -1,11 +1,21 @@
 name: PR title autofix
 
-# Strips placeholder prefixes (e.g. "[WIP]", "Draft:", "Initial plan") that some
-# coding agents apply to PR titles even though .github/copilot-instructions.md
-# forbids them. The agent's runtime token often lacks pull_requests:write, so the
-# agent itself cannot fix it after the fact — this workflow does it server-side
-# with the repo's GITHUB_TOKEN, then converts the PR to draft to preserve the
-# WIP intent. The existing pr-title.yml validator re-runs on the edited title.
+# Normalizes PR titles from coding agents so they pass pr-title.yml. Two passes:
+#
+#   1. Strip placeholder prefixes ("[WIP]", "Draft:", "Initial plan", …) that
+#      .github/copilot-instructions.md forbids. When a placeholder is stripped,
+#      convert the PR to draft to preserve the WIP intent.
+#   2. If the (possibly stripped) title starts with a known Conventional Commit
+#      type word followed by whitespace instead of a colon (e.g. "Refactor X"),
+#      rewrite it as "<type>: X" with the type lowercased. Also lowercase an
+#      already-colon'd capitalized type ("Refactor: X" -> "refactor: X"). This
+#      pass never forces draft — it only fixes capitalization/punctuation.
+#
+# The agent's runtime token often lacks pull_requests:write, so the agent itself
+# cannot fix the title after the fact — this workflow does it server-side with
+# the repo's GITHUB_TOKEN. The existing pr-title.yml validator re-runs on the
+# edited title. Both passes are idempotent so re-runs on already-clean titles
+# are a no-op and the title-edit webhook can't ping-pong.
 
 on:
   pull_request_target:
@@ -34,17 +44,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Case-insensitive match of known placeholder leaders, plus any
-          # trailing colon/whitespace. Idempotent: re-runs on already-clean
-          # titles are a no-op, so the title-edit webhook can't ping-pong.
+          # Pass 1: strip known placeholder leaders, plus any trailing
+          # colon/whitespace. Case-insensitive.
           cleaned="$(
             printf '%s' "$PR_TITLE" | sed -E \
               's/^[[:space:]]*(\[WIP\]|\[Draft\]|WIP|Draft|Initial plan( for #?[0-9]+)?)[[:space:]:]*//I'
           )"
-
-          if [[ "$cleaned" == "$PR_TITLE" ]]; then
-            echo "No placeholder prefix detected; nothing to do."
-            exit 0
+          stripped_placeholder=false
+          if [[ "$cleaned" != "$PR_TITLE" ]]; then
+            stripped_placeholder=true
           fi
 
           if [[ -z "${cleaned// }" ]]; then
@@ -57,12 +65,37 @@ jobs:
             exit 0
           fi
 
+          # Pass 2a: "Type X" (type word + whitespace, no colon) -> "type: X".
+          # Matches known Conventional Commit types from pr-title.yml. Does not
+          # match "Type:" / "Type(scope):" because the character after the type
+          # word must be whitespace.
+          cleaned="$(
+            printf '%s' "$cleaned" | sed -E \
+              's/^[[:space:]]*(feat|fix|docs|refactor|perf|test|build|ci|chore|style)[[:space:]]+([^[:space:]].*)$/\L\1\E: \2/I'
+          )"
+
+          # Pass 2b: lowercase a leading capitalized type prefix with colon,
+          # e.g. "Refactor: X" -> "refactor: X", "Feat(auth): X" -> "feat(auth): X".
+          cleaned="$(
+            printf '%s' "$cleaned" | sed -E \
+              's/^[[:space:]]*(feat|fix|docs|refactor|perf|test|build|ci|chore|style)(\([^)]+\))?(!?):/\L\1\E\2\3:/I'
+          )"
+
+          if [[ "$cleaned" == "$PR_TITLE" ]]; then
+            echo "Title already clean; nothing to do."
+            exit 0
+          fi
+
           echo "Rewriting title: '$PR_TITLE' -> '$cleaned'"
           gh pr edit "$PR_NUMBER" --title "$cleaned"
 
-          if [[ "$PR_DRAFT" != "true" ]]; then
-            gh pr ready "$PR_NUMBER" --undo
+          if [[ "$stripped_placeholder" == "true" ]]; then
+            if [[ "$PR_DRAFT" != "true" ]]; then
+              gh pr ready "$PR_NUMBER" --undo
+            fi
+            gh pr comment "$PR_NUMBER" --body \
+              "Auto-stripped placeholder prefix and converted to draft. Original: \`$PR_TITLE\` → \`$cleaned\`. Mark ready for review when the title and content are final."
+          else
+            gh pr comment "$PR_NUMBER" --body \
+              "Auto-normalized PR title to Conventional Commit format. Original: \`$PR_TITLE\` → \`$cleaned\`."
           fi
-
-          gh pr comment "$PR_NUMBER" --body \
-            "Auto-stripped placeholder prefix and converted to draft. Original: \`$PR_TITLE\` → \`$cleaned\`. Mark ready for review when the title and content are final."


### PR DESCRIPTION
## Summary

Coding agents (codex, claude) sometimes open PRs with titles like `Refactor client.rs into smaller modules` — placeholder-free but also not Conventional Commits, so `pr-title.yml` (amannn/action-semantic-pull-request) still rejects them and the agent's runtime token can't edit its own PR. Today's `pr-title-autofix.yml` only strips `[WIP]` / `Draft:` / `Initial plan`, so those PRs sit with a failing title check until a human retitles them (#390, #391, #392, #393 all hit this).

Extend the autofix with two idempotent passes on the (already placeholder-stripped) title:

- **Pass 2a** — `^<type>[[:space:]]+<rest>` → `<type>: <rest>` with the type lowercased. Matches the same types list as `pr-title.yml`. Does not match `type:` / `type(scope):` (next char is `:`, not whitespace), so already-correct titles pass through unchanged.
- **Pass 2b** — `^<Type>(\(scope\))?(!)?:` → lowercase the leading type word (`Refactor: X` → `refactor: X`, `Feat(auth)!: X` → `feat(auth)!: X`).

The "convert to draft + WIP comment" side effect is now gated on the placeholder-strip pass only; a bare capitalization fix posts a normalization comment without forcing draft.

Closes nothing — this is a follow-up to 46a2e2e (`ci: auto-strip placeholder prefixes from PR titles`).

## Changes

- `.github/workflows/pr-title-autofix.yml`: two new sed passes, `stripped_placeholder` flag gates the draft-conversion side effect, header comment rewritten to reflect the two-pass contract. Idempotency preserved so the title-edit webhook can't ping-pong.

## Type of Change

- [x] Build / CI

## Testing

### Environment

- **Platform**: N/A (GitHub Actions, ubuntu-latest)

### Checklist

- [x] Smoke-tested the two sed passes locally against representative titles:
  - `Refactor client.rs into smaller modules for review` → `refactor: client.rs into smaller modules for review`
  - `[WIP] Refactor diagnostics.rs` → `refactor: diagnostics.rs`
  - `Refactor: health module split` → `refactor: health module split`
  - `refactor(core): clean` → unchanged (idempotent)
  - `Feat(auth): add login` → `feat(auth): add login`
  - `FEAT!: breaking change` → `feat!: breaking change`
  - `Initial plan for #42` → empty → falls through to the placeholder-only branch (draft + comment)
  - `fix broken test` → `fix: broken test`
  - `docs update readme` → `docs: update readme`
- [x] Existing open PRs (#390–#393) retitled manually so their `pr-title.yml` check re-runs now rather than waiting on the next agent PR to validate the code path.

## Reviewer Notes

- The sed uses `\L…\E` case-conversion, which is a GNU sed extension. `ubuntu-latest` ships GNU sed, so this is safe for the workflow runner but would break on BSD sed — no concern here since the script only runs on `ubuntu-latest`.
- Pass 2b captures `(\([^)]+\))?` for the optional scope, which disallows nested parens. All realistic Conventional Commit scopes are a single bare word, so this is fine.
- The placeholder-only branch (`cleaned` entirely whitespace) is unchanged — still forces draft + posts the "please rewrite" comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request title auto-fixing with multi-pass normalization. Improved handling of Conventional Commit formatting and placeholder detection to better standardize PR title formats automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->