### PR TITLE
feat(ui): sidebar variants + formalized Collections section

### DIFF
--- a/docs/prps/reviews/fixes/quick-2026-04-22T21-06-11-fixes.md
+++ b/docs/prps/reviews/fixes/quick-2026-04-22T21-06-11-fixes.md
@@ -1,0 +1,84 @@
+---
+source_review: docs/prps/reviews/quick-2026-04-22T21-06-11-review.md
+generated_at: 2026-04-22T21:19:00Z
+branch: feat/sidebar-variants
+severity_threshold: LOW
+mode: single-pass (no --parallel / --team)
+worktree_isolation: false (run inside an existing worktree)
+---
+
+# Fix Report — `feat/sidebar-variants` quick review
+
+## Summary
+
+- 7 findings targeted (all Low/Nit).
+- 7 applied (`Status: Open` → `Status: Fixed` in the source artifact).
+- 0 failed.
+- 0 skipped.
+
+Validation run after all edits:
+
+| Check       | Command                   | Result                                                               |
+| ----------- | ------------------------- | -------------------------------------------------------------------- |
+| TypeScript  | `npm run typecheck`       | clean                                                                |
+| Vitest      | `npm test -- --run`       | 15 files / 62 tests pass                                             |
+| Lint bundle | `./scripts/lint.sh --fix` | clean for changed files (2 pre-existing warnings in untouched files) |
+
+## Fixes applied
+
+### [Fixed] #1 DRY widths — TS SSOT via inline style
+
+- **Files:** `src/components/layout/Sidebar.tsx`, `src/styles/sidebar.css`
+- **Change:** Added `style={{ width: \`${width}px\` }}`on the`<aside>`so`SIDEBAR_VARIANT_WIDTHS`(TS) is the single source of truth. Removed`.crosshook-sidebar { width: var(...) }`and the three`.crosshook-sidebar--<variant> { width: ... }` rules. CSS no longer knows or needs to know the pixel values.
+
+### [Fixed] #2 Dead CSS aliases
+
+- **Files:** `src/styles/variables.css`
+- **Change:** Deleted `--crosshook-sidebar-width-full`, `--crosshook-sidebar-width-mid`, `--crosshook-sidebar-width-rail`, `--crosshook-sidebar-width`, and `--crosshook-sidebar-width-collapsed`. Grep confirms no remaining consumers.
+
+### [Fixed] #3 Drop imperative panelRef.resize
+
+- **Files:** `src/components/layout/AppShell.tsx`
+- **Change:** Removed `sidebarPanelRef` + the `useEffect` that called `panelRef.resize(sidebarWidth)` and removed `panelRef={sidebarPanelRef}` from the sidebar `<Panel>`. `react-resizable-panels@4.7` re-clamps on min/max prop changes, so the declarative constraints are now the sole sizing mechanism.
+
+### [Fixed] #4 Drop `crosshook-sidebar--<variant>` class
+
+- **Files:** `src/components/layout/Sidebar.tsx`, `src/styles/sidebar.css`
+- **Change:** `<aside>` class is now just `"crosshook-sidebar"`. `data-sidebar-variant` is the canonical variant hook. CSS selectors `.crosshook-sidebar--mid`, `.crosshook-sidebar--rail`, `.crosshook-sidebar--mid[data-collapsed='true']`, `.crosshook-sidebar--rail[data-collapsed='true']` rewritten to `[data-sidebar-variant='...']`.
+- **Partial-fix note:** `data-collapsed` was retained — removing it would have required rewriting ~20 existing `[data-collapsed='true']` selectors to `:not([data-sidebar-variant='full'])`, and updating 4 test assertions, for a net loss in CSS readability. Tracked as acceptable residual overlap (variant ↔ collapsed is deterministic and computed in one place in `Sidebar.tsx`).
+
+### [Fixed] #5 Promote `section-label` to `<h2>`
+
+- **Files:** `src/components/layout/Sidebar.tsx`
+- **Change:** `SidebarSectionBlock` now renders the label as `<h2 className="crosshook-sidebar__section-label">`. Restores heading-level a11y for every section (Game / Collections / Setup / Dashboards / Community), including the Collections heading lost when `CollectionsSidebar` was folded into the generic wrapper.
+
+### [Fixed] #6 Narrow `getBoundingClientRect` spy
+
+- **Files:** `src/components/layout/__tests__/AppShell.test.tsx`
+- **Change:** `mockAppShellRect` now captures the original `HTMLDivElement.prototype.getBoundingClientRect` and calls it through (`original.call(this)`) for any non-shell div instead of returning `{0,0}`. Test suite still passes; future layout-dependent assertions won't be silently poisoned.
+
+### [Fixed] #7 Simplify `collectionInitial`
+
+- **Files:** `src/components/collections/CollectionsSidebar.tsx`
+- **Change:** Replaced `return trimmed === '' ? '?' : (trimmed[0]?.toUpperCase() ?? '?');` with an explicit early return for the empty case, then `return trimmed.charAt(0).toUpperCase();`. `charAt` is total (no optional chain / fallback needed after the empty check), removing the unreachable branches.
+
+## Files modified
+
+- `src/crosshook-native/src/components/layout/Sidebar.tsx`
+- `src/crosshook-native/src/components/layout/AppShell.tsx`
+- `src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx`
+- `src/crosshook-native/src/components/collections/CollectionsSidebar.tsx`
+- `src/crosshook-native/src/styles/sidebar.css`
+- `src/crosshook-native/src/styles/variables.css`
+
+(`sidebarVariants.ts`, `Sidebar.test.tsx`, `CollectionsSidebar.test.tsx`, `sidebarVariants.test.ts`, `theme.css` were not changed by these fixes — they remain the originally staged additions for the feature.)
+
+## Residual / deferred
+
+- **Partial #4** — `data-collapsed` attribute retained. Low-value to remove; would churn ~20 CSS selectors and 4 test assertions. Documented above.
+
+## Next steps
+
+1. Review the diff (`git diff`) against the uncommitted feature work.
+2. Re-run `/ycc:code-review --quick` if you want a second pass.
+3. `/ycc:git-workflow` (or manual `git add` + `git commit`) to land the changes. Suggested scope: fold these nits into the upcoming `feat(ui): sidebar-variants` commit rather than a standalone fix commit, since nothing has shipped yet.

--- a/docs/prps/reviews/quick-2026-04-22T21-06-11-review.md
+++ b/docs/prps/reviews/quick-2026-04-22T21-06-11-review.md
@@ -1,0 +1,86 @@
+---
+mode: quick-local
+generated_at: 2026-04-22T21:06:11Z
+branch: feat/sidebar-variants
+decision: COMMENT (quick mode — no toolchain validation run)
+---
+
+# Quick Code Review — `feat/sidebar-variants` (uncommitted)
+
+## Scope
+
+7 modified + 4 new files. Introduces `SidebarVariant` (`rail` | `mid` | `full`) driven by `useBreakpoint`, replaces CSS-only collapsed sidebar with a declarative variant system, flattens `CollectionsSidebar` into a generic `SidebarSectionBlock`, and adds Vitest coverage for `AppShell`, `Sidebar`, `CollectionsSidebar`, and `sidebarVariants`.
+
+Quick mode: typecheck/lint/test/build were **not** run. Findings are source-read only.
+
+## Summary
+
+No blocking correctness or security issues. All findings below are low-severity maintainability / a11y / test-hygiene items. The variant module is well-factored and tested.
+
+## Findings
+
+### [Low] Duplicate source-of-truth for sidebar widths — maintainability
+
+- **File:** `src/crosshook-native/src/components/layout/sidebarVariants.ts:5-9` + `src/crosshook-native/src/styles/variables.css:123-125`
+- **Status:** Fixed
+- **Issue:** Canonical widths (56 / 68 / 240) are declared twice — as `SIDEBAR_VARIANT_WIDTHS` in TS and as `--crosshook-sidebar-width-{rail,mid,full}` in CSS. If one is changed without the other, the Panel's fixed pixel constraint (`defaultSize`/`minSize`/`maxSize`) and the `.crosshook-sidebar--<variant>` CSS width will disagree, producing clipped or empty columns. Violates the DRY rule in `CLAUDE.md`.
+- **Fix:** Drop the per-variant CSS custom properties (or the TS constants) and derive one from the other. Simplest: remove the `.crosshook-sidebar--<variant> { width: ... }` rules and set `style={{ width: \`${width}px\` }}`on the`<aside>`in`Sidebar.tsx`from the TS constants. Tests using`data-sidebar-width` still pass.
+
+### [Low] Dead CSS alias — cleanup
+
+- **File:** `src/crosshook-native/src/styles/variables.css:126-127`
+- **Status:** Fixed
+- **Issue:** `--crosshook-sidebar-width` (alias to full) is referenced only by the base `.crosshook-sidebar` rule, which is always overridden by a variant class; `--crosshook-sidebar-width-collapsed` is not referenced anywhere after this change (confirmed via grep).
+- **Fix:** Delete both aliases; the variant-specific vars cover every current consumer. `CLAUDE.md` says "Remove unused code, imports, and commented-out blocks."
+
+### [Low] Redundant declarative + imperative panel sizing
+
+- **File:** `src/crosshook-native/src/components/layout/AppShell.tsx:162-166,189-193`
+- **Status:** Fixed
+- **Issue:** `defaultSize={sidebarWidth}`, `minSize={sidebarWidth}`, `maxSize={sidebarWidth}` are all set to the same value on every render, AND a `useEffect` calls `sidebarPanelRef.current?.resize(sidebarWidth)` when the width changes. `react-resizable-panels@4.7` re-clamps when min/max props change, so the imperative `resize` is likely a no-op. Two mechanisms doing the same job makes it harder to reason about which one is authoritative.
+- **Fix:** Pick one. Either (a) remove the `useEffect + panelRef` branch and rely on prop-driven re-clamp, or (b) drop the fixed min/max and drive the layout purely from the imperative `resize` call. Option (a) is simpler and removes the `sidebarPanelRef` entirely.
+
+### [Low] Overlapping variant data-attributes + class — API surface bloat
+
+- **File:** `src/crosshook-native/src/components/layout/Sidebar.tsx:193-201`
+- **Status:** Fixed
+- **Issue:** `<aside>` carries `class="crosshook-sidebar crosshook-sidebar--${variant}"`, `data-collapsed`, `data-sidebar-variant`, and `data-sidebar-width`. All four encode the same state. This creates four styling hooks to keep in sync and makes future refactors harder.
+- **Fix:** Keep `data-sidebar-variant` (used by the tests and derivable by CSS via `[data-sidebar-variant="..."]`). Drop the `crosshook-sidebar--${variant}` class (or the attribute — pick one), and compute `data-collapsed` in CSS via `[data-sidebar-variant]:not([data-sidebar-variant="full"])` instead of persisting it in the DOM twice.
+
+### [Low] a11y regression — lost `<h2>` heading for Collections
+
+- **File:** `src/crosshook-native/src/components/collections/CollectionsSidebar.tsx:117` (removed `<nav aria-label="Collections">` + `<h2>`) and `src/crosshook-native/src/components/layout/Sidebar.tsx:152-153` (new generic wrapper uses `<div>`)
+- **Status:** Fixed
+- **Issue:** The old Collections section rendered its label as `<h2 class="crosshook-sidebar__section-label">`. After moving Collections into the generic `SidebarSectionBlock`, all section labels render as `<div>`. Screen-reader users who navigate by heading level lose the Collections landmark. The enclosing `<aside aria-label="CrossHook navigation">` still identifies the sidebar itself, so this is a regression in granularity, not a landmark loss.
+- **Fix:** Render `section-label` as a heading (`<h2>` or `<h3>`) inside `SidebarSectionBlock` so every section — not just Collections — is heading-navigable. Keep the visual styling via the existing `.crosshook-sidebar__section-label` class.
+
+### [Low] Prototype-level `getBoundingClientRect` spy is test-fragile
+
+- **File:** `src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx:43-52`
+- **Status:** Fixed
+- **Issue:** `mockAppShellRect` spies `HTMLDivElement.prototype.getBoundingClientRect` and returns `{0,0}` for every div that is not `.crosshook-app-layout`. Radix primitives (Tooltip portal, Tabs indicator) and other layout code call `getBoundingClientRect` during mount; returning zero rects for them is silently swallowed today but can cause layout-dependent tests to flake if more a11y/layout assertions are added later.
+- **Fix:** Narrow the spy. Either attach it only to the specific div via ref after render, or inside the impl default to the original via `originalGetBoundingClientRect.call(this)` when the class doesn't match.
+
+### [Nit] Over-defensive optional chaining in `collectionInitial`
+
+- **File:** `src/crosshook-native/src/components/collections/CollectionsSidebar.tsx:16-19`
+- **Status:** Fixed
+- **Issue:** `trimmed === '' ? '?' : (trimmed[0]?.toUpperCase() ?? '?')` — the early empty-string return guarantees `trimmed.length >= 1`, so `trimmed[0]` is defined and `?.` / `?? '?'` are unreachable fallbacks. TS `noUncheckedIndexedAccess` makes the optional chain necessary for the type-checker, but the `?? '?'` branch can never fire.
+- **Fix:** Either drop the `?? '?'` (keep `?.toUpperCase() ?? ''` if the type insists) or just `return trimmed.charAt(0).toUpperCase();` after the empty check.
+
+### [Observation] Vertical resize handle removed by design — confirm intent
+
+- **File:** `src/crosshook-native/src/components/layout/AppShell.tsx` (removed `<Separator className="crosshook-resize-handle crosshook-resize-handle--vertical" />`)
+- **Status:** Acknowledged
+- **Note:** With fixed min/max/default widths per breakpoint, the vertical drag handle was dead UI. Removing it is consistent with the variant model. Flag: users on `rail`/`mid` have no affordance to temporarily expand the sidebar — if that's a PRD omission, surface it; if it's intentional, no action.
+
+## What I did not check (quick mode)
+
+- `npm run typecheck`, `npm test`, `./scripts/lint.sh` — rerun before committing.
+- Whether the new tests pass under happy-dom with the prototype spy.
+- Visual parity in browser dev mode across breakpoints.
+
+## Next steps
+
+- 7 findings — all Low/Nit. Fan-out would be overkill.
+- Recommended: `/ycc:review-fix` (single-pass) to walk through and close each item, then run `npm run typecheck && npm test && ./scripts/lint.sh` before committing.

--- a/src/crosshook-native/src/components/collections/CollectionsSidebar.tsx
+++ b/src/crosshook-native/src/components/collections/CollectionsSidebar.tsx
@@ -13,6 +13,12 @@ export interface CollectionsSidebarProps {
   onOpenCollection: (id: string) => void;
 }
 
+function collectionInitial(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed === '') return '?';
+  return trimmed.charAt(0).toUpperCase();
+}
+
 export function CollectionsSidebar({ onOpenCollection }: CollectionsSidebarProps) {
   const { collections, createCollection, error, prepareCollectionImportPreview, applyImportedCollection } =
     useCollections();
@@ -109,64 +115,71 @@ export function CollectionsSidebar({ onOpenCollection }: CollectionsSidebarProps
 
   return (
     <>
-      <nav className="crosshook-sidebar__section crosshook-collections-sidebar" aria-label="Collections">
-        <h2 className="crosshook-sidebar__section-label">Collections</h2>
-        {collections.length > 0 ? (
-          <ul className="crosshook-sidebar__section-items crosshook-collections-sidebar__list">
-            {collections.map((c) => (
-              <li key={c.collection_id}>
-                <button
-                  type="button"
-                  className="crosshook-sidebar__item crosshook-collections-sidebar__item"
-                  onClick={() => handleClickCollection(c.collection_id)}
-                  title={c.name}
+      {collections.length > 0 ? (
+        <ul className="crosshook-sidebar__section-items crosshook-collections-sidebar__list">
+          {collections.map((c) => (
+            <li key={c.collection_id}>
+              <button
+                type="button"
+                className="crosshook-sidebar__item crosshook-collections-sidebar__item"
+                onClick={() => handleClickCollection(c.collection_id)}
+                title={c.name}
+              >
+                <span
+                  className="crosshook-sidebar__item-icon crosshook-collections-sidebar__item-avatar"
+                  aria-hidden="true"
                 >
-                  <span className="crosshook-collections-sidebar__item-name">{c.name}</span>
-                  <span className="crosshook-collections-sidebar__item-count">
-                    {c.profile_count}
-                    <span className="crosshook-visually-hidden"> {c.profile_count === 1 ? 'profile' : 'profiles'}</span>
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="crosshook-collections-sidebar__empty-copy">
-            No collections yet. Create one or import a preset to group your profiles.
-          </p>
-        )}
+                  {collectionInitial(c.name)}
+                </span>
+                <span className="crosshook-sidebar__item-label crosshook-collections-sidebar__item-name">{c.name}</span>
+                <span className="crosshook-collections-sidebar__item-count">
+                  {c.profile_count}
+                  <span className="crosshook-visually-hidden"> {c.profile_count === 1 ? 'profile' : 'profiles'}</span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="crosshook-collections-sidebar__empty-copy">
+          No collections yet. Create one or import a preset to group your profiles.
+        </p>
+      )}
 
-        <button
-          type="button"
-          className="crosshook-sidebar__item crosshook-collections-sidebar__cta"
-          onClick={() => {
-            setCreateSessionError(null);
-            setCreateOpen(true);
-          }}
-        >
-          <span className="crosshook-sidebar__item-icon" aria-hidden="true">
-            +
-          </span>
-          <span className="crosshook-sidebar__item-label">New Collection</span>
-        </button>
+      <button
+        type="button"
+        className="crosshook-sidebar__item crosshook-collections-sidebar__cta"
+        aria-label="New Collection"
+        onClick={() => {
+          setCreateSessionError(null);
+          setCreateOpen(true);
+        }}
+        title="New Collection"
+      >
+        <span className="crosshook-sidebar__item-icon" aria-hidden="true">
+          +
+        </span>
+        <span className="crosshook-sidebar__item-label">New Collection</span>
+      </button>
 
-        <button
-          type="button"
-          className="crosshook-sidebar__item crosshook-collections-sidebar__cta"
-          onClick={() => void handleImportPreset()}
-        >
-          <span className="crosshook-sidebar__item-icon" aria-hidden="true">
-            &gt;
-          </span>
-          <span className="crosshook-sidebar__item-label">Import Preset</span>
-        </button>
+      <button
+        type="button"
+        className="crosshook-sidebar__item crosshook-collections-sidebar__cta"
+        aria-label="Import Preset"
+        onClick={() => void handleImportPreset()}
+        title="Import Preset"
+      >
+        <span className="crosshook-sidebar__item-icon" aria-hidden="true">
+          &gt;
+        </span>
+        <span className="crosshook-sidebar__item-label">Import Preset</span>
+      </button>
 
-        {(createSessionError ?? importSessionError ?? error) !== null && (
-          <p className="crosshook-collections-sidebar__error" role="alert">
-            {createSessionError ?? importSessionError ?? error}
-          </p>
-        )}
-      </nav>
+      {(createSessionError ?? importSessionError ?? error) !== null && (
+        <p className="crosshook-collections-sidebar__error" role="alert">
+          {createSessionError ?? importSessionError ?? error}
+        </p>
+      )}
 
       <CollectionEditModal
         open={createOpen}

--- a/src/crosshook-native/src/components/collections/__tests__/CollectionsSidebar.test.tsx
+++ b/src/crosshook-native/src/components/collections/__tests__/CollectionsSidebar.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CollectionsProvider } from '@/context/CollectionsContext';
+import { renderWithMocks } from '@/test/render';
+import { CollectionsSidebar } from '../CollectionsSidebar';
+
+describe('CollectionsSidebar', () => {
+  it('renders collection actions and opens the selected collection', async () => {
+    const onOpenCollection = vi.fn();
+
+    renderWithMocks(
+      <CollectionsProvider>
+        <CollectionsSidebar onOpenCollection={onOpenCollection} />
+      </CollectionsProvider>
+    );
+
+    const collectionButton = await screen.findByRole('button', { name: /Action \/ Adventure/i });
+    fireEvent.click(collectionButton);
+
+    expect(onOpenCollection).toHaveBeenCalledWith('mock-collection-1');
+    expect(screen.getByRole('button', { name: 'New Collection' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Import Preset' })).toBeInTheDocument();
+  });
+});

--- a/src/crosshook-native/src/components/layout/AppShell.tsx
+++ b/src/crosshook-native/src/components/layout/AppShell.tsx
@@ -14,11 +14,13 @@ import { LaunchStateProvider } from '@/context/LaunchStateContext';
 import { PreferencesProvider, usePreferencesContext } from '@/context/PreferencesContext';
 import { useProfileContext } from '@/context/ProfileContext';
 import { useHighContrastTheme } from '@/hooks/useAccessibilityEnhancements';
+import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useCollections } from '@/hooks/useCollections';
 import { useFlatpakMigrationToast } from '@/hooks/useFlatpakMigrationToast';
 import { subscribeEvent } from '@/lib/events';
 import { isAppRoute } from '@/lib/validAppRoutes';
 import type { OnboardingCheckPayload } from '@/types/onboarding';
+import { sidebarVariantFromBreakpoint, sidebarWidthForVariant } from './sidebarVariants';
 
 function ConsoleDock({ panelRef }: { panelRef: RefObject<PanelImperativeHandle | null> }) {
   const { settings } = usePreferencesContext();
@@ -46,8 +48,12 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
     useProfileContext();
   const [route, setRoute] = useState<AppRoute>('library');
   const lastProfile = profileName.trim() || selectedProfile;
+  const shellRef = useRef<HTMLDivElement>(null);
   const consolePanelRef = useRef<PanelImperativeHandle>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const breakpoint = useBreakpoint(shellRef);
+  const sidebarVariant = sidebarVariantFromBreakpoint(breakpoint.size, breakpoint.height);
+  const sidebarWidth = sidebarWidthForVariant(sidebarVariant);
 
   const {
     open: collectionModalOpen,
@@ -167,22 +173,27 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
               if (isAppRoute(value)) setRoute(value);
             }}
           >
-            <div className="crosshook-app-layout">
+            <div className="crosshook-app-layout" ref={shellRef}>
               <Group
                 className="crosshook-shell-group"
                 orientation="horizontal"
                 resizeTargetMinimumSize={{ coarse: 36, fine: 12 }}
               >
-                <Panel className="crosshook-shell-panel" defaultSize="20%" minSize="14%" maxSize="40%">
+                <Panel
+                  className="crosshook-shell-panel"
+                  defaultSize={sidebarWidth}
+                  minSize={sidebarWidth}
+                  maxSize={sidebarWidth}
+                >
                   <Sidebar
                     activeRoute={route}
                     onNavigate={setRoute}
                     controllerMode={controllerMode}
                     lastProfile={lastProfile}
                     onOpenCollection={handleOpenCollection}
+                    variant={sidebarVariant}
                   />
                 </Panel>
-                <Separator className="crosshook-resize-handle crosshook-resize-handle--vertical" />
                 <Panel className="crosshook-shell-panel" minSize="28%">
                   <Group
                     className="crosshook-shell-group"

--- a/src/crosshook-native/src/components/layout/Sidebar.tsx
+++ b/src/crosshook-native/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   SettingsIcon,
 } from '../icons/SidebarIcons';
 import { ROUTE_NAV_LABEL } from './routeMetadata';
+import { isSidebarCollapsedVariant, type SidebarVariant, sidebarWidthForVariant } from './sidebarVariants';
 
 export type AppRoute =
   | 'library'
@@ -35,6 +36,7 @@ export interface SidebarProps {
   controllerMode: boolean;
   lastProfile: string;
   onOpenCollection: (id: string) => void;
+  variant: SidebarVariant;
 }
 
 interface SidebarSectionItem {
@@ -43,14 +45,26 @@ interface SidebarSectionItem {
   icon: ComponentType<SVGProps<SVGSVGElement>>;
 }
 
-interface SidebarSection {
+interface SidebarRouteSection {
+  key: string;
   label: string;
+  type: 'routes';
   items: SidebarSectionItem[];
 }
 
+interface SidebarCollectionsSection {
+  key: 'collections';
+  label: 'Collections';
+  type: 'collections';
+}
+
+type SidebarSection = SidebarRouteSection | SidebarCollectionsSection;
+
 const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
+    key: 'game',
     label: 'Game',
+    type: 'routes',
     items: [
       { route: 'library', label: ROUTE_NAV_LABEL.library, icon: LibraryIcon },
       { route: 'profiles', label: ROUTE_NAV_LABEL.profiles, icon: ProfilesIcon },
@@ -58,11 +72,20 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
     ],
   },
   {
+    key: 'collections',
+    label: 'Collections',
+    type: 'collections',
+  },
+  {
+    key: 'setup',
     label: 'Setup',
+    type: 'routes',
     items: [{ route: 'install', label: ROUTE_NAV_LABEL.install, icon: InstallIcon }],
   },
   {
+    key: 'dashboards',
     label: 'Dashboards',
+    type: 'routes',
     items: [
       { route: 'health', label: ROUTE_NAV_LABEL.health, icon: HealthIcon },
       { route: 'host-tools', label: ROUTE_NAV_LABEL['host-tools'], icon: HostToolsIcon },
@@ -70,7 +93,9 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
     ],
   },
   {
+    key: 'community',
     label: 'Community',
+    type: 'routes',
     items: [
       { route: 'community', label: ROUTE_NAV_LABEL.community, icon: BrowseIcon },
       { route: 'discover', label: ROUTE_NAV_LABEL.discover, icon: DiscoverIcon },
@@ -113,12 +138,63 @@ function StatusRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function Sidebar({ activeRoute, onNavigate, controllerMode, lastProfile, onOpenCollection }: SidebarProps) {
+function SidebarSectionBlock({
+  section,
+  activeRoute,
+  onNavigate,
+  onOpenCollection,
+}: {
+  section: SidebarSection;
+  activeRoute: AppRoute;
+  onNavigate: (route: AppRoute) => void;
+  onOpenCollection: (id: string) => void;
+}) {
+  return (
+    <div className="crosshook-sidebar__section" key={section.key}>
+      <h2 className="crosshook-sidebar__section-label">{section.label}</h2>
+      {section.type === 'routes' ? (
+        <div className="crosshook-sidebar__section-items">
+          {section.items.map((item) => (
+            <SidebarTrigger
+              key={item.route}
+              activeRoute={activeRoute}
+              onNavigate={onNavigate}
+              route={item.route}
+              label={item.label}
+              icon={item.icon}
+            />
+          ))}
+        </div>
+      ) : (
+        <CollectionsSidebar onOpenCollection={onOpenCollection} />
+      )}
+    </div>
+  );
+}
+
+export function Sidebar({
+  activeRoute,
+  onNavigate,
+  controllerMode,
+  lastProfile,
+  onOpenCollection,
+  variant,
+}: SidebarProps) {
   const controllerLabel = controllerMode ? 'On' : 'Off';
   const profileLabel = lastProfile.trim() || 'No profile selected';
+  const collapsed = isSidebarCollapsedVariant(variant);
+  const width = sidebarWidthForVariant(variant);
 
   return (
-    <aside className="crosshook-sidebar" data-crosshook-focus-zone="sidebar" aria-label="CrossHook navigation">
+    <aside
+      className="crosshook-sidebar"
+      style={{ width: `${width}px` }}
+      data-collapsed={collapsed ? 'true' : 'false'}
+      data-crosshook-focus-zone="sidebar"
+      data-sidebar-variant={variant}
+      data-sidebar-width={width}
+      aria-label="CrossHook navigation"
+    >
       <div className="crosshook-sidebar__brand">
         <div className="crosshook-sidebar__brand-content">
           <p className="crosshook-sidebar__brand-title">CrossHook</p>
@@ -152,42 +228,14 @@ export function Sidebar({ activeRoute, onNavigate, controllerMode, lastProfile, 
       </div>
 
       <Tabs.List className="crosshook-sidebar__nav" aria-label="CrossHook sections">
-        {SIDEBAR_SECTIONS[0] ? (
-          <div className="crosshook-sidebar__section" key={SIDEBAR_SECTIONS[0].label}>
-            <div className="crosshook-sidebar__section-label">{SIDEBAR_SECTIONS[0].label}</div>
-            <div className="crosshook-sidebar__section-items">
-              {SIDEBAR_SECTIONS[0].items.map((item) => (
-                <SidebarTrigger
-                  key={item.route}
-                  activeRoute={activeRoute}
-                  onNavigate={onNavigate}
-                  route={item.route}
-                  label={item.label}
-                  icon={item.icon}
-                />
-              ))}
-            </div>
-          </div>
-        ) : null}
-
-        <CollectionsSidebar onOpenCollection={onOpenCollection} />
-
-        {SIDEBAR_SECTIONS.slice(1).map((section) => (
-          <div className="crosshook-sidebar__section" key={section.label}>
-            <div className="crosshook-sidebar__section-label">{section.label}</div>
-            <div className="crosshook-sidebar__section-items">
-              {section.items.map((item) => (
-                <SidebarTrigger
-                  key={item.route}
-                  activeRoute={activeRoute}
-                  onNavigate={onNavigate}
-                  route={item.route}
-                  label={item.label}
-                  icon={item.icon}
-                />
-              ))}
-            </div>
-          </div>
+        {SIDEBAR_SECTIONS.map((section) => (
+          <SidebarSectionBlock
+            key={section.key}
+            section={section}
+            activeRoute={activeRoute}
+            onNavigate={onNavigate}
+            onOpenCollection={onOpenCollection}
+          />
         ))}
 
         <div className="crosshook-sidebar__footer">

--- a/src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx
+++ b/src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from '@/components/layout/AppShell';
 import { CollectionsProvider } from '@/context/CollectionsContext';
@@ -21,8 +21,47 @@ function AppShellInAppProviders() {
   );
 }
 
+function setInnerWidth(w: number): void {
+  Object.defineProperty(window, 'innerWidth', { value: w, configurable: true, writable: true });
+}
+
+function setInnerHeight(h: number): void {
+  Object.defineProperty(window, 'innerHeight', { value: h, configurable: true, writable: true });
+}
+
+function shellRect(width: number, height: number): DOMRect {
+  return {
+    width,
+    height,
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function mockAppShellRect(width: number, height: number) {
+  const original = HTMLDivElement.prototype.getBoundingClientRect;
+  return vi.spyOn(HTMLDivElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+    this: HTMLDivElement
+  ) {
+    if (this.classList.contains('crosshook-app-layout')) {
+      return shellRect(width, height);
+    }
+    return original.call(this);
+  });
+}
+
 describe('AppShell (integration)', () => {
+  let prevWidth: number;
+  let prevHeight: number;
+
   beforeEach(() => {
+    prevWidth = window.innerWidth;
+    prevHeight = window.innerHeight;
     const memory = new Map<string, string>();
     vi.stubGlobal('localStorage', {
       get length() {
@@ -43,6 +82,8 @@ describe('AppShell (integration)', () => {
   });
 
   afterEach(() => {
+    setInnerWidth(prevWidth);
+    setInnerHeight(prevHeight);
     vi.unstubAllGlobals();
   });
 
@@ -53,5 +94,42 @@ describe('AppShell (integration)', () => {
     expect(layout).not.toBeNull();
     expect(layout).toBeInTheDocument();
     expect(screen.getByLabelText('CrossHook navigation')).toBeInTheDocument();
+  });
+
+  it('uses the rail sidebar variant for deck-sized shells', async () => {
+    setInnerWidth(1280);
+    setInnerHeight(800);
+    const rectSpy = mockAppShellRect(1280, 800);
+
+    renderWithMocks(<AppShellInAppProviders />);
+
+    await waitFor(() => {
+      const nav = screen.getByLabelText('CrossHook navigation');
+      expect(nav).toHaveAttribute('data-sidebar-variant', 'rail');
+      expect(nav).toHaveAttribute('data-sidebar-width', '56');
+      expect(nav).toHaveAttribute('data-collapsed', 'true');
+    });
+    rectSpy.mockRestore();
+  });
+
+  it('uses the full sidebar variant for desktop-sized shells and keeps Collections in declared order', async () => {
+    setInnerWidth(1920);
+    setInnerHeight(1080);
+    const rectSpy = mockAppShellRect(1920, 1080);
+
+    renderWithMocks(<AppShellInAppProviders />);
+
+    await waitFor(() => {
+      const nav = screen.getByLabelText('CrossHook navigation');
+      expect(nav).toHaveAttribute('data-sidebar-variant', 'full');
+      expect(nav).toHaveAttribute('data-sidebar-width', '240');
+      expect(nav).toHaveAttribute('data-collapsed', 'false');
+    });
+
+    const sectionLabels = Array.from(document.querySelectorAll('.crosshook-sidebar__section-label')).map((node) =>
+      node.textContent?.trim()
+    );
+    expect(sectionLabels).toEqual(['Game', 'Collections', 'Setup', 'Dashboards', 'Community']);
+    rectSpy.mockRestore();
   });
 });

--- a/src/crosshook-native/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/crosshook-native/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,54 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CollectionsProvider } from '@/context/CollectionsContext';
+import { renderWithMocks } from '@/test/render';
+import { Sidebar } from '../Sidebar';
+
+function renderSidebar(variant: 'rail' | 'mid' | 'full') {
+  return renderWithMocks(
+    <CollectionsProvider>
+      <Tabs.Root orientation="vertical" value="library">
+        <Sidebar
+          activeRoute="library"
+          onNavigate={() => undefined}
+          controllerMode={false}
+          lastProfile="Deck Test Profile"
+          onOpenCollection={vi.fn()}
+          variant={variant}
+        />
+      </Tabs.Root>
+    </CollectionsProvider>
+  );
+}
+
+describe('Sidebar', () => {
+  it('renders sections in declared order with Collections formalized between Game and Setup', async () => {
+    renderSidebar('full');
+
+    await screen.findByRole('button', { name: /Action \/ Adventure/i });
+
+    const sectionLabels = Array.from(document.querySelectorAll('.crosshook-sidebar__section-label')).map((node) =>
+      node.textContent?.trim()
+    );
+
+    expect(sectionLabels).toEqual(['Game', 'Collections', 'Setup', 'Dashboards', 'Community']);
+    expect(screen.getByLabelText('CrossHook navigation')).toHaveAttribute('data-sidebar-variant', 'full');
+    expect(screen.getByLabelText('CrossHook navigation')).toHaveAttribute('data-sidebar-width', '240');
+    expect(screen.getByLabelText('CrossHook navigation')).toHaveAttribute('data-collapsed', 'false');
+  });
+
+  it('marks the mid variant as collapsed while preserving the declared section structure', async () => {
+    renderSidebar('mid');
+
+    await screen.findByRole('button', { name: /Action \/ Adventure/i });
+
+    const nav = screen.getByLabelText('CrossHook navigation');
+    expect(nav).toHaveAttribute('data-sidebar-variant', 'mid');
+    expect(nav).toHaveAttribute('data-sidebar-width', '68');
+    expect(nav).toHaveAttribute('data-collapsed', 'true');
+    expect(Array.from(document.querySelectorAll('.crosshook-sidebar__section')).length).toBe(5);
+    expect(screen.getByRole('button', { name: 'New Collection' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Import Preset' })).toBeInTheDocument();
+  });
+});

--- a/src/crosshook-native/src/components/layout/__tests__/sidebarVariants.test.ts
+++ b/src/crosshook-native/src/components/layout/__tests__/sidebarVariants.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSidebarCollapsedVariant,
+  SIDEBAR_VARIANT_WIDTHS,
+  sidebarVariantFromBreakpoint,
+  sidebarWidthForVariant,
+} from '../sidebarVariants';
+
+describe('sidebarVariants', () => {
+  it('maps PRD breakpoint buckets to sidebar variants', () => {
+    expect(sidebarVariantFromBreakpoint('deck')).toBe('rail');
+    expect(sidebarVariantFromBreakpoint('narrow')).toBe('mid');
+    expect(sidebarVariantFromBreakpoint('narrow', 800)).toBe('rail');
+    expect(sidebarVariantFromBreakpoint('desk')).toBe('full');
+    expect(sidebarVariantFromBreakpoint('uw')).toBe('full');
+  });
+
+  it('exposes the canonical width contract for each variant', () => {
+    expect(sidebarWidthForVariant('rail')).toBe(56);
+    expect(sidebarWidthForVariant('mid')).toBe(68);
+    expect(sidebarWidthForVariant('full')).toBe(240);
+    expect(SIDEBAR_VARIANT_WIDTHS).toEqual({ rail: 56, mid: 68, full: 240 });
+  });
+
+  it('treats non-full variants as collapsed', () => {
+    expect(isSidebarCollapsedVariant('rail')).toBe(true);
+    expect(isSidebarCollapsedVariant('mid')).toBe(true);
+    expect(isSidebarCollapsedVariant('full')).toBe(false);
+  });
+});

--- a/src/crosshook-native/src/components/layout/sidebarVariants.ts
+++ b/src/crosshook-native/src/components/layout/sidebarVariants.ts
@@ -1,0 +1,29 @@
+import type { BreakpointSize } from '@/hooks/useBreakpoint';
+
+export type SidebarVariant = 'rail' | 'mid' | 'full';
+
+export const SIDEBAR_VARIANT_WIDTHS = {
+  rail: 56,
+  mid: 68,
+  full: 240,
+} as const satisfies Record<SidebarVariant, number>;
+
+export function sidebarVariantFromBreakpoint(size: BreakpointSize, height = 900): SidebarVariant {
+  switch (size) {
+    case 'deck':
+      return 'rail';
+    case 'narrow':
+      return height <= 820 ? 'rail' : 'mid';
+    case 'desk':
+    case 'uw':
+      return 'full';
+  }
+}
+
+export function sidebarWidthForVariant(variant: SidebarVariant): number {
+  return SIDEBAR_VARIANT_WIDTHS[variant];
+}
+
+export function isSidebarCollapsedVariant(variant: SidebarVariant): boolean {
+  return variant !== 'full';
+}

--- a/src/crosshook-native/src/styles/sidebar.css
+++ b/src/crosshook-native/src/styles/sidebar.css
@@ -10,6 +10,17 @@
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 26%), var(--crosshook-color-surface-strong);
   box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.02);
+  transition:
+    width var(--crosshook-transition-standard) ease,
+    padding var(--crosshook-transition-standard) ease;
+}
+
+.crosshook-sidebar[data-sidebar-variant='mid'] {
+  padding-inline: 10px;
+}
+
+.crosshook-sidebar[data-sidebar-variant='rail'] {
+  padding-inline: 8px;
 }
 
 .crosshook-sidebar__brand {
@@ -201,35 +212,25 @@
   text-transform: uppercase;
 }
 
-.crosshook-sidebar--collapsed,
 .crosshook-sidebar[data-collapsed='true'] {
-  width: var(--crosshook-sidebar-width-collapsed);
-  padding: 16px 8px;
   align-items: center;
 }
 
-.crosshook-sidebar--collapsed .crosshook-sidebar__brand,
-.crosshook-sidebar--collapsed .crosshook-sidebar__section-label,
-.crosshook-sidebar--collapsed .crosshook-sidebar__item-label,
-.crosshook-sidebar--collapsed .crosshook-sidebar__status,
-.crosshook-sidebar--collapsed .crosshook-sidebar__status-group,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__brand,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__section-label,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__item-label,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__status,
-.crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__status-group {
+.crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__status-group,
+.crosshook-sidebar[data-collapsed='true'] .crosshook-collections-sidebar__item-count,
+.crosshook-sidebar[data-collapsed='true'] .crosshook-collections-sidebar__empty-copy,
+.crosshook-sidebar[data-collapsed='true'] .crosshook-collections-sidebar__error {
   display: none;
 }
 
-.crosshook-sidebar--collapsed .crosshook-sidebar__brand-subtitle,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__brand-subtitle {
   display: none;
 }
 
-.crosshook-sidebar--collapsed .crosshook-sidebar__nav,
-.crosshook-sidebar--collapsed .crosshook-sidebar__section,
-.crosshook-sidebar--collapsed .crosshook-sidebar__section-items,
-.crosshook-sidebar--collapsed .crosshook-sidebar__footer,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__nav,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__section,
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__section-items,
@@ -237,10 +238,46 @@
   width: 100%;
 }
 
-.crosshook-sidebar--collapsed .crosshook-sidebar__item,
+.crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__brand {
+  min-height: 84px;
+  padding: 10px 0;
+  justify-content: center;
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__brand-content {
+  display: none;
+}
+
+.crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__brand-art {
+  width: 40px;
+  height: 40px;
+}
+
+.crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__section-items {
+  justify-items: center;
+}
+
 .crosshook-sidebar[data-collapsed='true'] .crosshook-sidebar__item {
   justify-content: center;
   padding-inline: 0;
+}
+
+.crosshook-sidebar[data-sidebar-variant='mid'] .crosshook-sidebar__item {
+  min-height: 46px;
+}
+
+.crosshook-sidebar[data-sidebar-variant='rail'] .crosshook-sidebar__item {
+  min-height: 44px;
+}
+
+.crosshook-sidebar[data-collapsed='true'] .crosshook-collections-sidebar__list {
+  gap: 6px;
+  max-height: none;
+  overflow: visible;
 }
 
 @media (max-height: 820px) {

--- a/src/crosshook-native/src/styles/theme.css
+++ b/src/crosshook-native/src/styles/theme.css
@@ -5880,6 +5880,16 @@ textarea {
   border-radius: var(--crosshook-radius-sm);
 }
 
+.crosshook-collections-sidebar__item-avatar {
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  background: rgba(74, 125, 181, 0.16);
+  color: var(--crosshook-color-accent-strong);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
 .crosshook-collections-sidebar__item:hover {
   background: rgba(255, 255, 255, 0.04);
 }

--- a/src/crosshook-native/src/styles/variables.css
+++ b/src/crosshook-native/src/styles/variables.css
@@ -120,8 +120,6 @@
   );
   --crosshook-page-header-gap: 10px;
   --crosshook-page-header-margin-bottom: 24px;
-  --crosshook-sidebar-width: 200px;
-  --crosshook-sidebar-width-collapsed: 56px;
   --crosshook-console-drawer-height: 280px;
   --crosshook-console-drawer-handle-height: 44px;
   /* Breathing room between route scroll content and the horizontal resize / collapsed console strip */


### PR DESCRIPTION
## Summary

Phase 3 of the unified-desktop redesign: wire the sidebar's full/mid/rail variants from `useBreakpoint` and formalize Collections as a declared `SIDEBAR_SECTIONS` entry so it renders in order between Game and Setup (no more mid-list injection).

Closes #415
Closes #442

## Changes

- New `sidebarVariants.ts` module — `SIDEBAR_VARIANT_WIDTHS` (rail 56 / mid 68 / full 240) and `sidebarVariantFromBreakpoint` (deck → rail, narrow → mid or rail when height ≤ 820, desk/uw → full).
- `AppShell` Panel sizing + `<aside>` width driven by the variant; pixel widths are owned by TS and applied via inline style so CSS cannot drift.
- `CollectionsSidebar` restructured as one branch of a generic `SidebarSectionBlock`; collection items now use letter-avatar icons and collapse cleanly under rail/mid.
- Section labels render as `<h2>` for heading-level a11y across every section.
- Vitest coverage: `Sidebar`, `CollectionsSidebar`, `AppShell` (variant wiring at deck and desktop sizes), `sidebarVariants`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

### Environment

- **Platform**: Linux desktop (browser dev mode smoke)

### Checklist

- [x] `./scripts/lint.sh` passes (two pre-existing warnings in untouched files remain)
- [x] `npm run typecheck` passes
- [x] `npm test -- --run` passes (15 files / 62 tests)
- [x] `./scripts/build-native.sh --binary-only` — not run (UI-only change; no Rust)
- [ ] `cargo test …` — not run (UI-only change)

## Reviewer Notes

- Acceptance criteria from #415 met: 1280×800 → ~56px rail; 1920×1080 → 240px full; Collections renders in declared section order (Game → Collections → Setup → Dashboards → Community), asserted in `AppShell.test.tsx` and `Sidebar.test.tsx`.
- **Width SSOT:** `SIDEBAR_VARIANT_WIDTHS` (TS) is the only place pixel widths live; the `<aside>` gets `style={{ width: \`${width}px\` }}` and CSS only carries per-variant padding tweaks keyed on `[data-sidebar-variant='…']`.
- **`data-collapsed` retained** (not dropped in favor of `:not([data-sidebar-variant='full'])`) to avoid rewriting ~20 existing CSS selectors. Documented in the fix artifact.
- Vertical `<Separator>` between the sidebar panel and the main panel was removed — with fixed min/max/default per variant there's nothing to drag. Flag if the PRD wants a temporary expand-affordance for rail/mid users.
- Pre-commit quick review + fixes captured under `docs/prps/reviews/` (second commit, `docs(internal):`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now intelligently adapts its width and layout based on screen size for optimized space usage.
  * Collections display visual avatars with collection initials for improved identification.

* **Improvements**
  * Enhanced accessibility with clearer labels on collection management actions.
  * Improved sidebar styling for better visual consistency across different screen sizes.
  * Removed manual sidebar resizing; width now adjusts automatically based on display size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->