### PR TITLE
feat(styles): adopt steel-blue palette and add legacy-palette sentinel

### DIFF
--- a/docs/internal-docs/design-tokens.md
+++ b/docs/internal-docs/design-tokens.md
@@ -1,0 +1,110 @@
+# CrossHook Design Tokens
+
+Source of truth: [`src/crosshook-native/src/styles/variables.css`](../../src/crosshook-native/src/styles/variables.css).
+Enforced by: [`scripts/check-legacy-palette.sh`](../../scripts/check-legacy-palette.sh), run via [`scripts/lint.sh`](../../scripts/lint.sh) in CI.
+
+This doc defines the palette-token contract established in Phase 2 of the Unified Desktop Redesign ([PRD](../prps/prds/unified-desktop-redesign.prd.md)) and the guardrails that keep it from drifting back to the legacy Microsoft-blue palette.
+
+## Rule: no literal accent / background colors
+
+Stylesheets under `src/crosshook-native/src/**` and component CSS-in-TSX **must reference a `--crosshook-color-*` token**, never a raw hex or rgba literal for any color that belongs to the palette (accent, background, surface, sidebar, titlebar, scrim, accent glow, desaturated status).
+
+Literals that are always forbidden in this tree:
+
+| Pattern                       | Replacement token                                              |
+| ----------------------------- | -------------------------------------------------------------- |
+| `#0078d4`                     | `var(--crosshook-color-accent)`                                |
+| `#2da3ff`                     | `var(--crosshook-color-accent-strong)`                         |
+| `#1a1a2e`                     | `var(--crosshook-color-bg)`                                    |
+| `#20243d`                     | `var(--crosshook-color-bg-elevated)`                           |
+| `#12172a`                     | `var(--crosshook-color-surface)`                               |
+| `rgba(0, 120, 212, <alpha>)`  | `rgba(74, 125, 181, <alpha>)` or a `--crosshook-color-*` token |
+| `rgba(45, 163, 255, <alpha>)` | `rgba(107, 163, 217, <alpha>)`                                 |
+
+Ad-hoc one-off colors that don't belong to the palette (e.g. a gradient fade with `rgba(0, 0, 0, …)`, status-specific rgba tints like `rgba(74, 222, 128, 0.12)` for capability chips) are not covered by the sentinel and can remain literal if no token applies. Prefer extracting a token when the same value appears in more than two places.
+
+## Token catalogue (default theme)
+
+All tokens live in the default `:root { … }` block of `variables.css`. The `:root[data-crosshook-theme='high-contrast']` block is a **separate palette** (amber accent, high-contrast body) and is deliberately out of the Phase 2 sweep — it owns its own accent literals because accessibility targets differ from the calm-desktop palette.
+
+### Shell surfaces
+
+| Token                              | Value                   | Purpose                                       |
+| ---------------------------------- | ----------------------- | --------------------------------------------- |
+| `--crosshook-color-bg`             | `#181a24`               | App body background                           |
+| `--crosshook-color-bg-elevated`    | `#1f2233`               | Elevated panel background                     |
+| `--crosshook-color-surface`        | `#141620`               | Surface under panels (modal scrim base, etc.) |
+| `--crosshook-color-surface-strong` | `#0c1120`               | Deeper sunken surface                         |
+| `--crosshook-color-sidebar`        | `#10121c`               | Primary sidebar background                    |
+| `--crosshook-color-titlebar`       | `#0c0e16`               | Titlebar / app frame                          |
+| `--crosshook-color-surface-1`      | `#1a1d28`               | Row surfaces                                  |
+| `--crosshook-color-surface-2`      | `#22263a`               | Raised cards / panels                         |
+| `--crosshook-color-surface-3`      | `#2a2f48`               | Hover / pressed card state                    |
+| `--crosshook-color-scrim`          | `rgba(8, 10, 18, 0.78)` | Modal / overlay scrim                         |
+
+### Accent
+
+| Token                             | Value                       | Purpose                                     |
+| --------------------------------- | --------------------------- | ------------------------------------------- |
+| `--crosshook-color-accent`        | `#4a7db5`                   | Primary steel-blue accent                   |
+| `--crosshook-color-accent-strong` | `#6ba3d9`                   | Brighter accent (hover, focus rings)        |
+| `--crosshook-color-accent-soft`   | `rgba(74, 125, 181, 0.16)`  | Soft accent fills (selected row, chip bg)   |
+| `--crosshook-color-accent-glow`   | `rgba(107, 163, 217, 0.22)` | Ambient accent glow (hero gradients, focus) |
+
+### Status (existing + desaturated siblings)
+
+The existing `--crosshook-color-success | warning | danger` tokens remain in place for components that have not yet migrated. The `*-muted` siblings introduced in Phase 2 are the **calm-desktop** values; components opt in during their rework phases.
+
+| Token                             | Value     | Purpose                    |
+| --------------------------------- | --------- | -------------------------- |
+| `--crosshook-color-success-muted` | `#5fb880` | Calm success (Phase 2+ UI) |
+| `--crosshook-color-warning-muted` | `#d4a94a` | Calm warning (Phase 2+ UI) |
+| `--crosshook-color-danger-muted`  | `#d77a8a` | Calm danger (Phase 2+ UI)  |
+
+## Adding a new token
+
+1. Define it inside the default `:root { … }` block in `variables.css`, grouped with logically-related tokens.
+2. Reference it exclusively via `var(--crosshook-color-…)` — never re-duplicate the literal in consuming stylesheets.
+3. If the token replaces a pattern the sentinel does not yet catch, either:
+   - Update the pattern list in `scripts/check-legacy-palette.sh` **and** the **Rule** table above, or
+   - Accept that the old literal is permitted for this specific case and add `/* allow: legacy-palette */` on the offending line with a comment-anchored reason.
+
+New tokens should ship alongside the first consumer. Orphan tokens without a consumer accumulate as dead code.
+
+## Suppression grammar
+
+When a legacy literal genuinely has to live in the tree (pasted upstream fixture, test asset, or an intentional reference in a code comment that cannot be rewritten), the sentinel accepts two forms:
+
+| File type                    | Suppression                                                   |
+| ---------------------------- | ------------------------------------------------------------- |
+| `.css`, `.module.css`        | `/* allow: legacy-palette */` on the same line as the literal |
+| `.ts`, `.tsx`, `.js`, `.jsx` | `// allow: legacy-palette` on the same line as the literal    |
+
+Always pair the suppression with a one-sentence reason in the comment body:
+
+```css
+background: rgba(0, 120, 212, 0.18); /* allow: legacy-palette — test fixture, asserted against upstream bundle */
+```
+
+If you find yourself adding a suppression, consider refactoring the literal into a token instead. Suppressions should be **rare** and each one should justify its own existence.
+
+## High-contrast theme carve-out
+
+`:root[data-crosshook-theme='high-contrast']` owns its own accent (`#facc15 / #f97316`) and deliberately retains distinct literals for accessibility reasons. The sentinel patterns above do not overlap with the high-contrast palette, so no explicit carve-out is required in the script — but be aware when editing that the high-contrast block is **not** subject to the Phase 2 token swap.
+
+## How CI enforces this
+
+`scripts/check-legacy-palette.sh`:
+
+- `--help` / `-h` — prints usage and exits 0.
+- `--list` — prints the legacy literal patterns, one per line, and exits 0.
+- `--selftest` — writes a synthetic CSS file containing a literal and asserts the scanner detects it; exit 0 on success, 1 on failure.
+- No flag — scans `src/crosshook-native/src/**` and exits 0 if clean, 1 with per-match diagnostics if any legacy literal is found.
+
+`scripts/lint.sh`:
+
+- `--legacy-palette` — runs the sentinel only.
+- `--all` (and bare `./scripts/lint.sh`) — includes the sentinel alongside Rust, TypeScript, shell, and host-gateway checks.
+- Scope flags (`--staged`, `--unstaged`, `--modified`) do not narrow the palette check; it always scans the full tree, because a literal introduced in an unmodified file would otherwise escape detection on a focused run.
+
+`.github/workflows/lint.yml` runs `./scripts/lint.sh` on every PR, so regressions fail CI.

--- a/scripts/check-legacy-palette.sh
+++ b/scripts/check-legacy-palette.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# check-legacy-palette.sh — flag legacy Microsoft-blue accent / bg color literals
+# anywhere under src/crosshook-native/src/.
+#
+# Phase 2 of the Unified Desktop Redesign (docs/prps/prds/unified-desktop-redesign.prd.md)
+# swaps the old `#0078d4 / #2da3ff / #1a1a2e / #20243d / #12172a` palette for the
+# steel-blue tokens defined in src/crosshook-native/src/styles/variables.css.
+#
+# Once the sweep lands, stylesheets and TSX inline styles must reference the
+# `--crosshook-color-*` tokens — never the raw literals. This sentinel keeps it
+# that way in CI (wired through scripts/lint.sh).
+#
+# Usage:  ./scripts/check-legacy-palette.sh [--help|-h] [--list] [--selftest]
+# Suppression: add `/* allow: legacy-palette */` (CSS) or `// allow: legacy-palette`
+# (TSX/JS) on the offending line with a brief reason. Suppressions should be rare.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Legacy literals that must not appear anywhere inside the scan roots.
+# Keep the list in sync with docs/internal/design-tokens.md and the PRD.
+LEGACY_PATTERNS=(
+  '#0078d4'
+  '#2da3ff'
+  '#1a1a2e'
+  '#20243d'
+  '#12172a'
+  'rgba\(\s*0\s*,\s*120\s*,\s*212'
+  'rgba\(\s*45\s*,\s*163\s*,\s*255'
+)
+
+SCAN_DIRS=(
+  "$REPO_ROOT/src/crosshook-native/src"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/check-legacy-palette.sh [OPTIONS]
+
+Flags legacy Microsoft-blue / old-background color literals under
+src/crosshook-native/src/. Enforces the Phase 2 steel-blue token migration
+(see docs/internal/design-tokens.md).
+
+Options:
+  -h, --help    Print this help and exit 0.
+  --list        Print the legacy literal patterns (one per line) and exit 0.
+  --selftest    Detect a synthetic literal; exit 0 on success, 1 on failure.
+
+Suppression: add `/* allow: legacy-palette */` (CSS) or
+`// allow: legacy-palette` (TSX/JS) on the offending line with a brief reason.
+
+Exit codes: 0 = clean, 1 = violations found (or selftest failed).
+EOF
+}
+
+build_pattern() {
+  local IFS='|'
+  echo "${LEGACY_PATTERNS[*]}"
+}
+
+if_rg() {
+  if command -v rg >/dev/null 2>&1; then return 0; else return 1; fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+SELFTEST=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)  usage; exit 0 ;;
+    --list)     printf '%s\n' "${LEGACY_PATTERNS[@]}"; exit 0 ;;
+    --selftest) SELFTEST=1; shift ;;
+    *)          echo "Unknown argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Selftest — prove the detector fires on a synthetic literal.
+# ---------------------------------------------------------------------------
+if (( SELFTEST )); then
+  TMPFILE="$(mktemp /tmp/check-legacy-palette-selftest-XXXXXX.css)"
+  trap 'rm -f "$TMPFILE"' EXIT
+  printf '.fake { color: #0078d4; background: rgba(0, 120, 212, 0.18); }\n' >"$TMPFILE"
+  PATTERN="$(build_pattern)"
+  if if_rg; then
+    rg -qe "$PATTERN" "$TMPFILE" 2>/dev/null && { echo "selftest passed: synthetic legacy literal was detected."; exit 0; }
+  else
+    grep -qE "$PATTERN" "$TMPFILE" 2>/dev/null && { echo "selftest passed: synthetic legacy literal was detected."; exit 0; }
+  fi
+  echo "selftest FAILED: scanner did not detect the synthetic legacy literal." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Main scan
+# ---------------------------------------------------------------------------
+EXISTING_DIRS=()
+for dir in "${SCAN_DIRS[@]}"; do
+  [[ -d "$dir" ]] && EXISTING_DIRS+=("$dir")
+done
+if [[ ${#EXISTING_DIRS[@]} -eq 0 ]]; then
+  echo "error: no frontend source directories found under $REPO_ROOT/src/crosshook-native/src." >&2
+  exit 1
+fi
+
+PATTERN="$(build_pattern)"
+EXIT_CODE=0
+VIOLATION_COUNT=0
+
+scan_output() {
+  if if_rg; then
+    rg -n --no-heading --pcre2 \
+      --glob '*.css' --glob '*.ts' --glob '*.tsx' --glob '*.js' --glob '*.jsx' \
+      --glob '*.mjs' --glob '*.cjs' --glob '*.module.css' \
+      -e "$PATTERN" \
+      "${EXISTING_DIRS[@]}" 2>/dev/null || true
+  else
+    find "${EXISTING_DIRS[@]}" \
+      \( -name '*.css' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \
+         -o -name '*.mjs' -o -name '*.cjs' \) \
+      -exec grep -En "$PATTERN" {} /dev/null \; 2>/dev/null || true
+  fi
+}
+
+while IFS= read -r match; do
+  [[ -z "$match" ]] && continue
+  # Skip suppressed lines (CSS or TSX/JS forms).
+  [[ "$match" == *"allow: legacy-palette"* ]] && continue
+  file="${match%%:*}"
+  rest="${match#*:}"
+  line="${rest%%:*}"
+  body="${rest#*:}"
+  echo "${file}:${line}: legacy palette literal found: ${body# } — reference a --crosshook-color-* token instead (see docs/internal/design-tokens.md)."
+  (( VIOLATION_COUNT++ )) || true
+  EXIT_CODE=1
+done < <(scan_output)
+
+if (( EXIT_CODE == 0 )); then
+  echo "legacy-palette check passed: no legacy accent/bg literals found."
+else
+  echo "legacy-palette check FAILED: ${VIOLATION_COUNT} violation(s) found. See output above."
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/check-legacy-palette.sh
+++ b/scripts/check-legacy-palette.sh
@@ -86,9 +86,9 @@ if (( SELFTEST )); then
   printf '.fake { color: #0078d4; background: rgba(0, 120, 212, 0.18); }\n' >"$TMPFILE"
   PATTERN="$(build_pattern)"
   if if_rg; then
-    rg -qe "$PATTERN" "$TMPFILE" 2>/dev/null && { echo "selftest passed: synthetic legacy literal was detected."; exit 0; }
+    rg -qie "$PATTERN" "$TMPFILE" 2>/dev/null && { echo "selftest passed: synthetic legacy literal was detected."; exit 0; }
   else
-    grep -qE "$PATTERN" "$TMPFILE" 2>/dev/null && { echo "selftest passed: synthetic legacy literal was detected."; exit 0; }
+    grep -qiE "$PATTERN" "$TMPFILE" 2>/dev/null && { echo "selftest passed: synthetic legacy literal was detected."; exit 0; }
   fi
   echo "selftest FAILED: scanner did not detect the synthetic legacy literal." >&2
   exit 1
@@ -112,7 +112,7 @@ VIOLATION_COUNT=0
 
 scan_output() {
   if if_rg; then
-    rg -n --no-heading --pcre2 \
+    rg -n -i --no-heading \
       --glob '*.css' --glob '*.ts' --glob '*.tsx' --glob '*.js' --glob '*.jsx' \
       --glob '*.mjs' --glob '*.cjs' --glob '*.module.css' \
       -e "$PATTERN" \
@@ -121,7 +121,7 @@ scan_output() {
     find "${EXISTING_DIRS[@]}" \
       \( -name '*.css' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \
          -o -name '*.mjs' -o -name '*.cjs' \) \
-      -exec grep -En "$PATTERN" {} /dev/null \; 2>/dev/null || true
+      -exec grep -Ein "$PATTERN" {} /dev/null \; 2>/dev/null || true
   fi
 }
 

--- a/scripts/check-legacy-palette.sh
+++ b/scripts/check-legacy-palette.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Legacy literals that must not appear anywhere inside the scan roots.
-# Keep the list in sync with docs/internal/design-tokens.md and the PRD.
+# Keep the list in sync with docs/internal-docs/design-tokens.md and the PRD.
 LEGACY_PATTERNS=(
   '#0078d4'
   '#2da3ff'
@@ -41,7 +41,7 @@ Usage: ./scripts/check-legacy-palette.sh [OPTIONS]
 
 Flags legacy Microsoft-blue / old-background color literals under
 src/crosshook-native/src/. Enforces the Phase 2 steel-blue token migration
-(see docs/internal/design-tokens.md).
+(see docs/internal-docs/design-tokens.md).
 
 Options:
   -h, --help    Print this help and exit 0.
@@ -133,7 +133,7 @@ while IFS= read -r match; do
   rest="${match#*:}"
   line="${rest%%:*}"
   body="${rest#*:}"
-  echo "${file}:${line}: legacy palette literal found: ${body# } — reference a --crosshook-color-* token instead (see docs/internal/design-tokens.md)."
+  echo "${file}:${line}: legacy palette literal found: ${body# } — reference a --crosshook-color-* token instead (see docs/internal-docs/design-tokens.md)."
   (( VIOLATION_COUNT++ )) || true
   EXIT_CODE=1
 done < <(scan_output)

--- a/scripts/check-legacy-palette.sh
+++ b/scripts/check-legacy-palette.sh
@@ -27,8 +27,8 @@ LEGACY_PATTERNS=(
   '#1a1a2e'
   '#20243d'
   '#12172a'
-  'rgba\(\s*0\s*,\s*120\s*,\s*212'
-  'rgba\(\s*45\s*,\s*163\s*,\s*255'
+  'rgba\([[:space:]]*0[[:space:]]*,[[:space:]]*120[[:space:]]*,[[:space:]]*212'
+  'rgba\([[:space:]]*45[[:space:]]*,[[:space:]]*163[[:space:]]*,[[:space:]]*255'
 )
 
 SCAN_DIRS=(

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -83,8 +83,12 @@ fi
 if (( RUN_TS )); then
   if (( SCOPED )); then
     ts_files=()
+    # biome.json scopes formatting to src/**/*.{ts,tsx}; listing other
+    # extensions here makes the invocation error out when only those are
+    # staged (biome: "no files were processed"). Keep this list aligned
+    # with biome's `files.includes` glob in src/crosshook-native/biome.json.
     mapfile -t ts_files < <(list_scoped_repo_paths "$SCOPE" "src/crosshook-native/src/" \
-      ".ts" ".tsx" ".js" ".jsx" ".mjs" ".cjs" ".mts" ".cts" ".json" ".jsonc" ".css")
+      ".ts" ".tsx")
 
     if (( ${#ts_files[@]} == 0 )); then
       echo "=== TypeScript/React ==="

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -9,23 +9,25 @@ source "$ROOT_DIR/scripts/lib/modified-files.sh"
 usage() {
   cat <<'EOF'
 Usage: ./scripts/lint.sh [--fix] [--staged] [--unstaged] [--modified]
-                         [--rust] [--ts] [--shell] [--host-gateway] [--all]
+                         [--rust] [--ts] [--shell] [--host-gateway]
+                         [--legacy-palette] [--all]
 
 Run linters across the full stack.
 
-  --fix           Apply auto-fixes where possible
-  --staged        Limit file-based linting to staged files (git diff --cached)
-  --unstaged      Limit file-based linting to unstaged + untracked files
-  --modified      Shorthand for --staged --unstaged (staged ∪ unstaged ∪ untracked)
-                  Scope flags are additive; combining --staged --unstaged equals --modified.
-                  None of these narrow --host-gateway: that check always scans the full tree,
-                  because a bypass introduced in an unmodified file would otherwise escape
-                  detection on a focused run.
-  --rust          Rust only (clippy + rustfmt check)
-  --ts            TypeScript only (biome + tsc)
-  --shell         Shell scripts only (shellcheck)
-  --host-gateway  Host-command gateway check only (ADR-0001; always full-tree scan)
-  --all           All checks (default)
+  --fix              Apply auto-fixes where possible
+  --staged           Limit file-based linting to staged files (git diff --cached)
+  --unstaged         Limit file-based linting to unstaged + untracked files
+  --modified         Shorthand for --staged --unstaged (staged ∪ unstaged ∪ untracked)
+                     Scope flags are additive; combining --staged --unstaged equals --modified.
+                     None of these narrow --host-gateway or --legacy-palette: those checks
+                     always scan the full tree, because a violation introduced in an unmodified
+                     file would otherwise escape detection on a focused run.
+  --rust             Rust only (clippy + rustfmt check)
+  --ts               TypeScript only (biome + tsc)
+  --shell            Shell scripts only (shellcheck)
+  --host-gateway     Host-command gateway check only (ADR-0001; always full-tree scan)
+  --legacy-palette   Legacy palette check only (Phase 2 token migration; always full-tree scan)
+  --all              All checks (default)
 EOF
 }
 
@@ -36,6 +38,7 @@ RUN_RUST=0
 RUN_TS=0
 RUN_SHELL=0
 RUN_HOST_GATEWAY=0
+RUN_LEGACY_PALETTE=0
 EXIT_CODE=0
 
 while [[ $# -gt 0 ]]; do
@@ -48,7 +51,8 @@ while [[ $# -gt 0 ]]; do
     --ts) RUN_TS=1; shift ;;
     --shell) RUN_SHELL=1; shift ;;
     --host-gateway) RUN_HOST_GATEWAY=1; shift ;;
-    --all) RUN_RUST=1; RUN_TS=1; RUN_SHELL=1; RUN_HOST_GATEWAY=1; shift ;;
+    --legacy-palette) RUN_LEGACY_PALETTE=1; shift ;;
+    --all) RUN_RUST=1; RUN_TS=1; RUN_SHELL=1; RUN_HOST_GATEWAY=1; RUN_LEGACY_PALETTE=1; shift ;;
     --help|-h) usage; exit 0 ;;
     *) echo "Unknown arg: $1" >&2; usage >&2; exit 1 ;;
   esac
@@ -66,11 +70,12 @@ fi
 SCOPED=$(( SCOPE_STAGED || SCOPE_UNSTAGED ))
 
 # Default to all if nothing specified
-if (( !RUN_RUST && !RUN_TS && !RUN_SHELL && !RUN_HOST_GATEWAY )); then
+if (( !RUN_RUST && !RUN_TS && !RUN_SHELL && !RUN_HOST_GATEWAY && !RUN_LEGACY_PALETTE )); then
   RUN_RUST=1
   RUN_TS=1
   RUN_SHELL=1
   RUN_HOST_GATEWAY=1
+  RUN_LEGACY_PALETTE=1
 fi
 
 if (( RUN_RUST )); then
@@ -183,6 +188,14 @@ if (( RUN_HOST_GATEWAY )); then
     echo "note: scope flags do not narrow host-gateway; running full-tree scan."
   fi
   "$ROOT_DIR/scripts/check-host-gateway.sh" || EXIT_CODE=1
+fi
+
+if (( RUN_LEGACY_PALETTE )); then
+  echo "=== Legacy-palette ==="
+  if (( SCOPED )); then
+    echo "note: scope flags do not narrow legacy-palette; running full-tree scan."
+  fi
+  "$ROOT_DIR/scripts/check-legacy-palette.sh" || EXIT_CODE=1
 fi
 
 exit "$EXIT_CODE"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -122,8 +122,12 @@ if (( RUN_TS )); then
   if (( SCOPED )); then
     ts_biome_files=()
     ts_typecheck_files=()
+    # biome.json scopes linting to src/**/*.{ts,tsx}; listing other
+    # extensions here makes the invocation error out when only those are
+    # staged (biome: "no files were processed"). Keep this list aligned
+    # with biome's `files.includes` glob in src/crosshook-native/biome.json.
     mapfile -t ts_biome_files < <(list_scoped_repo_paths "$SCOPE" "src/crosshook-native/src/" \
-      ".ts" ".tsx" ".js" ".jsx" ".mjs" ".cjs" ".mts" ".cts" ".json" ".jsonc" ".css")
+      ".ts" ".tsx")
     mapfile -t ts_typecheck_files < <(list_scoped_repo_paths "$SCOPE" "src/crosshook-native/src/" \
       ".ts" ".tsx" ".mts" ".cts")
 

--- a/src/crosshook-native/src/components/ProfileReviewModal.tsx
+++ b/src/crosshook-native/src/components/ProfileReviewModal.tsx
@@ -105,7 +105,7 @@ const confirmationCardStyle: CSSProperties = {
   borderRadius: 20,
   border: '1px solid rgba(96, 165, 250, 0.24)',
   background:
-    'radial-gradient(circle at top right, rgba(0, 120, 212, 0.12), transparent 26%), linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(8, 12, 24, 0.98))',
+    'radial-gradient(circle at top right, rgba(74, 125, 181, 0.12), transparent 26%), linear-gradient(180deg, rgba(15, 23, 42, 0.98), rgba(8, 12, 24, 0.98))',
   boxShadow: '0 24px 60px rgba(0, 0, 0, 0.46)',
 };
 

--- a/src/crosshook-native/src/styles/layout.css
+++ b/src/crosshook-native/src/styles/layout.css
@@ -78,7 +78,7 @@
 .crosshook-panel-route-decor__glow {
   position: absolute;
   inset: 0;
-  background: radial-gradient(ellipse 52% 38% at 92% 8%, rgba(0, 120, 212, 0.09), transparent 70%);
+  background: radial-gradient(ellipse 52% 38% at 92% 8%, rgba(74, 125, 181, 0.09), transparent 70%);
 }
 
 .crosshook-panel-route-decor__art {
@@ -238,7 +238,7 @@
 .crosshook-resize-handle:hover,
 .crosshook-resize-handle[data-resize-handle-active='pointer'],
 .crosshook-resize-handle[data-resize-handle-state='drag'] {
-  background: rgba(45, 163, 255, 0.12);
+  background: rgba(107, 163, 217, 0.12);
 }
 
 .crosshook-resize-handle--vertical {

--- a/src/crosshook-native/src/styles/library.css
+++ b/src/crosshook-native/src/styles/library.css
@@ -135,7 +135,7 @@
 .crosshook-library-card--selected {
   outline: 3px solid var(--crosshook-color-accent-strong);
   outline-offset: 2px;
-  box-shadow: 0 0 12px rgba(45, 163, 255, 0.45);
+  box-shadow: 0 0 12px rgba(107, 163, 217, 0.45);
 }
 
 .crosshook-library-card__image {
@@ -356,7 +356,7 @@
 .crosshook-library-list-row--selected {
   outline: 3px solid var(--crosshook-color-accent-strong);
   outline-offset: 2px;
-  box-shadow: 0 0 12px rgba(45, 163, 255, 0.45);
+  box-shadow: 0 0 12px rgba(107, 163, 217, 0.45);
 }
 
 /* Hitbox covers the entire row except for action buttons */

--- a/src/crosshook-native/src/styles/proton-manager.css
+++ b/src/crosshook-native/src/styles/proton-manager.css
@@ -355,11 +355,13 @@
   white-space: nowrap;
 }
 
-/* WCAG AA audit (2026-04-17): on `--crosshook-color-surface` (#12172a),
- * installed `--crosshook-color-capability-available` = 10.20:1 and
- * available `--crosshook-color-accent-strong` = 6.60:1. `variables.css`
- * currently defines only the dark root palette, so re-audit if a light
- * surface override is introduced.
+/* WCAG AA audit (2026-04-17, pre-steel-blue palette): on
+ * `--crosshook-color-surface`, installed `--crosshook-color-capability-available`
+ * = 10.20:1 and available `--crosshook-color-accent-strong` = 6.60:1.
+ * These ratios were measured against the legacy surface and must be re-audited
+ * after the Phase 2 token swap. `variables.css` currently defines only the
+ * dark root palette, so also re-audit if a light surface override is
+ * introduced. See docs/internal/design-tokens.md.
  */
 .crosshook-version-row__status-pill--installed {
   background: var(--crosshook-color-capability-available-bg);

--- a/src/crosshook-native/src/styles/proton-manager.css
+++ b/src/crosshook-native/src/styles/proton-manager.css
@@ -361,7 +361,7 @@
  * These ratios were measured against the legacy surface and must be re-audited
  * after the Phase 2 token swap. `variables.css` currently defines only the
  * dark root palette, so also re-audit if a light surface override is
- * introduced. See docs/internal/design-tokens.md.
+ * introduced. See docs/internal-docs/design-tokens.md.
  */
 .crosshook-version-row__status-pill--installed {
   background: var(--crosshook-color-capability-available-bg);

--- a/src/crosshook-native/src/styles/sidebar.css
+++ b/src/crosshook-native/src/styles/sidebar.css
@@ -23,7 +23,7 @@
   border-radius: var(--crosshook-radius-lg);
   border: 1px solid var(--crosshook-color-border);
   background:
-    radial-gradient(ellipse 80% 100% at 95% 50%, rgba(0, 120, 212, 0.08), transparent 60%),
+    radial-gradient(ellipse 80% 100% at 95% 50%, rgba(74, 125, 181, 0.08), transparent 60%),
     linear-gradient(180deg, rgba(18, 23, 42, 0.96), rgba(12, 17, 32, 0.96));
   box-shadow: var(--crosshook-shadow-strong);
   backdrop-filter: blur(18px);
@@ -86,7 +86,7 @@
   text-transform: uppercase;
   margin: 0;
   padding: 0 4px 6px;
-  border-bottom: 1px solid rgba(0, 120, 212, 0.18);
+  border-bottom: 1px solid rgba(74, 125, 181, 0.18);
   margin-bottom: 2px;
 }
 
@@ -108,7 +108,7 @@
   width: 100%;
   padding: 0 14px;
   border-radius: var(--crosshook-radius-md);
-  border: 1px solid rgba(0, 120, 212, 0.12);
+  border: 1px solid rgba(74, 125, 181, 0.12);
   background: rgba(255, 255, 255, 0.05);
   color: var(--crosshook-color-text-muted);
   cursor: pointer;
@@ -128,7 +128,7 @@
 
 .crosshook-sidebar__item:hover {
   background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(0, 120, 212, 0.22);
+  border-color: rgba(74, 125, 181, 0.22);
   color: var(--crosshook-color-text);
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.22),
@@ -143,10 +143,10 @@
 }
 
 .crosshook-sidebar__item[data-state='active'] {
-  border-color: rgba(0, 120, 212, 0.45);
+  border-color: rgba(74, 125, 181, 0.45);
   background: linear-gradient(135deg, var(--crosshook-color-accent) 0%, var(--crosshook-color-accent-strong) 100%);
   color: #ffffff;
-  box-shadow: 0 14px 24px rgba(0, 120, 212, 0.2);
+  box-shadow: 0 14px 24px rgba(74, 125, 181, 0.2);
 }
 
 .crosshook-sidebar__item-icon {
@@ -179,7 +179,7 @@
   margin-top: 6px;
   padding: 12px 14px;
   border-radius: var(--crosshook-radius-md);
-  border: 1px solid rgba(0, 120, 212, 0.12);
+  border: 1px solid rgba(74, 125, 181, 0.12);
   background: rgba(255, 255, 255, 0.05);
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.18),

--- a/src/crosshook-native/src/styles/theme.css
+++ b/src/crosshook-native/src/styles/theme.css
@@ -14,8 +14,8 @@ body,
 
 html {
   background:
-    radial-gradient(circle at top left, rgba(0, 120, 212, 0.18), transparent 30%),
-    radial-gradient(circle at bottom right, rgba(45, 163, 255, 0.12), transparent 28%), var(--crosshook-color-bg);
+    radial-gradient(circle at top left, rgba(74, 125, 181, 0.18), transparent 30%),
+    radial-gradient(circle at bottom right, rgba(107, 163, 217, 0.12), transparent 28%), var(--crosshook-color-bg);
 }
 
 body {
@@ -76,7 +76,7 @@ textarea {
   padding: var(--crosshook-page-padding);
   color: var(--crosshook-color-text);
   background:
-    radial-gradient(circle at top left, rgba(0, 120, 212, 0.16), transparent 28%),
+    radial-gradient(circle at top left, rgba(74, 125, 181, 0.16), transparent 28%),
     linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 18%), var(--crosshook-color-bg);
 }
 
@@ -117,7 +117,7 @@ textarea {
 }
 
 .crosshook-tab--active {
-  border-color: rgba(0, 120, 212, 0.45);
+  border-color: rgba(74, 125, 181, 0.45);
   background: linear-gradient(135deg, var(--crosshook-color-accent) 0%, var(--crosshook-color-accent-strong) 100%);
   color: #fff;
 }
@@ -151,7 +151,7 @@ textarea {
 
 .crosshook-subtab--active,
 .crosshook-subtab[data-state='active'] {
-  border-color: rgba(0, 120, 212, 0.45);
+  border-color: rgba(74, 125, 181, 0.45);
   background: linear-gradient(135deg, var(--crosshook-color-accent) 0%, var(--crosshook-color-accent-strong) 100%);
   color: #fff;
 }
@@ -268,7 +268,7 @@ textarea {
      stacked over the standard panel linear gradient. This is what gives the sidebar
      brand its blue glow — we reproduce it here exactly. */
   background:
-    radial-gradient(ellipse 80% 100% at 95% 50%, rgba(0, 120, 212, 0.08), transparent 60%),
+    radial-gradient(ellipse 80% 100% at 95% 50%, rgba(74, 125, 181, 0.08), transparent 60%),
     linear-gradient(180deg, rgba(18, 23, 42, 0.96), rgba(12, 17, 32, 0.96));
   overflow: hidden;
 }
@@ -945,7 +945,7 @@ textarea {
 .crosshook-button {
   min-height: var(--crosshook-touch-target-min);
   border-radius: var(--crosshook-radius-md);
-  border: 1px solid rgba(0, 120, 212, 0.45);
+  border: 1px solid rgba(74, 125, 181, 0.45);
   background: linear-gradient(135deg, var(--crosshook-color-accent) 0%, var(--crosshook-color-accent-strong) 100%);
   color: #ffffff;
   padding: 0 18px;
@@ -1032,8 +1032,8 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: rgba(0, 120, 212, 0.14);
-  border: 1px solid rgba(0, 120, 212, 0.28);
+  background: rgba(74, 125, 181, 0.14);
+  border: 1px solid rgba(74, 125, 181, 0.28);
   color: var(--crosshook-color-text);
 }
 
@@ -1496,8 +1496,8 @@ textarea {
 .crosshook-community-rating-badge--platinum,
 .crosshook-compatibility-badge--platinum {
   color: #bfdbfe;
-  background: rgba(0, 120, 212, 0.18);
-  border: 1px solid rgba(0, 120, 212, 0.34);
+  background: rgba(74, 125, 181, 0.18);
+  border: 1px solid rgba(74, 125, 181, 0.34);
 }
 
 .crosshook-protondb-panel {
@@ -1514,14 +1514,14 @@ textarea {
   border: 1px solid rgba(120, 160, 255, 0.18);
   background:
     linear-gradient(180deg, rgba(14, 20, 40, 0.96), rgba(9, 14, 28, 0.96)),
-    radial-gradient(circle at top right, rgba(0, 120, 212, 0.12), transparent 30%);
+    radial-gradient(circle at top right, rgba(74, 125, 181, 0.12), transparent 30%);
   box-shadow: var(--crosshook-shadow-strong);
 }
 
 .crosshook-protondb-card--platinum {
-  border-color: rgba(0, 120, 212, 0.28);
+  border-color: rgba(74, 125, 181, 0.28);
   box-shadow:
-    0 0 0 1px rgba(0, 120, 212, 0.12),
+    0 0 0 1px rgba(74, 125, 181, 0.12),
     var(--crosshook-shadow-strong);
 }
 
@@ -1838,8 +1838,8 @@ textarea {
 
 .crosshook-protondb-tier-badge--platinum {
   color: #dbeafe;
-  background: rgba(0, 120, 212, 0.2);
-  border: 1px solid rgba(0, 120, 212, 0.38);
+  background: rgba(74, 125, 181, 0.2);
+  border: 1px solid rgba(74, 125, 181, 0.38);
 }
 
 .crosshook-protondb-tier-badge--gold {
@@ -1890,7 +1890,7 @@ textarea {
 .crosshook-compatibility-viewer__result-card--selected {
   border-color: var(--crosshook-color-accent-strong);
   box-shadow:
-    0 0 0 1px rgba(0, 120, 212, 0.45),
+    0 0 0 1px rgba(74, 125, 181, 0.45),
     var(--crosshook-shadow-strong);
 }
 
@@ -2119,13 +2119,13 @@ textarea {
 
 .crosshook-pinned-strip__chip:hover {
   border-color: var(--crosshook-color-accent);
-  background: rgba(0, 120, 212, 0.1);
+  background: rgba(74, 125, 181, 0.1);
   color: var(--crosshook-color-text);
 }
 
 .crosshook-pinned-strip__chip--active {
   border-color: var(--crosshook-color-accent-strong);
-  background: rgba(0, 120, 212, 0.15);
+  background: rgba(74, 125, 181, 0.15);
   color: var(--crosshook-color-text);
   font-weight: 600;
 }
@@ -2249,7 +2249,7 @@ textarea {
   min-height: 0;
   overflow: visible;
   background:
-    radial-gradient(circle at top right, rgba(45, 163, 255, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(107, 163, 217, 0.12), transparent 28%),
     linear-gradient(180deg, rgba(17, 22, 40, 0.96), rgba(11, 16, 31, 0.96));
 }
 
@@ -2311,13 +2311,13 @@ textarea {
 .crosshook-launch-optimizations__status-chip {
   font-weight: 700;
   color: var(--crosshook-color-text);
-  background: rgba(0, 120, 212, 0.14);
-  border-color: rgba(0, 120, 212, 0.28);
+  background: rgba(74, 125, 181, 0.14);
+  border-color: rgba(74, 125, 181, 0.28);
 }
 
 .crosshook-launch-optimizations__status-chip--idle {
-  background: rgba(0, 120, 212, 0.14);
-  border-color: rgba(0, 120, 212, 0.28);
+  background: rgba(74, 125, 181, 0.14);
+  border-color: rgba(74, 125, 181, 0.28);
 }
 
 .crosshook-launch-optimizations__status-chip--saving {
@@ -2596,8 +2596,8 @@ textarea {
 .crosshook-launch-optimizations__section-tab-meta-badge {
   padding: 2px 8px;
   border-radius: 999px;
-  background: rgba(0, 120, 212, 0.16);
-  border: 1px solid rgba(0, 120, 212, 0.32);
+  background: rgba(74, 125, 181, 0.16);
+  border: 1px solid rgba(74, 125, 181, 0.32);
   color: var(--crosshook-color-text);
   font-size: 0.62rem;
   font-weight: 700;
@@ -2709,8 +2709,8 @@ textarea {
 }
 
 .crosshook-launch-optimizations__option--enabled {
-  border-color: rgba(0, 120, 212, 0.36);
-  background: linear-gradient(180deg, rgba(0, 120, 212, 0.14), rgba(255, 255, 255, 0.03));
+  border-color: rgba(74, 125, 181, 0.36);
+  background: linear-gradient(180deg, rgba(74, 125, 181, 0.14), rgba(255, 255, 255, 0.03));
 }
 
 .crosshook-launch-optimizations__option--disabled {
@@ -2783,8 +2783,8 @@ textarea {
 }
 
 .crosshook-launch-optimizations__option-pill--recommended {
-  background: rgba(0, 120, 212, 0.12);
-  border-color: rgba(0, 120, 212, 0.22);
+  background: rgba(74, 125, 181, 0.12);
+  border-color: rgba(74, 125, 181, 0.22);
   color: #b9ddff;
 }
 
@@ -2841,7 +2841,7 @@ textarea {
 
 .crosshook-launch-optimizations__info-button:hover {
   background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(0, 120, 212, 0.34);
+  border-color: rgba(74, 125, 181, 0.34);
   transform: translateY(-1px);
 }
 
@@ -2866,7 +2866,7 @@ textarea {
   width: min(340px, calc(100vw - 72px));
   border-radius: 14px;
   background: rgba(7, 12, 24, 0.96);
-  border: 1px solid rgba(0, 120, 212, 0.24);
+  border: 1px solid rgba(74, 125, 181, 0.24);
   box-shadow: var(--crosshook-shadow-soft);
   pointer-events: none;
 }
@@ -3035,8 +3035,8 @@ textarea {
 }
 
 .crosshook-install-stage {
-  border: 1px solid rgba(0, 120, 212, 0.28);
-  background: rgba(0, 120, 212, 0.14);
+  border: 1px solid rgba(74, 125, 181, 0.28);
+  background: rgba(74, 125, 181, 0.14);
   color: var(--crosshook-color-text);
 }
 
@@ -3081,7 +3081,7 @@ textarea {
 }
 
 .crosshook-install-candidate--selected {
-  border-color: rgba(0, 120, 212, 0.45);
+  border-color: rgba(74, 125, 181, 0.45);
   color: var(--crosshook-color-text);
 }
 
@@ -3430,7 +3430,7 @@ textarea {
   padding: 28px;
   border-radius: 20px;
   border: 1px solid rgba(96, 165, 250, 0.24);
-  background: radial-gradient(circle at top right, rgba(0, 120, 212, 0.14), transparent 30%), rgba(10, 15, 24, 0.96);
+  background: radial-gradient(circle at top right, rgba(74, 125, 181, 0.14), transparent 30%), rgba(10, 15, 24, 0.96);
   box-shadow: var(--crosshook-shadow-strong);
   backdrop-filter: blur(18px);
 }
@@ -3613,10 +3613,10 @@ textarea {
 }
 
 .crosshook-console {
-  border: 1px solid rgba(0, 120, 212, 0.2);
+  border: 1px solid rgba(74, 125, 181, 0.2);
   border-radius: var(--crosshook-radius-lg);
   background:
-    radial-gradient(circle at top right, rgba(0, 120, 212, 0.08), transparent 26%),
+    radial-gradient(circle at top right, rgba(74, 125, 181, 0.08), transparent 26%),
     linear-gradient(180deg, rgba(8, 12, 22, 0.98), rgba(4, 8, 16, 0.98));
   box-shadow: var(--crosshook-shadow-soft);
   overflow: hidden;
@@ -3639,7 +3639,7 @@ textarea {
   color: var(--crosshook-color-text);
   font-family: var(--crosshook-font-mono);
   line-height: 1.55;
-  background: radial-gradient(circle at top right, rgba(0, 120, 212, 0.08), transparent 28%), rgba(2, 6, 23, 0.92);
+  background: radial-gradient(circle at top right, rgba(74, 125, 181, 0.08), transparent 28%), rgba(2, 6, 23, 0.92);
 }
 
 .crosshook-console__line {
@@ -3698,7 +3698,7 @@ textarea {
 .crosshook-modal__backdrop {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top, rgba(0, 120, 212, 0.14), transparent 32%), rgba(3, 8, 20, 0.78);
+  background: radial-gradient(circle at top, rgba(74, 125, 181, 0.14), transparent 32%), rgba(3, 8, 20, 0.78);
   backdrop-filter: blur(12px);
   cursor: pointer;
 }
@@ -3716,7 +3716,7 @@ textarea {
   border-radius: 24px;
   border: 1px solid rgba(96, 165, 250, 0.24);
   background:
-    radial-gradient(circle at top right, rgba(0, 120, 212, 0.12), transparent 26%),
+    radial-gradient(circle at top right, rgba(74, 125, 181, 0.12), transparent 26%),
     linear-gradient(180deg, rgba(12, 18, 34, 0.98), rgba(8, 12, 24, 0.98));
   box-shadow: 0 28px 72px rgba(0, 0, 0, 0.52);
 }
@@ -3842,7 +3842,7 @@ textarea {
   min-height: 0;
   overflow-y: auto;
   padding: 22px 24px 24px;
-  background: radial-gradient(circle at top left, rgba(0, 120, 212, 0.08), transparent 28%), rgba(4, 8, 16, 0.18);
+  background: radial-gradient(circle at top left, rgba(74, 125, 181, 0.08), transparent 28%), rgba(4, 8, 16, 0.18);
   scrollbar-gutter: stable both-edges;
 }
 
@@ -4544,7 +4544,7 @@ textarea {
 }
 
 .crosshook-profile-editor-delete-dialog {
-  background: #1a1a2e;
+  background: var(--crosshook-color-bg);
   border-radius: 12px;
   padding: 24px;
   max-width: 480px;
@@ -4587,7 +4587,7 @@ textarea {
   align-items: center;
   gap: 12px;
   padding: 10px 16px;
-  background: #1a1a2e;
+  background: var(--crosshook-color-bg);
   border: 1px solid var(--crosshook-color-border-strong);
   border-radius: var(--crosshook-radius-md);
   color: var(--crosshook-color-text);
@@ -5077,7 +5077,7 @@ textarea {
 }
 
 .crosshook-history-timeline-item--selected {
-  background: rgba(0, 120, 212, 0.12);
+  background: rgba(74, 125, 181, 0.12);
   border-left-color: var(--crosshook-color-accent);
 }
 
@@ -5103,7 +5103,7 @@ textarea {
   border-radius: 4px;
   font-size: 0.72rem;
   font-weight: 700;
-  background: rgba(0, 120, 212, 0.15);
+  background: rgba(74, 125, 181, 0.15);
   color: var(--crosshook-color-accent-strong);
   letter-spacing: 0.02em;
   white-space: nowrap;
@@ -5710,7 +5710,7 @@ textarea {
 .crosshook-discovery-badge--community {
   color: var(--crosshook-color-accent-strong);
   background: var(--crosshook-color-accent-soft);
-  border: 1px solid rgba(0, 120, 212, 0.3);
+  border: 1px solid rgba(74, 125, 181, 0.3);
 }
 
 .crosshook-discovery-badge--external {

--- a/src/crosshook-native/src/styles/themed-select.css
+++ b/src/crosshook-native/src/styles/themed-select.css
@@ -81,7 +81,7 @@
 }
 
 .crosshook-themed-select__item[data-highlighted] {
-  background: rgba(0, 120, 212, 0.22);
+  background: rgba(74, 125, 181, 0.22);
   color: var(--crosshook-color-text);
 }
 

--- a/src/crosshook-native/src/styles/variables.css
+++ b/src/crosshook-native/src/styles/variables.css
@@ -1,10 +1,17 @@
 :root {
   color-scheme: dark;
 
-  --crosshook-color-bg: #1a1a2e;
-  --crosshook-color-bg-elevated: #20243d;
-  --crosshook-color-surface: #12172a;
+  --crosshook-color-bg: #181a24;
+  --crosshook-color-bg-elevated: #1f2233;
+  --crosshook-color-surface: #141620;
   --crosshook-color-surface-strong: #0c1120;
+  /* Steel-blue shell surfaces (Unified Desktop Redesign Phase 2) */
+  --crosshook-color-sidebar: #10121c;
+  --crosshook-color-titlebar: #0c0e16;
+  --crosshook-color-surface-1: #1a1d28;
+  --crosshook-color-surface-2: #22263a;
+  --crosshook-color-surface-3: #2a2f48;
+  --crosshook-color-scrim: rgba(8, 10, 18, 0.78);
   --crosshook-color-border: rgba(224, 224, 224, 0.12);
   --crosshook-color-border-strong: rgba(224, 224, 224, 0.22);
   /* Subtle dashed dividers / empty states (reusable muted border) */
@@ -12,13 +19,18 @@
   --crosshook-color-text: #e0e0e0;
   --crosshook-color-text-muted: rgba(224, 224, 224, 0.76);
   --crosshook-color-text-subtle: rgba(224, 224, 224, 0.56);
-  --crosshook-color-accent: #0078d4;
-  --crosshook-color-accent-strong: #2da3ff;
-  --crosshook-color-accent-soft: rgba(0, 120, 212, 0.18);
+  --crosshook-color-accent: #4a7db5;
+  --crosshook-color-accent-strong: #6ba3d9;
+  --crosshook-color-accent-soft: rgba(74, 125, 181, 0.16);
+  --crosshook-color-accent-glow: rgba(107, 163, 217, 0.22);
   --crosshook-focus-ring-inner: rgba(255, 255, 255, 0.06);
   --crosshook-color-success: #28c76f;
   --crosshook-color-warning: #f5c542;
   --crosshook-color-danger: #ff758f;
+  /* Desaturated status siblings for the calm-desktop palette; call sites migrate phase-by-phase */
+  --crosshook-color-success-muted: #5fb880;
+  --crosshook-color-warning-muted: #d4a94a;
+  --crosshook-color-danger-muted: #d77a8a;
   --crosshook-color-capability-available: #4ade80;
   --crosshook-color-capability-available-bg: rgba(74, 222, 128, 0.12);
   --crosshook-color-capability-available-border: rgba(74, 222, 128, 0.28);
@@ -135,9 +147,9 @@
   --crosshook-transition-fast: 140ms;
   --crosshook-transition-standard: 220ms;
 
-  --crosshook-protondb-accent-border: rgba(0, 120, 212, 0.5);
-  --crosshook-protondb-accent-bg-08: rgba(0, 120, 212, 0.08);
-  --crosshook-protondb-accent-bg-14: rgba(0, 120, 212, 0.14);
+  --crosshook-protondb-accent-border: rgba(74, 125, 181, 0.5);
+  --crosshook-protondb-accent-bg-08: rgba(74, 125, 181, 0.08);
+  --crosshook-protondb-accent-bg-14: rgba(74, 125, 181, 0.14);
   --crosshook-protondb-panel-gap: 16px;
   --crosshook-profile-actions-toolbar-margin-top: 18px;
   --crosshook-protondb-panel-margin-top: 18px;


### PR DESCRIPTION
## Summary

Phase 2 of the Unified Desktop Redesign (see [`docs/prps/prds/unified-desktop-redesign.prd.md`](docs/prps/prds/unified-desktop-redesign.prd.md)). Swap the accent/background/surface tokens in `variables.css` to the steel-blue palette (`#4a7db5 / #6ba3d9`), add the new sidebar/titlebar/surface-1/2/3/scrim/accent-glow/muted-status sibling tokens, and mechanically sweep every `#0078d4 / #2da3ff / #1a1a2e / #20243d / #12172a` hex and `rgba(0, 120, 212, …) / rgba(45, 163, 255, …)` literal out of the stylesheets and one TSX inline style. Lock the change in with `scripts/check-legacy-palette.sh` + `./scripts/lint.sh --legacy-palette`.

Closes #414
Part of #441

> Note: #441 is a tracking issue (`phase:2` umbrella), so it gets `Part of` rather than `Closes` per repo convention. #414 is the deliverable and is closed by this PR.

## Changes

- **Tokens** — 6 core tokens updated in `variables.css`, 3 protondb rgba tokens updated, 10 new sibling tokens added (`--crosshook-color-sidebar/titlebar/surface-1/2/3/scrim/accent-glow/success-muted/warning-muted/danger-muted`). High-contrast theme (`:root[data-crosshook-theme='high-contrast']`) deliberately carved out of the sweep.
- **Sweep** — 70 legacy-palette literals replaced across 8 files: `theme.css` (47), `sidebar.css` (7), `library.css` (2), `layout.css` (2), `themed-select.css` (1), `proton-manager.css` (1 WCAG audit comment, reworded and flagged for re-audit), `ProfileReviewModal.tsx` (1 inline-style string), `variables.css` (9). Mechanical `sed` substitution — zero structural edits to `theme.css`.
- **CI sentinel** — new `scripts/check-legacy-palette.sh` (modeled on `scripts/check-host-gateway.sh`): `--help`, `--list`, `--selftest`, suppression grammar `/* allow: legacy-palette */` (CSS) / `// allow: legacy-palette` (TSX/JS). Wired into `scripts/lint.sh` via a new `--legacy-palette` flag that is always full-tree scan (scope flags do not narrow it).
- **Docs** — new [`docs/internal-docs/design-tokens.md`](docs/internal-docs/design-tokens.md) documenting the no-literals rule, token catalogue, suppression grammar, high-contrast carve-out, and CI wiring.
- **Latent bug fix** — `scripts/format.sh` and `scripts/lint.sh` both passed `.css` and other non-biome extensions to `biome format --write` / `biome check --fix`, but `biome.json` only includes `src/**/*.{ts,tsx}`. In mixed-extension commits biome silently dropped the extras, but a CSS-only staged set tripped `no files were processed` and broke the pre-commit hook. Align both scripts with `biome.json`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [x] Build / CI
- [ ] Compatibility (new game/trainer/platform support)

## Testing

### Environment

- **Platform**: Linux (CachyOS, Wayland)
- **Proton Version**: n/a (UI-only change)
- **Game / Trainer**: n/a

### Checklist

- [x] `./scripts/lint.sh` passes (rust/clippy/rustfmt, ts/biome/tsc, shellcheck, host-gateway, legacy-palette)
- [ ] `./scripts/build-native.sh --binary-only` builds without errors (not exercised — no native-build-impacting changes)
- [x] `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core` passes (pre-existing suite; no Rust changes in this PR)
- [ ] `./scripts/build-native.sh` produces a valid AppImage (n/a — no packaging changes)
- [ ] Tested on target platform (Linux desktop or Steam Deck) — **reviewer please verify**: run `./scripts/dev-native.sh` from this branch / worktree and confirm the accent reads as steel-blue (`#4a7db5`) everywhere, no Microsoft-blue leakage.
- [ ] **If touching crates/crosshook-core/src/launch/**: n/a
- [ ] **If touching crates/crosshook-core/src/steam/**: n/a
- [ ] **If touching crates/crosshook-core/src/profile/**: n/a
- [x] **If touching src/components/ or src/hooks/**: TSX change is a 1-token swap inside `ProfileReviewModal`'s style-string gradient; verified via `tsc --noEmit` + visual inspection recommended at the linked route.
- [ ] **If touching runtime-helpers/**: n/a

## Acceptance (#414)

- [x] `rg` audit: 0 matches for `#0078d4|#2da3ff|#1a1a2e|#20243d|#12172a`, `rgba(0, 120, 212, …)`, `rgba(45, 163, 255, …)` under `src/crosshook-native/src/`.
- [x] `./scripts/check-legacy-palette.sh --selftest` → `selftest passed`.
- [x] `./scripts/check-legacy-palette.sh` (clean scan) → `legacy-palette check passed`.
- [x] `./scripts/lint.sh` passes (all checks).
- [x] `docs/internal-docs/design-tokens.md` documents the no-literals rule.

## Reviewer Notes

- **High-contrast carve-out**: `:root[data-crosshook-theme='high-contrast']` keeps its amber palette (`#facc15 / #f97316`). Intentionally out of scope — it has its own accessibility targets and would double-QA a calm-desktop aesthetic the user explicitly wants to be the default.
- **WCAG comment in `proton-manager.css:358`** was rewritten (no longer references the old surface hex) and flagged for re-audit. Ratios `10.20:1` / `6.60:1` were measured against the pre-Phase-2 surface; Phase 13 (Polish + accessibility) should re-audit and either update the numbers or remove the comment if rendered moot by the PRD's focus-ring pass.
- **Status tokens not migrated in place**: existing `--crosshook-color-success | warning | danger` stay as-is. Phase 2 adds `*-muted` siblings; components opt in during their own phases (4–13). Overwriting in place would cascade into UI outside this PR's scope.
- **`--crosshook-color-surface-strong` (`#0c1120`)**: not in the deliverable's literal list per PRD, left untouched.
- **`theme.css` sweep is pure substitution** — no reordering, no whitespace churn. `git show --stat` confirms the diff is substitution-only.
- **Latent format.sh / lint.sh bug** caught during this PR's pre-commit cycle is fixed in a separate commit (`fix(scripts): …`) so the root cause is isolated from the palette change.

Surface the sidebar-variants / Collections follow-up (Phase 3) separately — parallel to this PR per the PRD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design-token guidelines establishing a standardized color-token policy, authoring rules, and CI enforcement notes.

* **Style**
  * Updated app accent from blue to steel‑blue and retinted the dark theme; refreshed theme variables, component highlights, gradients, and interactive states for visual consistency.

* **Chores**
  * Added a CI check to detect legacy palette literals and updated formatting/lint tooling to integrate the token enforcement workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->