### PR TITLE
feat(ui): add global command palette

### DIFF
--- a/docs/prps/plans/unified-desktop-phase-6-command-palette.plan.md
+++ b/docs/prps/plans/unified-desktop-phase-6-command-palette.plan.md
@@ -21,6 +21,21 @@ Today the only palette affordance is the optional `LibraryToolbar` button, and `
 - **GitHub Issues**: #445 tracking, #418 deliverable
 - **Persistence Classification**: runtime-only palette state (`open`, `query`, `activeIndex`, filtered command ids); no new TOML settings; no new SQLite tables or migrations.
 
+## Persistence and Usability
+
+1. **Classification by storage boundary**
+   - **User-editable preferences (TOML / settings UI)**: Phase 6 does not add palette-specific keys. Existing app preferences continue to use the normal TOML / settings path; nothing in the palette is persisted there.
+   - **Operational / history / cache (SQLite metadata DB)**: No new palette tables, command history, or recency. The v1 catalog is static in code; filtered results are derived in memory, not read from or written to SQLite.
+   - **Ephemeral runtime state (memory only)**: Palette visibility and interaction state—`open`, the search `query`, selection (exposed in the hook as `activeId` / `activeIndex` relative to the filtered list), and the **filtered command ids** (derived from the static catalog and query)—live only in React state and are cleared on close (`reset`).
+
+2. **Migration and backward compatibility**: There is no on-disk or schema-bound palette data to migrate across app versions. Upgrades do not need to transform palette fields; if an older build lacks the feature, it simply has no palette. Future persistence (e.g. recent commands) would be a follow-up with an explicit storage contract.
+
+3. **Offline behavior**: The palette UI and static catalog are fully client-side. Execution uses existing in-app route/profile flows. Network is not required to open, search, or run commands, except where an underlying feature already needs connectivity (the palette does not add a new online gate).
+
+4. **Degraded fallback (metadata / settings unavailable)**: The palette does not read TOML or SQLite directly. If the shell cannot supply profile-based commands (e.g. no active profile) or the app is in a degraded state, entries are disabled or omitted per existing catalog rules; the overlay should still open and list route commands. No separate “palette DB” failure mode.
+
+5. **User visibility and editability**: Users cannot edit the command list or add shortcuts in Phase 6. While the dialog is open, they can only change the search `query` and move selection; closing discards that ephemeral state. There is no palette screen under Settings for v1.
+
 ## Batches
 
 Tasks grouped by dependency for parallel execution. Tasks within the same batch run concurrently; batches run in order.

--- a/docs/prps/plans/unified-desktop-phase-6-command-palette.plan.md
+++ b/docs/prps/plans/unified-desktop-phase-6-command-palette.plan.md
@@ -1,0 +1,449 @@
+# Plan: Unified Desktop Phase 6 Command Palette
+
+## Summary
+
+Implement Phase 6 of the Unified Desktop Redesign from GitHub issue #445 / #418: replace the Library-local `console.debug` placeholder with a real hand-rolled command palette that opens from `Cmd/Ctrl+K` anywhere in the shell. The palette stays dependency-free, uses a static command catalog plus substring filtering, reuses the existing modal focus-trap contract, and executes route/profile actions without adding new Tauri commands or persistence.
+
+## User Story
+
+As a CrossHook power user, I want a global command palette for navigation and profile actions, so that I can jump to common destinations and actions without changing routes manually or reaching for the mouse.
+
+## Problem -> Solution
+
+Today the only palette affordance is the optional `LibraryToolbar` button, and `LibraryPage` still handles it with `console.debug('Command palette (Phase 6)')`. Phase 6 moves ownership into `AppShell`: `AppShell` registers the global shortcut, builds the runtime command list from current route/profile state, renders a portaled `CommandPalette`, and passes an `onOpenCommandPalette` callback down to the Library toolbar so both entry points use the same overlay and execution path.
+
+## Metadata
+
+- **Complexity**: Large
+- **Source PRD**: `docs/prps/prds/unified-desktop-redesign.prd.md`
+- **PRD Phase**: Phase 6 - ⌘K command palette
+- **Estimated Files**: 13
+- **GitHub Issues**: #445 tracking, #418 deliverable
+- **Persistence Classification**: runtime-only palette state (`open`, `query`, `activeIndex`, filtered command ids); no new TOML settings; no new SQLite tables or migrations.
+
+## Batches
+
+Tasks grouped by dependency for parallel execution. Tasks within the same batch run concurrently; batches run in order.
+
+| Batch | Tasks         | Depends On | Parallel Width |
+| ----- | ------------- | ---------- | -------------- |
+| B1    | 1.1, 1.2, 1.3 | -          | 3              |
+| B2    | 2.1, 2.2      | B1         | 2              |
+| B3    | 3.1, 3.2, 3.3 | B2         | 3              |
+
+- **Total tasks**: 8
+- **Total batches**: 3
+- **Max parallel width**: 3
+
+---
+
+## UX Design
+
+### Before
+
+```text
+AppShell
+├─ route state + sidebar + content
+├─ LibraryPage
+│  └─ LibraryToolbar button: "⌘K"
+│     └─ LibraryPage callback -> console.debug(...)
+└─ No global shortcut, no overlay, no command execution
+```
+
+### After
+
+```text
+AppShell
+├─ route state + sidebar + content
+├─ global Cmd/Ctrl+K listener
+├─ useCommandPalette state
+├─ CommandPalette portal
+│  ├─ search input
+│  ├─ icon + label + optional hint rows
+│  ├─ arrow-key selection + Enter execute
+│  └─ Esc / close button restores focus
+└─ LibraryToolbar button delegates to the same open() path
+```
+
+### Interaction Changes
+
+| Touchpoint              | Before                              | After                                                                                               | Notes                                                              |
+| ----------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `Cmd/Ctrl+K`            | No-op everywhere                    | Opens palette over the current shell mode                                                           | Implemented in `AppShell`, not per-page                            |
+| Library toolbar trigger | Calls page-local placeholder logger | Opens the shared palette                                                                            | Keeps the existing button contract but changes the target behavior |
+| Querying commands       | Not available                       | Case-insensitive substring filter over static labels and keywords                                   | No fuzzy scoring or recency                                        |
+| Keyboard navigation     | Not available                       | `ArrowDown` / `ArrowUp` move active option; `Enter` executes; `Esc` closes                          | Must coexist with `useFocusTrap` and `useScrollEnhance`            |
+| Closing palette         | Not available                       | Escape, backdrop click, or Close button restores focus to the invoking element when still connected | Reuse modal focus-trap behavior                                    |
+| Executing commands      | Not available                       | Route commands call `setRoute`; profile actions call `selectProfile(...)` then navigate             | No new backend command surface                                     |
+
+---
+
+## Mandatory Reading
+
+Files that MUST be read before implementing:
+
+| Priority | File                                                                       | Lines            | Why                                                                                                      |
+| -------- | -------------------------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| P0       | `docs/prps/prds/unified-desktop-redesign.prd.md`                           | 253-257          | Phase 6 goal, scope, and success signal define the acceptance contract.                                  |
+| P0       | `src/crosshook-native/src/App.tsx`                                         | 15-27, 29-48     | Global app-level hooks already handle scroll enhancement and gamepad-back modal close behavior.          |
+| P0       | `src/crosshook-native/src/components/layout/AppShell.tsx`                  | 50-64, 172-240   | Owns route state, shell layout, and the only correct place for the global shortcut and shared overlay.   |
+| P0       | `src/crosshook-native/src/components/layout/ContentArea.tsx`               | 16-19, 37-60     | Current route-to-page dispatch contract for threading `onOpenCommandPalette` down to Library.            |
+| P0       | `src/crosshook-native/src/components/pages/LibraryPage.tsx`                | 121-170, 236-302 | Existing launch/edit/detail handlers plus the current palette placeholder entry point.                   |
+| P0       | `src/crosshook-native/src/hooks/useFocusTrap.ts`                           | 172-307          | Shared modal contract: body lock, inert siblings, Escape ownership, Tab trapping, and focus restoration. |
+| P1       | `src/crosshook-native/src/hooks/useScrollEnhance.ts`                       | 8-10, 96-126     | Scrollable selector and keyboard-scroll logic that the palette list must integrate with.                 |
+| P1       | `src/crosshook-native/src/components/library/LibraryToolbar.tsx`           | 15-25, 117-125   | Existing optional toolbar trigger contract that should remain additive.                                  |
+| P1       | `src/crosshook-native/src/components/layout/routeMetadata.ts`              | 31-139           | Current route labels and route inventory for navigation commands.                                        |
+| P1       | `src/crosshook-native/src/lib/validAppRoutes.ts`                           | 1-20             | Runtime route validation pattern for any string-to-route execution path.                                 |
+| P1       | `src/crosshook-native/src/main.tsx`                                        | 4-15             | Global stylesheet import contract if a dedicated `palette.css` file is added.                            |
+| P1       | `src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx` | 54-188           | Existing Library harness and expectations around the toolbar trigger and detail persistence.             |
+| P1       | `src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx`   | 79-188           | Full-shell integration harness for keyboard shortcuts and sidebar/inspector assertions.                  |
+| P1       | `src/crosshook-native/tests/smoke.spec.ts`                                 | 51-174           | Browser-dev smoke style and zero-console-error enforcement to extend for the palette flow.               |
+
+## External Documentation
+
+| Topic         | Source | Key Takeaway                                                                                                    |
+| ------------- | ------ | --------------------------------------------------------------------------------------------------------------- |
+| External docs | none   | No external library/API research is needed; the Phase 6 contract is fully covered by repo patterns and the PRD. |
+
+---
+
+## Patterns to Mirror
+
+Code patterns discovered in the codebase. Follow these exactly.
+
+### STATIC_RECORD_PATTERN
+
+```ts
+// SOURCE: src/crosshook-native/src/lib/validAppRoutes.ts:3-19
+const VALID_APP_ROUTES: Record<AppRoute, true> = {
+  library: true,
+  profiles: true,
+  launch: true,
+};
+```
+
+Keep the command catalog static and typed with `Record<Union, ...>` or readonly arrays plus narrow helpers. Do not build the v1 palette around free-form strings or ad hoc object literals scattered across components.
+
+### HOOK_CONTRACT_PATTERN
+
+```ts
+// SOURCE: src/crosshook-native/src/hooks/useFocusTrap.ts:10-37
+export interface UseFocusTrapOptions {
+  open: boolean;
+  panelRef: RefObject<HTMLElement | null>;
+  onClose: () => void;
+}
+```
+
+`useCommandPalette` should follow the same `UseXOptions` / `UseXReturn` naming style and return a stable, explicit contract instead of leaking raw implementation state across `AppShell` and `CommandPalette`.
+
+### OPTIONAL_CALLBACK_PATTERN
+
+```tsx
+// SOURCE: src/crosshook-native/src/components/library/LibraryToolbar.tsx:15-25
+interface LibraryToolbarProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  onOpenCommandPalette?: () => void;
+}
+```
+
+Keep palette wiring additive. Thread `onOpenCommandPalette?: () => void` through `ContentArea` / `LibraryPage` without making the Library route depend on the palette implementation details.
+
+### ROUTE_AND_ACTION_PATTERN
+
+```tsx
+// SOURCE: src/crosshook-native/src/components/pages/LibraryPage.tsx:121-135
+setLaunchingName(name);
+try {
+  await selectProfile(name, { collectionId: collectionIdForLoad });
+  onNavigate?.('launch');
+} finally {
+  setLaunchingName(undefined);
+}
+```
+
+Command execution should reuse the existing action flow: call `selectProfile(...)` first for profile commands, then navigate. Do not introduce duplicate launch/edit state machines inside the palette component.
+
+### FOCUS_TRAP_PATTERN
+
+```tsx
+// SOURCE: src/crosshook-native/src/hooks/useFocusTrap.ts:215-223, 258-274
+const frame = window.requestAnimationFrame(() => {
+  const focusable = panel ? getFocusableElements(panel) : [];
+  if (focusable.length > 0) focusElement(focusable[0]);
+});
+queueMicrotask(() => {
+  if (restoreTarget?.isConnected) focusElement(restoreTarget);
+});
+```
+
+The palette must use the shared trap instead of inventing its own modal stack. Preserve the open-focus / close-restore semantics and keep `data-crosshook-focus-root="modal"` on the dialog surface.
+
+### KEYBOARD_LIST_PATTERN
+
+```tsx
+// SOURCE: src/crosshook-native/src/components/collections/CollectionAssignMenu.tsx:148-161
+if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+  event.preventDefault();
+  const idx = focusable.indexOf(document.activeElement as HTMLElement);
+  next = event.key === 'ArrowDown' ? idx + 1 : idx - 1;
+}
+```
+
+Mirror the existing arrow-key list navigation pattern for palette results. Whether the active option is focused directly or scrolled into view via refs, wrap at the ends and keep the behavior deterministic.
+
+### SCROLL_SELECTOR_PATTERN
+
+```ts
+// SOURCE: src/crosshook-native/src/hooks/useScrollEnhance.ts:8-10
+const SCROLLABLE = '.crosshook-route-card-scroll, ... , .crosshook-inspector__body, .crosshook-hero-detail__body';
+```
+
+Any new scrollable palette result list must be added to `SCROLLABLE` and styled with `overscroll-behavior: contain`; otherwise WebKitGTK will scroll the parent container and introduce dual-scroll jank.
+
+### TEST_TAB_ORDER_PATTERN
+
+```tsx
+// SOURCE: src/crosshook-native/src/components/library/__tests__/LibraryToolbar.test.tsx:54-78
+await user.tab();
+expect(screen.getByRole('searchbox', { name: 'Search games' })).toHaveFocus();
+await user.tab();
+expect(screen.getByRole('button', { name: 'Recent' })).toHaveFocus();
+```
+
+Use role-based, sequential keyboard assertions for palette focus order. Avoid brittle class-based selectors in RTL tests.
+
+### SMOKE_ERROR_CAPTURE_PATTERN
+
+```ts
+// SOURCE: src/crosshook-native/tests/helpers.ts:7-17
+page.on('pageerror', (err) => {
+  capture.errors.push(`pageerror: ${err.message}`);
+});
+```
+
+Palette smoke coverage must remain zero-error. If the new overlay emits `console.error` or unhandled exceptions in browser dev mode, treat that as a regression even when the UI still appears to work.
+
+---
+
+## Files to Change
+
+| File                                                                            | Action | Justification                                                                                                               |
+| ------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `src/crosshook-native/src/lib/commands.ts`                                      | CREATE | Static, typed command catalog and substring-match helpers for route and profile actions.                                    |
+| `src/crosshook-native/src/hooks/useCommandPalette.ts`                           | CREATE | Shared open/query/selection/filter state and keyboard action helpers owned by `AppShell`.                                   |
+| `src/crosshook-native/src/components/palette/CommandPalette.tsx`                | CREATE | Portaled focus-trapped overlay surface with search input, result list, icons, and execution affordances.                    |
+| `src/crosshook-native/src/components/palette/__tests__/CommandPalette.test.tsx` | CREATE | Unit coverage for filtering, arrow navigation, execute-on-enter, close paths, and empty state rendering.                    |
+| `src/crosshook-native/src/styles/palette.css`                                   | CREATE | Dedicated BEM-style overlay, list, row, and state styles to keep palette chrome out of `theme.css`.                         |
+| `src/crosshook-native/src/main.tsx`                                             | UPDATE | Import the new stylesheet into the frontend bundle.                                                                         |
+| `src/crosshook-native/src/hooks/useScrollEnhance.ts`                            | UPDATE | Register `.crosshook-palette__list` in `SCROLLABLE` so wheel/keyboard scroll targets the result list.                       |
+| `src/crosshook-native/src/components/layout/AppShell.tsx`                       | UPDATE | Own palette state, register the global shortcut, execute commands, and render the shared overlay.                           |
+| `src/crosshook-native/src/components/layout/ContentArea.tsx`                    | UPDATE | Thread an optional `onOpenCommandPalette` callback through to `LibraryPage`.                                                |
+| `src/crosshook-native/src/components/pages/LibraryPage.tsx`                     | UPDATE | Replace the placeholder logger with a page-to-shell callback and keep the toolbar trigger visible after detail transitions. |
+| `src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx`        | UPDATE | Full-shell assertions for `Ctrl/Cmd+K`, route execution, and focus restoration.                                             |
+| `src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx`      | UPDATE | Library route assertions that the toolbar trigger delegates upward and still survives detail/back flows.                    |
+| `src/crosshook-native/tests/smoke.spec.ts`                                      | UPDATE | Browser-dev smoke for open/close, keyboard navigation, command execution, and zero-console-error behavior.                  |
+
+## NOT Building
+
+- No new npm dependency such as `cmdk`, `kbar`, `react-router-dom`, or a hotkey package.
+- No fuzzy matching, ranking, recency memory, or persisted “recent commands” list.
+- No new Tauri command, Rust IPC handler, SQLite migration, or TOML setting.
+- No URL routing or route-history integration; palette navigation still mutates `AppRoute` state in `AppShell`.
+- No gamepad-nav zone refactor; the palette participates as a modal via the existing `data-crosshook-focus-root="modal"` contract.
+- No command authoring UI or user-editable command registry; v1 ships a hand-authored static catalog only.
+
+---
+
+## Step-by-Step Tasks
+
+### Task 1.1: Add a typed static command catalog module — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `src/crosshook-native/src/lib/commands.ts`.
+- **IMPLEMENT**: Define the static v1 command shape, action union, icon ids, keyword aliases, and helpers for case-insensitive substring matching. Keep route commands hand-authored and typed against `AppRoute`; model active-profile actions as separate typed entries so `AppShell` can enable/disable or inject them without stringly logic.
+- **MIRROR**: `STATIC_RECORD_PATTERN`, `HOOK_CONTRACT_PATTERN`, `Type Definitions` findings from the discovery tables.
+- **IMPORTS**: `AppRoute` from `@/components/layout/Sidebar`; no component imports.
+- **GOTCHA**: Do not import `ROUTE_METADATA` into `src/lib`; that would drag component-level dependencies into the catalog. Keep the module UI-agnostic and use icon ids rather than JSX.
+- **VALIDATE**: `cd src/crosshook-native && npm run typecheck` passes with no implicit-`any` or unused export errors in the new module.
+
+### Task 1.2: Create `useCommandPalette` state and selection helpers — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `src/crosshook-native/src/hooks/useCommandPalette.ts`.
+- **IMPLEMENT**: Expose explicit hook types for open/close state, query text, filtered command list, active index/id, `setQuery`, `moveActive(delta)`, `reset`, and `executeActive`. Reset the query and selection when closing; when the filtered list changes, clamp or reset the active index so Enter never executes a stale command.
+- **MIRROR**: `HOOK_CONTRACT_PATTERN`, `KEYBOARD_LIST_PATTERN`.
+- **IMPORTS**: React hooks, command types/helpers from `@/lib/commands`.
+- **GOTCHA**: The active selection must remain stable across rerenders but must also recover cleanly when the query yields zero results. Avoid storing a bare array index without clamping it against the filtered list.
+- **VALIDATE**: Typecheck passes and the hook can be consumed from `AppShell` without additional wrapper state.
+
+### Task 1.3: Add palette styles and scroll registration — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `src/crosshook-native/src/styles/palette.css`, import it from `src/crosshook-native/src/main.tsx`, and update `src/crosshook-native/src/hooks/useScrollEnhance.ts`.
+- **IMPLEMENT**: Add `crosshook-palette*` classes for the shell, header, search input, results list, row states, empty state, and hint chip. Reuse the shared `.crosshook-modal` / `.crosshook-modal__surface` base styles via a palette-specific modifier class instead of duplicating the full modal chrome. Append `.crosshook-palette__list` to `SCROLLABLE` and set `overflow-y: auto; overscroll-behavior: contain;` on the list container.
+- **MIRROR**: `SCROLL_SELECTOR_PATTERN`, existing modal surface styling in `theme.css`.
+- **IMPORTS**: stylesheet import in `main.tsx`; no runtime code imports.
+- **GOTCHA**: The palette list is the scroll target, not the whole modal body. If the list is not whitelisted in `SCROLLABLE`, ArrowUp/ArrowDown will scroll the parent route body instead of the overlay.
+- **VALIDATE**: Browser build still includes all stylesheets, and `useScrollEnhance.ts` contains `.crosshook-palette__list` exactly once.
+
+### Task 2.1: Build the `CommandPalette` overlay component — Depends on [1.1, 1.2, 1.3]
+
+- **BATCH**: B2
+- **ACTION**: Create `src/crosshook-native/src/components/palette/CommandPalette.tsx`.
+- **IMPLEMENT**: Render a portaled modal dialog using `createPortal`, the shared `useFocusTrap`, a close button marked with `data-crosshook-modal-close`, a search field, and a result list with icon, label, and optional hint. Compose the focus-trap `handleKeyDown` with palette-specific ArrowUp/ArrowDown/Enter handlers, and scroll the active row into view when selection changes. Support empty-state rendering when no commands match.
+- **MIRROR**: `FOCUS_TRAP_PATTERN`, `KEYBOARD_LIST_PATTERN`, `OPTIONAL_CALLBACK_PATTERN`.
+- **IMPORTS**: `createPortal`, `useRef`, `useFocusTrap`, command types from `@/lib/commands`, and existing icon components from `@/components/icons/SidebarIcons`.
+- **GOTCHA**: `App.tsx` gamepad-back closes the topmost modal by querying `[data-crosshook-focus-root="modal"] [data-crosshook-modal-close]`. Without the close button marker, controller back will regress even if keyboard Escape still works.
+- **VALIDATE**: The component can render open/closed in isolation, and Escape / backdrop / close button all hit the same `onClose` path.
+
+### Task 2.2: Wire `AppShell`, `ContentArea`, and `LibraryPage` to the shared palette — Depends on [1.1, 1.2, 1.3]
+
+- **BATCH**: B2
+- **ACTION**: Update `src/crosshook-native/src/components/layout/AppShell.tsx`, `src/crosshook-native/src/components/layout/ContentArea.tsx`, and `src/crosshook-native/src/components/pages/LibraryPage.tsx`.
+- **IMPLEMENT**: Make `AppShell` own the command list and palette state, register a document-level `Cmd/Ctrl+K` listener, render `CommandPalette`, and execute commands by calling `setRoute(...)` or `selectProfile(...)` plus navigation. Thread `onOpenCommandPalette?: () => void` through `ContentArea` to `LibraryPage` so the existing toolbar trigger opens the same overlay, replacing the placeholder logger. Keep all route changes inside the existing `AppRoute` contract and do not add new IPC.
+- **MIRROR**: `ROUTE_AND_ACTION_PATTERN`, `OPTIONAL_CALLBACK_PATTERN`, `Data Flow` findings from the discovery tables.
+- **IMPORTS**: `useCommandPalette`, `CommandPalette`, `type AppRoute`, `selectProfile` from the existing profile context usage already present in `AppShell`.
+- **GOTCHA**: Guard the global key listener against duplicate fires (`event.repeat`) and unsupported modifier combinations. The handler should `preventDefault()` for the shortcut, but it must not hijack unrelated keyboard flow once the palette is already open.
+- **VALIDATE**: `Ctrl/Cmd+K` opens from any route, the Library toolbar button opens the same palette, and choosing a route command updates the selected sidebar tab.
+
+### Task 3.1: Add palette unit tests and update LibraryPage delegation coverage — Depends on [2.1, 2.2]
+
+- **BATCH**: B3
+- **ACTION**: Create `src/crosshook-native/src/components/palette/__tests__/CommandPalette.test.tsx` and update `src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx`.
+- **IMPLEMENT**: Cover render/open state, substring filtering, empty results, ArrowUp/ArrowDown wrap, Enter execution, Escape close, and click execution for `CommandPalette`. In `LibraryPage.test.tsx`, stop asserting `console.debug` and instead assert that clicking the toolbar trigger calls the delegated `onOpenCommandPalette` callback while existing detail/back assertions still pass.
+- **MIRROR**: `TEST_TAB_ORDER_PATTERN`, existing `LibraryPage` harness/provider setup.
+- **IMPORTS**: `render`, `screen`, `waitFor`, `userEvent`, `vi`, and the existing test helpers already used by page tests.
+- **GOTCHA**: Keep tests role-driven. Avoid asserting implementation details such as internal active-index state when the visible selection/focus contract is enough.
+- **VALIDATE**: `cd src/crosshook-native && npm test -- src/components/palette/__tests__/CommandPalette.test.tsx src/components/pages/__tests__/LibraryPage.test.tsx`
+
+### Task 3.2: Extend full-shell `AppShell` integration coverage — Depends on [2.1, 2.2]
+
+- **BATCH**: B3
+- **ACTION**: Update `src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx`.
+- **IMPLEMENT**: Add integration cases for opening the palette with `Ctrl+K`, executing a route command, and restoring focus to the Library toolbar trigger after closing from a button-opened palette. Keep the existing viewport mocking and provider harness patterns intact.
+- **MIRROR**: existing `AppShell` integration setup and the focus expectations used by current keyboard tests.
+- **IMPORTS**: existing test harness utilities plus `fireEvent` only if keyboard shortcut dispatch is cleaner than `user.keyboard`.
+- **GOTCHA**: Use `Ctrl+K` in tests unless a specific environment requires `Meta`; the implementation should support both, but CI/test environments are Linux-first.
+- **VALIDATE**: `cd src/crosshook-native && npm test -- src/components/layout/__tests__/AppShell.test.tsx`
+
+### Task 3.3: Add browser-dev smoke coverage for the palette flow — Depends on [2.1, 2.2]
+
+- **BATCH**: B3
+- **ACTION**: Update `src/crosshook-native/tests/smoke.spec.ts`.
+- **IMPLEMENT**: Add a smoke case that opens the palette with the keyboard, filters to a known route command such as Settings or Proton Manager, executes it with Enter, and asserts the destination route is active. Add an explicit open/close case from the Library toolbar trigger if needed to protect the button path. Keep zero-console-error enforcement via `attachConsoleCapture`.
+- **MIRROR**: `SMOKE_ERROR_CAPTURE_PATTERN`, existing role-based route assertions in `smoke.spec.ts`.
+- **IMPORTS**: no new helpers unless a tiny local helper reduces repeated keypress boilerplate.
+- **GOTCHA**: Browser-dev mode is mock-backed; do not add assertions that require new backend commands or real filesystem/network behavior.
+- **VALIDATE**: `cd src/crosshook-native && npm run test:smoke`
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test               | Input                                               | Expected Output                                                         | Edge Case? |
+| ------------------ | --------------------------------------------------- | ----------------------------------------------------------------------- | ---------- |
+| Command filtering  | query `set` against route + profile commands        | Only commands whose label/keywords contain `set` remain                 | No         |
+| Selection wrap     | active index at first/last item + ArrowUp/ArrowDown | Selection wraps to the opposite end                                     | Yes        |
+| Enter execution    | active command selected + Enter                     | `onExecute` receives the active command exactly once and palette closes | No         |
+| Empty results      | query with no matches                               | Empty-state copy renders; Enter is a no-op                              | Yes        |
+| Toolbar delegation | click `Open command palette` in `LibraryPage`       | delegated `onOpenCommandPalette` callback fires                         | No         |
+| AppShell shortcut  | `Ctrl+K` on an active shell route                   | Palette dialog opens and focus lands inside it                          | No         |
+| Focus restoration  | open from toolbar trigger, then Escape/Close        | Trigger regains focus if still connected                                | Yes        |
+
+### Edge Cases Checklist
+
+- [ ] `Ctrl+K` and `Meta+K` both open the palette
+- [ ] Repeated shortcut press while the palette is already open does not duplicate overlays or reset unexpectedly
+- [ ] Query with zero matches does not execute anything on Enter
+- [ ] Active-profile commands are hidden or disabled when no profile is selected
+- [ ] Arrow keys do not scroll the underlying route while the palette list is active
+- [ ] Closing from backdrop, Escape, and Close button all restore focus consistently
+- [ ] Browser dev mode stays green with no `console.error` / `pageerror`
+- [ ] Library detail mode still shows the toolbar trigger after Back
+
+---
+
+## Validation Commands
+
+### Static Analysis
+
+```bash
+cd src/crosshook-native && npm run typecheck
+```
+
+EXPECT: Zero TypeScript errors in the new palette files and updated shell/page/test surfaces.
+
+### Unit Tests
+
+```bash
+cd src/crosshook-native && npm test -- src/components/palette/__tests__/CommandPalette.test.tsx src/components/layout/__tests__/AppShell.test.tsx src/components/pages/__tests__/LibraryPage.test.tsx
+```
+
+EXPECT: Palette unit tests, shell integration tests, and Library delegation tests all pass.
+
+### Full Test Suite
+
+```bash
+./scripts/lint.sh
+```
+
+EXPECT: Biome, repo sentinels, and other configured checks pass with no new frontend regressions.
+
+### Browser Validation
+
+```bash
+cd src/crosshook-native && npm run test:smoke
+```
+
+EXPECT: Browser-dev smoke passes, including the new palette case, with zero captured `console.error` / `pageerror` output.
+
+### Manual Validation
+
+- [ ] Start browser dev mode with `./scripts/dev-native.sh --browser` and verify `Ctrl/Cmd+K` opens from Library, Health, and Settings.
+- [ ] From Library, click `Open command palette`, press `Escape`, and confirm focus returns to the toolbar trigger.
+- [ ] Type a partial query such as `host` and execute the Host Tools command with Enter.
+- [ ] Type a query that yields no matches and confirm the empty state is rendered with no accidental navigation.
+- [ ] On a long result list, use ArrowDown until scrolling is required and confirm the list scrolls instead of the background route.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `Cmd/Ctrl+K` opens a focus-trapped command palette from any route
+- [ ] Library toolbar trigger opens the same palette instead of logging a placeholder
+- [ ] Palette uses a static typed command catalog with substring filtering only
+- [ ] ArrowUp/ArrowDown move the active result; Enter executes; Escape closes
+- [ ] Focus returns to the invoking element when the palette closes and that element is still connected
+- [ ] `.crosshook-palette__list` is registered in `useScrollEnhance`
+- [ ] No new dependency, Tauri command, SQLite table, or TOML setting is added
+- [ ] Typecheck, targeted tests, lint, and smoke coverage all pass
+
+## Completion Checklist
+
+- [ ] Code follows the discovered static-record and hook-contract patterns
+- [ ] Overlay behavior reuses `useFocusTrap` rather than inventing a second modal system
+- [ ] Route/profile command execution reuses existing `selectProfile(...)` plus navigation flows
+- [ ] Palette styling stays modular in a dedicated stylesheet and uses `crosshook-*` BEM naming
+- [ ] Tests remain role-based and readable
+- [ ] Browser-dev mode works without new mock handlers
+- [ ] Scope stays inside Phase 6; no fuzzy ranking or persistence slips in
+- [ ] Implementation is self-contained and ready for `prp-implement --parallel`
+
+## Risks
+
+| Risk                                                                                                    | Likelihood | Impact | Mitigation                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Global shortcut conflicts with existing keyboard handling or repeats excessively                        | M          | M      | Guard on `event.repeat`, support both `ctrlKey` and `metaKey`, and keep the handler centralized in `AppShell`                                   |
+| Palette rows drift from route labels maintained elsewhere                                               | M          | M      | Keep route ids typed against `AppRoute`; either reuse existing labels intentionally or document the duplicated strings clearly in `commands.ts` |
+| Focus restoration or controller-back behavior regresses because the overlay misses shared modal markers | M          | H      | Use `useFocusTrap`, keep `data-crosshook-focus-root="modal"`, and render a close button with `data-crosshook-modal-close`                       |
+| Arrow keys scroll the background route instead of the results list                                      | H          | M      | Add `.crosshook-palette__list` to `SCROLLABLE`, mark the result container as interactive, and cover keyboard navigation in RTL + smoke          |
+| Profile actions behave inconsistently when no profile is selected                                       | M          | M      | Model active-profile commands explicitly and hide/disable them when selection state is missing                                                  |
+
+## Notes
+
+- External research was intentionally skipped; the PRD and existing overlay/navigation patterns are sufficient for a self-contained Phase 6 plan.
+- Persistence remains runtime-only for Phase 6. If future work adds recent-command memory or palette preferences, that should be planned as a separate issue with an explicit storage-boundary section.

--- a/src/crosshook-native/src/components/layout/AppShell.tsx
+++ b/src/crosshook-native/src/components/layout/AppShell.tsx
@@ -11,6 +11,7 @@ import ControllerPrompts from '@/components/layout/ControllerPrompts';
 import { Inspector } from '@/components/layout/Inspector';
 import Sidebar, { type AppRoute } from '@/components/layout/Sidebar';
 import { OnboardingWizard } from '@/components/OnboardingWizard';
+import { CommandPalette } from '@/components/palette/CommandPalette';
 import { useInspectorSelection } from '@/context/InspectorSelectionContext';
 import { LaunchStateProvider } from '@/context/LaunchStateContext';
 import { PreferencesProvider, usePreferencesContext } from '@/context/PreferencesContext';
@@ -18,7 +19,14 @@ import { useProfileContext } from '@/context/ProfileContext';
 import { useHighContrastTheme } from '@/hooks/useAccessibilityEnhancements';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useCollections } from '@/hooks/useCollections';
+import { useCommandPalette } from '@/hooks/useCommandPalette';
 import { useFlatpakMigrationToast } from '@/hooks/useFlatpakMigrationToast';
+import {
+  type CommandPaletteCommand,
+  createProfileCommands,
+  isCommandPaletteCommandEnabled,
+  ROUTE_COMMANDS,
+} from '@/lib/commands';
 import { subscribeEvent } from '@/lib/events';
 import { isAppRoute } from '@/lib/validAppRoutes';
 import type { OnboardingCheckPayload } from '@/types/onboarding';
@@ -52,8 +60,10 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
     useProfileContext();
   const [route, setRoute] = useState<AppRoute>('library');
   const lastProfile = profileName.trim() || selectedProfile;
+  const activeProfileName = selectedProfile.trim();
   const shellRef = useRef<HTMLDivElement>(null);
   const consolePanelRef = useRef<PanelImperativeHandle>(null);
+  const paletteRestoreTargetRef = useRef<HTMLElement | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const breakpoint = useBreakpoint(shellRef);
   const sidebarVariant = sidebarVariantFromBreakpoint(breakpoint.size, breakpoint.height);
@@ -169,6 +179,122 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
     setShowOnboarding(false);
   }, []);
 
+  const commands = useMemo<readonly CommandPaletteCommand[]>(() => {
+    return [...ROUTE_COMMANDS, ...createProfileCommands(activeProfileName)];
+  }, [activeProfileName]);
+
+  const handleExecuteCommand = useCallback(
+    async (command: CommandPaletteCommand) => {
+      if (!isCommandPaletteCommandEnabled(command)) {
+        return;
+      }
+
+      switch (command.action) {
+        case 'route':
+          setRoute(command.route);
+          return;
+        case 'launch_profile':
+          await selectProfile(command.profileName);
+          setRoute('launch');
+          return;
+        case 'edit_profile':
+          await selectProfile(command.profileName);
+          setRoute('profiles');
+          return;
+        default: {
+          const _exhaustive: never = command;
+          return _exhaustive;
+        }
+      }
+    },
+    [selectProfile, setRoute]
+  );
+
+  const {
+    open: paletteOpen,
+    query: paletteQuery,
+    filteredCommands,
+    activeId: paletteActiveId,
+    openPalette: openPaletteFromHook,
+    closePalette,
+    setQuery: setPaletteQuery,
+    moveActive,
+  } = useCommandPalette({
+    commands,
+    onExecuteCommand: async (command) => {
+      await handleExecuteCommand(command);
+    },
+  });
+
+  const handleExecutePaletteCommand = useCallback(
+    async (command: CommandPaletteCommand) => {
+      await handleExecuteCommand(command);
+      closePalette();
+    },
+    [closePalette, handleExecuteCommand]
+  );
+
+  const openPalette = useCallback(
+    (restoreFocusTo?: HTMLElement | null) => {
+      if (restoreFocusTo instanceof HTMLElement && restoreFocusTo.isConnected) {
+        paletteRestoreTargetRef.current = restoreFocusTo;
+      } else if (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement) {
+        paletteRestoreTargetRef.current = document.activeElement;
+      } else {
+        paletteRestoreTargetRef.current = null;
+      }
+
+      openPaletteFromHook();
+    },
+    [openPaletteFromHook]
+  );
+
+  const handleClosePalette = useCallback(() => {
+    const restoreTarget = paletteRestoreTargetRef.current;
+    paletteRestoreTargetRef.current = null;
+    closePalette();
+
+    if (restoreTarget instanceof HTMLElement) {
+      queueMicrotask(() => {
+        if (restoreTarget.isConnected) {
+          restoreTarget.focus();
+        }
+      });
+    }
+  }, [closePalette]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const handleDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) {
+        return;
+      }
+
+      if (event.key.toLowerCase() !== 'k') {
+        return;
+      }
+
+      if ((!event.ctrlKey && !event.metaKey) || event.altKey || event.shiftKey) {
+        return;
+      }
+
+      event.preventDefault();
+      if (paletteOpen) {
+        return;
+      }
+
+      openPalette();
+    };
+
+    document.addEventListener('keydown', handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleDocumentKeyDown);
+    };
+  }, [openPalette, paletteOpen]);
+
   return (
     <Tooltip.Provider delayDuration={200}>
       <PreferencesProvider activeProfileName={lastProfile}>
@@ -211,7 +337,7 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
                     resizeTargetMinimumSize={{ coarse: 36, fine: 12 }}
                   >
                     <Panel className="crosshook-shell-panel" defaultSize="80%" minSize="28%">
-                      <ContentArea route={route} onNavigate={setRoute} />
+                      <ContentArea route={route} onNavigate={setRoute} onOpenCommandPalette={openPalette} />
                     </Panel>
                     <Separator className="crosshook-resize-handle crosshook-resize-handle--horizontal" />
                     <Panel
@@ -256,6 +382,16 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
               onOpenHostToolDashboard={handleOpenOnboardingHostToolDashboard}
             />
           )}
+          <CommandPalette
+            open={paletteOpen}
+            query={paletteQuery}
+            commands={filteredCommands}
+            activeId={paletteActiveId}
+            onClose={handleClosePalette}
+            onQueryChange={setPaletteQuery}
+            onMoveActive={moveActive}
+            onExecuteCommand={handleExecutePaletteCommand}
+          />
           <CollectionViewModal
             open={collectionModalOpen}
             collectionId={openCollectionId}

--- a/src/crosshook-native/src/components/layout/AppShell.tsx
+++ b/src/crosshook-native/src/components/layout/AppShell.tsx
@@ -221,9 +221,6 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
     moveActive,
   } = useCommandPalette({
     commands,
-    onExecuteCommand: async (command) => {
-      await handleExecuteCommand(command);
-    },
   });
 
   const handleExecutePaletteCommand = useCallback(

--- a/src/crosshook-native/src/components/layout/ContentArea.tsx
+++ b/src/crosshook-native/src/components/layout/ContentArea.tsx
@@ -16,9 +16,10 @@ import type { AppRoute } from './Sidebar';
 export interface ContentAreaProps {
   route: AppRoute;
   onNavigate?: (route: AppRoute) => void;
+  onOpenCommandPalette?: (restoreFocusTo?: HTMLElement | null) => void;
 }
 
-export function ContentArea({ route, onNavigate }: ContentAreaProps) {
+export function ContentArea({ route, onNavigate, onOpenCommandPalette }: ContentAreaProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
@@ -57,7 +58,7 @@ export function ContentArea({ route, onNavigate }: ContentAreaProps) {
       case 'proton-manager':
         return <ProtonManagerPage />;
       case 'library':
-        return <LibraryPage onNavigate={onNavigate} />;
+        return <LibraryPage onNavigate={onNavigate} onOpenCommandPalette={onOpenCommandPalette} />;
       default: {
         const _exhaustive: never = route;
         return _exhaustive;

--- a/src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx
+++ b/src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx
@@ -195,4 +195,69 @@ describe('AppShell (integration)', () => {
       rectSpy.mockRestore();
     }
   });
+
+  it('opens the command palette with Ctrl+K and focuses the search input', async () => {
+    const user = userEvent.setup();
+    setInnerWidth(1920);
+    setInnerHeight(1080);
+    const rectSpy = mockAppShellRect(1920, 1080);
+    try {
+      renderWithMocks(<AppShellInAppProviders />);
+
+      await user.keyboard('{Control>}k{/Control}');
+      const search = await screen.findByRole('searchbox', { name: 'Search commands' });
+      expect(search).toHaveFocus();
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('executes a palette command to navigate routes', async () => {
+    const user = userEvent.setup();
+    setInnerWidth(1920);
+    setInnerHeight(1080);
+    const rectSpy = mockAppShellRect(1920, 1080);
+    try {
+      renderWithMocks(<AppShellInAppProviders />);
+
+      await user.keyboard('{Control>}k{/Control}');
+      const search = await screen.findByRole('searchbox', { name: 'Search commands' });
+      await user.click(search);
+      await user.clear(search);
+      await user.type(search, 'settings');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: 'Settings' })).toHaveAttribute('aria-current', 'page');
+      });
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('restores focus to the invoking palette button after Escape close', async () => {
+    const user = userEvent.setup();
+    setInnerWidth(1920);
+    setInnerHeight(1080);
+    const rectSpy = mockAppShellRect(1920, 1080);
+    try {
+      renderWithMocks(<AppShellInAppProviders />);
+
+      const trigger = screen.getByRole('button', { name: 'Open command palette' });
+      await user.click(trigger);
+
+      const search = await screen.findByRole('searchbox', { name: 'Search commands' });
+      expect(search).toHaveFocus();
+
+      await user.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(screen.queryByRole('searchbox', { name: 'Search commands' })).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
 });

--- a/src/crosshook-native/src/components/library/LibraryToolbar.tsx
+++ b/src/crosshook-native/src/components/library/LibraryToolbar.tsx
@@ -21,7 +21,7 @@ interface LibraryToolbarProps {
   onSortChange: (key: LibrarySortKey) => void;
   filter: LibraryFilterKey;
   onFilterChange: (key: LibraryFilterKey) => void;
-  onOpenCommandPalette?: () => void;
+  onOpenCommandPalette?: (restoreFocusTo?: HTMLElement | null) => void;
 }
 
 export function LibraryToolbar({
@@ -119,7 +119,7 @@ export function LibraryToolbar({
           type="button"
           className="crosshook-library-toolbar__palette-trigger"
           aria-label="Open command palette"
-          onClick={() => onOpenCommandPalette()}
+          onClick={(event) => onOpenCommandPalette?.(event.currentTarget)}
         >
           ⌘K
         </button>

--- a/src/crosshook-native/src/components/pages/LibraryPage.tsx
+++ b/src/crosshook-native/src/components/pages/LibraryPage.tsx
@@ -32,9 +32,10 @@ function loadViewMode(): LibraryViewMode {
 
 interface LibraryPageProps {
   onNavigate?: (route: AppRoute) => void;
+  onOpenCommandPalette?: (restoreFocusTo?: HTMLElement | null) => void;
 }
 
-export function LibraryPage({ onNavigate }: LibraryPageProps) {
+export function LibraryPage({ onNavigate, onOpenCommandPalette }: LibraryPageProps) {
   const { profiles, favoriteProfiles, selectProfile, toggleFavorite, refreshProfiles, activeCollectionId } =
     useProfileContext();
   const {
@@ -265,9 +266,12 @@ export function LibraryPage({ onNavigate }: LibraryPageProps) {
     return () => setLibraryInspectorHandlers(undefined);
   }, [handleLaunch, handleEdit, handleToggleFavorite, setLibraryInspectorHandlers]);
 
-  const handleOpenCommandPalette = useCallback(() => {
-    console.debug('Command palette (Phase 6)');
-  }, []);
+  const handleOpenCommandPalette = useCallback(
+    (restoreFocusTo?: HTMLElement | null) => {
+      onOpenCommandPalette?.(restoreFocusTo);
+    },
+    [onOpenCommandPalette]
+  );
 
   const detailSummary =
     detailName == null ? null : (summaries.find((s) => s.name === detailName) ?? detailSummarySnapshot);

--- a/src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx
+++ b/src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx
@@ -11,12 +11,16 @@ import { ProfileHealthProvider } from '@/context/ProfileHealthContext';
 import { renderWithMocks } from '@/test/render';
 import { LibraryPage } from '../LibraryPage';
 
-function LibraryPageWithInspector() {
+interface LibraryPageHarnessProps {
+  onOpenCommandPalette?: () => void;
+}
+
+function LibraryPageWithInspector({ onOpenCommandPalette }: LibraryPageHarnessProps = {}) {
   const { inspectorSelection, libraryInspectorHandlers } = useInspectorSelection();
   return (
     <div style={{ display: 'flex' }}>
       <div style={{ flex: '1 1 50%', minWidth: 0 }}>
-        <LibraryPage />
+        <LibraryPage onOpenCommandPalette={onOpenCommandPalette} />
       </div>
       <div style={{ flex: '0 0 320px' }}>
         <Inspector
@@ -32,7 +36,7 @@ function LibraryPageWithInspector() {
   );
 }
 
-function renderLibraryHarness(options: Parameters<typeof renderWithMocks>[1] = {}) {
+function renderLibraryHarness(options: Parameters<typeof renderWithMocks>[1] = {}, onOpenCommandPalette?: () => void) {
   return renderWithMocks(
     <ProfileProvider>
       <PreferencesProvider>
@@ -40,7 +44,7 @@ function renderLibraryHarness(options: Parameters<typeof renderWithMocks>[1] = {
           <HostReadinessProvider>
             <CollectionsProvider>
               <InspectorSelectionProvider>
-                <LibraryPageWithInspector />
+                <LibraryPageWithInspector onOpenCommandPalette={onOpenCommandPalette} />
               </InspectorSelectionProvider>
             </CollectionsProvider>
           </HostReadinessProvider>
@@ -119,13 +123,13 @@ describe('LibraryPage', () => {
     expect(screen.getByRole('button', { name: 'Name' })).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('fires the command palette placeholder on ⌘K trigger', async () => {
+  it('delegates the command-palette trigger to callback', async () => {
     const user = userEvent.setup();
-    const debug = vi.mocked(console.debug);
-    renderLibraryHarness();
+    const onOpenCommandPalette = vi.fn();
+    renderLibraryHarness({}, onOpenCommandPalette);
 
     await user.click(screen.getByRole('button', { name: 'Open command palette' }));
-    expect(debug).toHaveBeenCalled();
+    expect(onOpenCommandPalette).toHaveBeenCalledTimes(1);
   });
 
   it('enters hero detail from the details control and returns on Back without losing inspector selection', async () => {

--- a/src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx
+++ b/src/crosshook-native/src/components/pages/__tests__/LibraryPage.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Inspector } from '@/components/layout/Inspector';
 import { CollectionsProvider } from '@/context/CollectionsContext';
@@ -12,7 +13,7 @@ import { renderWithMocks } from '@/test/render';
 import { LibraryPage } from '../LibraryPage';
 
 interface LibraryPageHarnessProps {
-  onOpenCommandPalette?: () => void;
+  onOpenCommandPalette?: ComponentProps<typeof LibraryPage>['onOpenCommandPalette'];
 }
 
 function LibraryPageWithInspector({ onOpenCommandPalette }: LibraryPageHarnessProps = {}) {
@@ -36,7 +37,10 @@ function LibraryPageWithInspector({ onOpenCommandPalette }: LibraryPageHarnessPr
   );
 }
 
-function renderLibraryHarness(options: Parameters<typeof renderWithMocks>[1] = {}, onOpenCommandPalette?: () => void) {
+function renderLibraryHarness(
+  options: Parameters<typeof renderWithMocks>[1] = {},
+  onOpenCommandPalette?: ComponentProps<typeof LibraryPage>['onOpenCommandPalette']
+) {
   return renderWithMocks(
     <ProfileProvider>
       <PreferencesProvider>

--- a/src/crosshook-native/src/components/palette/CommandPalette.tsx
+++ b/src/crosshook-native/src/components/palette/CommandPalette.tsx
@@ -1,0 +1,346 @@
+import { type KeyboardEvent, type MouseEvent, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import {
+  BrowseIcon,
+  CompatibilityIcon,
+  DiscoverIcon,
+  HealthIcon,
+  HostToolsIcon,
+  InfoCircleIcon,
+  InstallIcon,
+  LaunchIcon,
+  LibraryIcon,
+  ProfilesIcon,
+  ProtonManagerIcon,
+  SettingsIcon,
+} from '@/components/icons/SidebarIcons';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
+import {
+  type CommandPaletteCommand,
+  type CommandPaletteCommandId,
+  isCommandPaletteCommandEnabled,
+} from '@/lib/commands';
+
+type CommandPaletteIconId =
+  | 'browse'
+  | 'compatibility'
+  | 'discover'
+  | 'health'
+  | 'host_tools'
+  | 'info'
+  | 'install'
+  | 'launch'
+  | 'library'
+  | 'profiles'
+  | 'proton_manager'
+  | 'settings';
+
+export type CommandPaletteItem = CommandPaletteCommand & {
+  hint?: string;
+  icon?: CommandPaletteIconId;
+};
+
+export interface CommandPaletteProps {
+  open: boolean;
+  query: string;
+  commands: readonly CommandPaletteItem[];
+  activeId: CommandPaletteCommandId | null;
+  onClose: () => void;
+  onQueryChange: (query: string) => void;
+  onMoveActive: (delta: number) => void;
+  onExecuteCommand: (command: CommandPaletteItem) => void | Promise<void>;
+  onActiveCommandChange?: (commandId: CommandPaletteCommandId) => void;
+}
+
+function resolveCommandIconId(command: CommandPaletteItem): CommandPaletteIconId {
+  if (command.icon) {
+    return command.icon;
+  }
+
+  const haystack = [command.id, command.title, command.subtitle, ...(command.keywords ?? [])].join(' ').toLowerCase();
+
+  if (haystack.includes('setting')) {
+    return 'settings';
+  }
+  if (haystack.includes('proton')) {
+    return 'proton_manager';
+  }
+  if (haystack.includes('host')) {
+    return 'host_tools';
+  }
+  if (haystack.includes('compat')) {
+    return 'compatibility';
+  }
+  if (haystack.includes('health')) {
+    return 'health';
+  }
+  if (haystack.includes('discover') || haystack.includes('community')) {
+    return 'discover';
+  }
+  if (haystack.includes('browse')) {
+    return 'browse';
+  }
+  if (haystack.includes('install')) {
+    return 'install';
+  }
+  if (haystack.includes('launch') || haystack.includes('run')) {
+    return 'launch';
+  }
+  if (haystack.includes('profile')) {
+    return 'profiles';
+  }
+
+  return 'library';
+}
+
+function renderCommandIcon(iconId: CommandPaletteIconId) {
+  switch (iconId) {
+    case 'browse':
+      return <BrowseIcon className="crosshook-palette__row-icon" />;
+    case 'compatibility':
+      return <CompatibilityIcon className="crosshook-palette__row-icon" />;
+    case 'discover':
+      return <DiscoverIcon className="crosshook-palette__row-icon" />;
+    case 'health':
+      return <HealthIcon className="crosshook-palette__row-icon" />;
+    case 'host_tools':
+      return <HostToolsIcon className="crosshook-palette__row-icon" />;
+    case 'info':
+      return <InfoCircleIcon className="crosshook-palette__row-icon" />;
+    case 'install':
+      return <InstallIcon className="crosshook-palette__row-icon" />;
+    case 'launch':
+      return <LaunchIcon className="crosshook-palette__row-icon" />;
+    case 'profiles':
+      return <ProfilesIcon className="crosshook-palette__row-icon" />;
+    case 'proton_manager':
+      return <ProtonManagerIcon className="crosshook-palette__row-icon" />;
+    case 'settings':
+      return <SettingsIcon className="crosshook-palette__row-icon" />;
+    case 'library':
+      return <LibraryIcon className="crosshook-palette__row-icon" />;
+    default:
+      return <InfoCircleIcon className="crosshook-palette__row-icon" />;
+  }
+}
+
+export function CommandPalette({
+  open,
+  query,
+  commands,
+  activeId,
+  onClose,
+  onQueryChange,
+  onMoveActive,
+  onExecuteCommand,
+  onActiveCommandChange,
+}: CommandPaletteProps) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const listId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const portalHostRef = useRef<HTMLElement | null>(null);
+  const rowRefs = useRef(new Map<CommandPaletteCommandId, HTMLButtonElement>());
+  const [isMounted, setIsMounted] = useState(false);
+
+  const activeCommand = useMemo(
+    () => (activeId === null ? null : (commands.find((command) => command.id === activeId) ?? null)),
+    [activeId, commands]
+  );
+  const firstEnabledCommand = useMemo(() => {
+    return commands.find(isCommandPaletteCommandEnabled) ?? null;
+  }, [commands]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const host = document.createElement('div');
+    host.className = 'crosshook-modal-portal';
+    portalHostRef.current = host;
+    document.body.appendChild(host);
+    setIsMounted(true);
+
+    return () => {
+      host.remove();
+      portalHostRef.current = null;
+      rowRefs.current.clear();
+      setIsMounted(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open || activeId === null) {
+      return;
+    }
+
+    rowRefs.current.get(activeId)?.scrollIntoView({ block: 'nearest' });
+  }, [activeId, open]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const { handleKeyDown: handleFocusTrapKeyDown } = useFocusTrap({
+    open,
+    panelRef,
+    onClose: handleClose,
+    initialFocusRef: searchRef,
+  });
+
+  const handleExecute = useCallback(
+    (command: CommandPaletteItem) => {
+      if (!isCommandPaletteCommandEnabled(command)) {
+        return;
+      }
+
+      void onExecuteCommand(command);
+    },
+    [onExecuteCommand]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        onMoveActive(event.key === 'ArrowDown' ? 1 : -1);
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        const target = event.target;
+        if (target instanceof HTMLElement && target.closest('[data-crosshook-modal-close]')) {
+          handleFocusTrapKeyDown(event);
+          return;
+        }
+
+        const candidate = activeCommand ?? firstEnabledCommand;
+        if (candidate && isCommandPaletteCommandEnabled(candidate)) {
+          event.preventDefault();
+          handleExecute(candidate);
+          return;
+        }
+      }
+
+      handleFocusTrapKeyDown(event);
+    },
+    [activeCommand, handleExecute, handleFocusTrapKeyDown, onMoveActive]
+  );
+
+  if (!open || !isMounted || !portalHostRef.current) {
+    return null;
+  }
+
+  const node = (
+    <div className="crosshook-modal crosshook-palette" role="presentation">
+      <div
+        className="crosshook-modal__backdrop"
+        aria-hidden="true"
+        onMouseDown={(event: MouseEvent<HTMLDivElement>) => {
+          if (event.target === event.currentTarget) {
+            handleClose();
+          }
+        }}
+      />
+      <div
+        ref={panelRef}
+        className="crosshook-modal__surface crosshook-panel crosshook-focus-scope crosshook-palette__surface"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        data-crosshook-focus-root="modal"
+        onKeyDown={handleKeyDown}
+      >
+        <header className="crosshook-palette__header">
+          <div className="crosshook-modal__header">
+            <div className="crosshook-palette__header-copy">
+              <h2 id={titleId} className="crosshook-palette__title">
+                Command Palette
+              </h2>
+              <p id={descriptionId} className="crosshook-palette__description">
+                Jump to routes and actions without leaving the keyboard.
+              </p>
+            </div>
+            <div className="crosshook-modal__header-actions">
+              <button
+                type="button"
+                className="crosshook-button crosshook-button--ghost crosshook-modal__close"
+                aria-label="Close command palette"
+                data-crosshook-modal-close
+                onClick={handleClose}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+          <input
+            ref={searchRef}
+            type="search"
+            className="crosshook-palette__search"
+            placeholder="Search commands..."
+            aria-label="Search commands"
+            aria-controls={listId}
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+          />
+        </header>
+        <div className="crosshook-modal__body">
+          {commands.length === 0 ? (
+            <div className="crosshook-palette__empty" role="status" aria-live="polite">
+              <strong>No commands found</strong>
+              <span>{query.trim() ? `No commands match "${query.trim()}".` : 'Try a different search.'}</span>
+            </div>
+          ) : (
+            <ul id={listId} className="crosshook-palette__list" aria-label="Matching commands">
+              {commands.map((command) => {
+                const enabled = isCommandPaletteCommandEnabled(command);
+                const active = command.id === activeId;
+
+                return (
+                  <li key={command.id}>
+                    <button
+                      ref={(element) => {
+                        if (element) {
+                          rowRefs.current.set(command.id, element);
+                          return;
+                        }
+                        rowRefs.current.delete(command.id);
+                      }}
+                      type="button"
+                      aria-label={command.title}
+                      className={`crosshook-palette__row${active ? ' crosshook-palette__row--active' : ''}`}
+                      data-crosshook-command-id={command.id}
+                      data-state={active ? 'active' : undefined}
+                      aria-selected={active}
+                      disabled={!enabled}
+                      tabIndex={-1}
+                      onClick={() => handleExecute(command)}
+                      onMouseEnter={() => onActiveCommandChange?.(command.id)}
+                    >
+                      {renderCommandIcon(resolveCommandIconId(command))}
+                      <span className="crosshook-palette__row-copy">
+                        <span className="crosshook-palette__row-label">{command.title}</span>
+                        {command.subtitle ? (
+                          <span className="crosshook-palette__row-description">{command.subtitle}</span>
+                        ) : null}
+                      </span>
+                      {command.hint ? <span className="crosshook-palette__hint-chip">{command.hint}</span> : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(node, portalHostRef.current);
+}
+
+export default CommandPalette;

--- a/src/crosshook-native/src/components/palette/CommandPalette.tsx
+++ b/src/crosshook-native/src/components/palette/CommandPalette.tsx
@@ -19,22 +19,9 @@ import { useFocusTrap } from '@/hooks/useFocusTrap';
 import {
   type CommandPaletteCommand,
   type CommandPaletteCommandId,
+  type CommandPaletteIconId,
   isCommandPaletteCommandEnabled,
 } from '@/lib/commands';
-
-type CommandPaletteIconId =
-  | 'browse'
-  | 'compatibility'
-  | 'discover'
-  | 'health'
-  | 'host_tools'
-  | 'info'
-  | 'install'
-  | 'launch'
-  | 'library'
-  | 'profiles'
-  | 'proton_manager'
-  | 'settings';
 
 export type CommandPaletteItem = CommandPaletteCommand & {
   hint?: string;
@@ -227,7 +214,7 @@ export function CommandPalette({
 
       handleFocusTrapKeyDown(event);
     },
-    [activeCommand, handleExecute, handleFocusTrapKeyDown, onMoveActive]
+    [activeCommand, firstEnabledCommand, handleExecute, handleFocusTrapKeyDown, onMoveActive]
   );
 
   if (!open || !isMounted || !portalHostRef.current) {
@@ -288,7 +275,7 @@ export function CommandPalette({
             onChange={(event) => onQueryChange(event.target.value)}
           />
         </header>
-        <div className="crosshook-modal__body">
+        <div className="crosshook-modal__body crosshook-palette__body">
           {commands.length === 0 ? (
             <div className="crosshook-palette__empty" role="status" aria-live="polite">
               <strong>No commands found</strong>
@@ -315,7 +302,7 @@ export function CommandPalette({
                       className={`crosshook-palette__row${active ? ' crosshook-palette__row--active' : ''}`}
                       data-crosshook-command-id={command.id}
                       data-state={active ? 'active' : undefined}
-                      aria-selected={active}
+                      aria-current={active ? 'true' : undefined}
                       disabled={!enabled}
                       tabIndex={-1}
                       onClick={() => handleExecute(command)}

--- a/src/crosshook-native/src/components/palette/__tests__/CommandPalette.test.tsx
+++ b/src/crosshook-native/src/components/palette/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,193 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCommandPalette } from '@/hooks/useCommandPalette';
+import type { CommandPaletteCommand } from '@/lib/commands';
+import { renderWithMocks } from '@/test/render';
+import { CommandPalette } from '../CommandPalette';
+
+interface PaletteHarnessProps {
+  commands: readonly CommandPaletteCommand[];
+  onClose?: () => void;
+  onExecute?: (command: CommandPaletteCommand) => void | Promise<void>;
+}
+
+function PaletteHarness({ commands, onClose, onExecute }: PaletteHarnessProps) {
+  const { open, query, filteredCommands, activeId, setQuery, moveActive, closePalette } = useCommandPalette({
+    initialOpen: true,
+    commands,
+    onExecuteCommand: async (command) => {
+      await onExecute?.(command);
+    },
+  });
+
+  const handleClose = () => {
+    if (!open) {
+      return;
+    }
+    closePalette();
+    onClose?.();
+  };
+
+  const handleQuery = (next: string) => {
+    setQuery(next);
+  };
+
+  const handleExecute = async (command: CommandPaletteCommand) => {
+    await onExecute?.(command);
+  };
+
+  return (
+    <CommandPalette
+      open={open}
+      query={query}
+      commands={filteredCommands}
+      activeId={activeId}
+      onClose={handleClose}
+      onQueryChange={handleQuery}
+      onMoveActive={moveActive}
+      onExecuteCommand={handleExecute}
+    />
+  );
+}
+
+const COMMANDS: readonly CommandPaletteCommand[] = [
+  {
+    id: 'route:library',
+    action: 'route',
+    route: 'library',
+    title: 'Go to Library',
+    subtitle: 'Browse your library and favorites.',
+    icon: 'library',
+    keywords: ['library', 'games'],
+  },
+  {
+    id: 'route:profiles',
+    action: 'route',
+    route: 'profiles',
+    title: 'Go to Profiles',
+    subtitle: 'Edit existing launch profiles.',
+    icon: 'profiles',
+    keywords: ['profiles', 'edit'],
+  },
+  {
+    id: 'profile:launch-current:Test Game',
+    action: 'launch_profile',
+    profileName: 'Test Game',
+    title: 'Launch Test Game',
+    subtitle: 'Load a profile and switch to launch.',
+    icon: 'launch',
+  },
+  {
+    id: 'route:settings',
+    action: 'route',
+    route: 'settings',
+    title: 'Go to Settings',
+    subtitle: 'Open app-level settings.',
+    icon: 'settings',
+    keywords: ['settings', 'setup'],
+  },
+] as const;
+
+describe('CommandPalette', () => {
+  const renderPalette = (
+    commands = COMMANDS,
+    onExecute?: PaletteHarnessProps['onExecute'],
+    onClose?: PaletteHarnessProps['onClose']
+  ) => renderWithMocks(<PaletteHarness commands={commands} onExecute={onExecute} onClose={onClose} />);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when closed', () => {
+    renderWithMocks(
+      <CommandPalette
+        open={false}
+        query=""
+        commands={COMMANDS}
+        activeId={COMMANDS[0].id}
+        onClose={() => {}}
+        onQueryChange={() => {}}
+        onMoveActive={() => {}}
+        onExecuteCommand={() => Promise.resolve()}
+      />
+    );
+
+    expect(screen.queryByRole('heading', { name: 'Command Palette' })).not.toBeInTheDocument();
+  });
+
+  it('filters command results with substring input', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    const search = screen.getByRole('searchbox', { name: 'Search commands' });
+    await user.type(search, 'set');
+
+    expect(screen.getByRole('button', { name: /Go to Settings/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Go to Library/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Go to Profiles/i })).not.toBeInTheDocument();
+  });
+
+  it('shows empty-state messaging when no command matches', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    const search = screen.getByRole('searchbox', { name: 'Search commands' });
+    await user.type(search, 'totally-missing');
+
+    expect(screen.getByRole('status')).toHaveTextContent('No commands found');
+  });
+
+  it('supports arrow-key wrap navigation', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    const search = screen.getByRole('searchbox', { name: 'Search commands' });
+    await user.click(search);
+    await user.keyboard('{ArrowUp}');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Go to Settings/i })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    await user.keyboard('{ArrowDown}');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Go to Library/i })).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  it('executes active command on Enter', async () => {
+    const onExecute = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(COMMANDS, onExecute);
+
+    const search = screen.getByRole('searchbox', { name: 'Search commands' });
+    await user.click(search);
+    await user.keyboard('{Enter}');
+
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(onExecute).toHaveBeenCalledWith(COMMANDS[0]);
+  });
+
+  it('closes when Escape is pressed', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(COMMANDS, undefined, onClose);
+
+    const search = screen.getByRole('searchbox', { name: 'Search commands' });
+    await user.click(search);
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('searchbox', { name: 'Search commands' })).not.toBeInTheDocument();
+  });
+
+  it('executes command when clicked', async () => {
+    const onExecute = vi.fn();
+    const user = userEvent.setup();
+    renderPalette(COMMANDS, onExecute);
+
+    await user.click(screen.getByRole('button', { name: /Go to Profiles/i }));
+    expect(onExecute).toHaveBeenCalledWith(COMMANDS[1]);
+  });
+});

--- a/src/crosshook-native/src/components/palette/__tests__/CommandPalette.test.tsx
+++ b/src/crosshook-native/src/components/palette/__tests__/CommandPalette.test.tsx
@@ -147,12 +147,12 @@ describe('CommandPalette', () => {
     await user.click(search);
     await user.keyboard('{ArrowUp}');
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Go to Settings/i })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('button', { name: /Go to Settings/i })).toHaveAttribute('aria-current', 'true');
     });
 
     await user.keyboard('{ArrowDown}');
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Go to Library/i })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('button', { name: /Go to Library/i })).toHaveAttribute('aria-current', 'true');
     });
   });
 

--- a/src/crosshook-native/src/hooks/useCommandPalette.ts
+++ b/src/crosshook-native/src/hooks/useCommandPalette.ts
@@ -8,7 +8,8 @@ import {
 
 export interface UseCommandPaletteOptions {
   commands: readonly CommandPaletteCommand[];
-  onExecuteCommand: (command: CommandPaletteCommand) => void | Promise<void>;
+  /** Used by {@link UseCommandPaletteReturn.executeActive} only. Omit if execution is handled via {@link CommandPalette} `onExecuteCommand`. */
+  onExecuteCommand?: (command: CommandPaletteCommand) => void | Promise<void>;
   initialOpen?: boolean;
   initialQuery?: string;
 }
@@ -118,13 +119,15 @@ export function useCommandPalette({
   );
 
   const executeActive = useCallback(async (): Promise<boolean> => {
+    if (onExecuteCommand == null) {
+      return false;
+    }
+
     if (activeId === null) {
       return false;
     }
 
-    const activeCommand = filteredCommands.find(
-      (command) => command.id === activeId && isCommandPaletteCommandEnabled(command)
-    );
+    const activeCommand = enabledCommands.find((command) => command.id === activeId);
     if (!activeCommand) {
       return false;
     }
@@ -132,7 +135,7 @@ export function useCommandPalette({
     await onExecuteCommand(activeCommand);
     closePalette();
     return true;
-  }, [activeId, closePalette, filteredCommands, onExecuteCommand]);
+  }, [activeId, closePalette, enabledCommands, onExecuteCommand]);
 
   return {
     open,

--- a/src/crosshook-native/src/hooks/useCommandPalette.ts
+++ b/src/crosshook-native/src/hooks/useCommandPalette.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  type CommandPaletteCommand,
+  type CommandPaletteCommandId,
+  filterCommandPaletteCommands,
+  isCommandPaletteCommandEnabled,
+} from '@/lib/commands';
+
+export interface UseCommandPaletteOptions {
+  commands: readonly CommandPaletteCommand[];
+  onExecuteCommand: (command: CommandPaletteCommand) => void | Promise<void>;
+  initialOpen?: boolean;
+  initialQuery?: string;
+}
+
+export interface UseCommandPaletteReturn {
+  open: boolean;
+  query: string;
+  filteredCommands: CommandPaletteCommand[];
+  activeIndex: number;
+  activeId: CommandPaletteCommandId | null;
+  openPalette: () => void;
+  closePalette: () => void;
+  setQuery: (query: string) => void;
+  moveActive: (delta: number) => void;
+  reset: () => void;
+  executeActive: () => Promise<boolean>;
+}
+
+function clampWrappedIndex(index: number, length: number): number {
+  return ((index % length) + length) % length;
+}
+
+export function useCommandPalette({
+  commands,
+  onExecuteCommand,
+  initialOpen = false,
+  initialQuery = '',
+}: UseCommandPaletteOptions): UseCommandPaletteReturn {
+  const [open, setOpen] = useState(initialOpen);
+  const [query, setQueryState] = useState(initialQuery);
+  const [activeId, setActiveId] = useState<CommandPaletteCommandId | null>(null);
+
+  const filteredCommands = useMemo(() => filterCommandPaletteCommands(commands, query), [commands, query]);
+  const enabledCommands = useMemo(() => filteredCommands.filter(isCommandPaletteCommandEnabled), [filteredCommands]);
+  const activeIndex = useMemo(() => {
+    if (activeId === null) {
+      return -1;
+    }
+
+    return filteredCommands.findIndex((command) => command.id === activeId);
+  }, [activeId, filteredCommands]);
+
+  const reset = useCallback(() => {
+    setQueryState('');
+    setActiveId(null);
+  }, []);
+
+  const openPalette = useCallback(() => {
+    setOpen(true);
+  }, []);
+
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    reset();
+  }, [reset]);
+
+  const setQuery = useCallback((nextQuery: string) => {
+    setQueryState(nextQuery);
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const nextActive = enabledCommands[0] ?? null;
+    if (nextActive === null) {
+      if (activeId !== null) {
+        setActiveId(null);
+      }
+      return;
+    }
+
+    if (activeId === null) {
+      setActiveId(nextActive.id);
+      return;
+    }
+
+    const activeCommand = enabledCommands.find((command) => command.id === activeId);
+    if (!activeCommand) {
+      setActiveId(nextActive.id);
+    }
+  }, [activeId, enabledCommands, open]);
+
+  const moveActive = useCallback(
+    (delta: number) => {
+      if (!open) {
+        return;
+      }
+
+      if (enabledCommands.length === 0) {
+        setActiveId(null);
+        return;
+      }
+
+      const currentIndex = activeId === null ? -1 : enabledCommands.findIndex((command) => command.id === activeId);
+      const nextIndex =
+        currentIndex === -1
+          ? delta >= 0
+            ? 0
+            : enabledCommands.length - 1
+          : clampWrappedIndex(currentIndex + delta, enabledCommands.length);
+
+      setActiveId(enabledCommands[nextIndex].id);
+    },
+    [activeId, enabledCommands, open]
+  );
+
+  const executeActive = useCallback(async (): Promise<boolean> => {
+    if (activeId === null) {
+      return false;
+    }
+
+    const activeCommand = filteredCommands.find(
+      (command) => command.id === activeId && isCommandPaletteCommandEnabled(command)
+    );
+    if (!activeCommand) {
+      return false;
+    }
+
+    await onExecuteCommand(activeCommand);
+    closePalette();
+    return true;
+  }, [activeId, closePalette, filteredCommands, onExecuteCommand]);
+
+  return {
+    open,
+    query,
+    filteredCommands,
+    activeIndex,
+    activeId,
+    openPalette,
+    closePalette,
+    setQuery,
+    moveActive,
+    reset,
+    executeActive,
+  };
+}

--- a/src/crosshook-native/src/hooks/useScrollEnhance.ts
+++ b/src/crosshook-native/src/hooks/useScrollEnhance.ts
@@ -6,7 +6,7 @@ const WHEEL_MULTIPLIER = 2;
 const SMOOTH_FACTOR = 0.18;
 const ARROW_SCROLL_PX = 80;
 const SCROLLABLE =
-  '.crosshook-route-card-scroll, .crosshook-page-scroll-body, .crosshook-subtab-content__inner--scroll, .crosshook-console-drawer__body, .crosshook-modal__body, .crosshook-prefix-deps__log-output, .crosshook-discovery-results, .crosshook-collections-sidebar__list, .crosshook-collection-assign-menu__list, .crosshook-route-stack__body--scroll, .crosshook-sidebar__nav--scroll, .crosshook-inspector__body, .crosshook-hero-detail__body';
+  '.crosshook-route-card-scroll, .crosshook-page-scroll-body, .crosshook-subtab-content__inner--scroll, .crosshook-console-drawer__body, .crosshook-modal__body, .crosshook-palette__list, .crosshook-prefix-deps__log-output, .crosshook-discovery-results, .crosshook-collections-sidebar__list, .crosshook-collection-assign-menu__list, .crosshook-route-stack__body--scroll, .crosshook-sidebar__nav--scroll, .crosshook-inspector__body, .crosshook-hero-detail__body';
 const RESET_SCROLL_MOMENTUM_EVENT = 'crosshook:reset-scroll-momentum';
 
 const INTERACTIVE_ROLES = new Set([

--- a/src/crosshook-native/src/lib/commands.ts
+++ b/src/crosshook-native/src/lib/commands.ts
@@ -1,0 +1,162 @@
+import type { AppRoute } from '@/components/layout/Sidebar';
+
+export type CommandPaletteCommandId = string;
+
+export type CommandPaletteIconId =
+  | 'browse'
+  | 'compatibility'
+  | 'discover'
+  | 'health'
+  | 'host_tools'
+  | 'install'
+  | 'launch'
+  | 'library'
+  | 'profiles'
+  | 'proton_manager'
+  | 'settings';
+
+export type CommandPaletteAction = 'route' | 'launch_profile' | 'edit_profile';
+
+export interface CommandPaletteCommandBase {
+  readonly id: CommandPaletteCommandId;
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly keywords?: readonly string[];
+  readonly icon: CommandPaletteIconId;
+  readonly hint?: string;
+  readonly disabled?: boolean;
+}
+
+interface RouteCommand extends CommandPaletteCommandBase {
+  readonly action: 'route';
+  readonly route: AppRoute;
+}
+
+interface ProfileCommand extends CommandPaletteCommandBase {
+  readonly action: 'launch_profile' | 'edit_profile';
+  readonly profileName: string;
+}
+
+export type CommandPaletteCommand = RouteCommand | ProfileCommand;
+
+export interface CommandPaletteCommandSection {
+  readonly route: readonly CommandPaletteCommand[];
+}
+
+export function isCommandPaletteCommandEnabled(command: CommandPaletteCommand): boolean {
+  return command.disabled !== true;
+}
+
+function commandSearchHaystack(command: CommandPaletteCommand): string {
+  return [command.title, command.subtitle ?? '', ...(command.keywords ?? [])].filter(Boolean).join(' ').toLowerCase();
+}
+
+export function filterCommandPaletteCommands(
+  commands: readonly CommandPaletteCommand[],
+  query: string
+): CommandPaletteCommand[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return [...commands];
+  }
+
+  return commands.filter((command) => commandSearchHaystack(command).includes(normalizedQuery));
+}
+
+const ROUTE_TITLES: Record<AppRoute, string> = {
+  library: 'Go to Library',
+  profiles: 'Go to Profiles',
+  launch: 'Go to Launch',
+  install: 'Go to Install & Run',
+  community: 'Go to Browse',
+  discover: 'Go to Discover',
+  compatibility: 'Go to Compatibility',
+  settings: 'Go to Settings',
+  health: 'Go to Health',
+  'host-tools': 'Go to Host Tools',
+  'proton-manager': 'Go to Proton Manager',
+};
+
+const ROUTE_KEYWORDS: Record<AppRoute, readonly string[]> = {
+  library: ['games', 'browse'],
+  profiles: ['editor', 'profile'],
+  launch: ['run', 'play'],
+  install: ['setup', 'exe', 'msi'],
+  community: ['community', 'taps'],
+  discover: ['search', 'trainers'],
+  compatibility: ['compatibility', 'proton'],
+  settings: ['preferences', 'configuration'],
+  health: ['diagnostics', 'dashboard'],
+  'host-tools': ['dependencies', 'readiness'],
+  'proton-manager': ['proton', 'compatibility tool'],
+};
+
+const ROUTE_ICON: Record<AppRoute, CommandPaletteIconId> = {
+  library: 'library',
+  profiles: 'profiles',
+  launch: 'launch',
+  install: 'install',
+  community: 'browse',
+  discover: 'discover',
+  compatibility: 'compatibility',
+  settings: 'settings',
+  health: 'health',
+  'host-tools': 'host_tools',
+  'proton-manager': 'proton_manager',
+};
+
+const ROUTE_SUBTITLE: Record<AppRoute, string> = {
+  library: 'Browse your saved profiles, favorites, and launch shortcuts in one place.',
+  profiles: 'Create, select, and maintain profiles for each game and trainer setup.',
+  launch: 'Run the game or trainer with the active profile’s launch configuration.',
+  install: 'Install games, apply updates, or run an arbitrary Windows EXE or MSI without committing it.',
+  community: 'Search shared profiles from your taps and import them into your library.',
+  discover: 'Search community trainer sources linked from CrossHook (external sites only).',
+  compatibility: 'Inspect trainer compatibility data and manage Proton installs.',
+  settings: 'Startup behavior, storage paths, integrations, and recent history.',
+  health: 'Validate profiles, review issues, and track launch health across your library.',
+  'host-tools': 'Inspect detected host tools, capability state, and install guidance.',
+  'proton-manager': 'Download, install, and manage Proton versions for your Steam library.',
+};
+
+export const ROUTE_COMMANDS: readonly CommandPaletteCommand[] = (
+  Object.entries(ROUTE_TITLES) as Array<[AppRoute, string]>
+).map(([route, title]) => ({
+  id: `route:${route}`,
+  action: 'route',
+  route,
+  title,
+  subtitle: ROUTE_SUBTITLE[route],
+  keywords: ROUTE_KEYWORDS[route],
+  icon: ROUTE_ICON[route],
+}));
+
+export function createProfileCommands(activeProfileName: string): readonly CommandPaletteCommand[] {
+  const trimmed = activeProfileName.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  return [
+    {
+      id: `profile:launch-current:${trimmed}`,
+      action: 'launch_profile',
+      profileName: trimmed,
+      title: `Launch ${trimmed}`,
+      subtitle: 'Load the selected profile and switch to Launch.',
+      keywords: ['run', 'active profile'],
+      icon: 'launch',
+      hint: 'Active profile',
+    },
+    {
+      id: `profile:edit-current:${trimmed}`,
+      action: 'edit_profile',
+      profileName: trimmed,
+      title: `Edit ${trimmed}`,
+      subtitle: 'Load the selected profile in the Profiles editor.',
+      keywords: ['profiles', 'active profile'],
+      icon: 'profiles',
+      hint: 'Active profile',
+    },
+  ];
+}

--- a/src/crosshook-native/src/lib/commands.ts
+++ b/src/crosshook-native/src/lib/commands.ts
@@ -8,6 +8,7 @@ export type CommandPaletteIconId =
   | 'discover'
   | 'health'
   | 'host_tools'
+  | 'info'
   | 'install'
   | 'launch'
   | 'library'
@@ -39,6 +40,7 @@ interface ProfileCommand extends CommandPaletteCommandBase {
 
 export type CommandPaletteCommand = RouteCommand | ProfileCommand;
 
+/** TODO: reserved for future command-grouping in the palette (e.g. section headers); not yet used by the UI. */
 export interface CommandPaletteCommandSection {
   readonly route: readonly CommandPaletteCommand[];
 }

--- a/src/crosshook-native/src/main.tsx
+++ b/src/crosshook-native/src/main.tsx
@@ -11,6 +11,7 @@ import './styles/console-drawer.css';
 import './styles/themed-select.css';
 import './styles/collapsible-section.css';
 import './styles/library.css';
+import './styles/palette.css';
 import './styles/hero-detail.css';
 import './styles/collections-sidebar.css';
 

--- a/src/crosshook-native/src/styles/palette.css
+++ b/src/crosshook-native/src/styles/palette.css
@@ -5,7 +5,7 @@
 .crosshook-palette__surface.crosshook-modal__surface,
 .crosshook-palette .crosshook-modal__surface {
   width: min(760px, calc(100vw - var(--crosshook-modal-offset)));
-  height: auto;
+  height: min(720px, calc(100dvh - var(--crosshook-modal-offset)));
   min-height: 0;
   max-height: min(720px, calc(100dvh - var(--crosshook-modal-offset)));
   grid-template-rows: auto minmax(0, 1fr);
@@ -16,8 +16,18 @@
   gap: 14px;
   min-width: 0;
   padding: 20px 24px 18px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(180deg, rgba(13, 19, 34, 0.98), rgba(13, 19, 34, 0.9));
+  border-bottom: 1px solid var(--crosshook-palette-border-on-dark);
+  background: linear-gradient(
+    180deg,
+    var(--crosshook-palette-bg-dark-98),
+    var(--crosshook-palette-bg-dark-90)
+  );
+}
+
+.crosshook-palette__body {
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
 }
 
 .crosshook-palette__header-copy {
@@ -66,6 +76,7 @@
 
 .crosshook-palette__list {
   min-height: 0;
+  height: 100%;
   margin: 0;
   padding: 10px 12px 16px;
   list-style: none;
@@ -106,7 +117,7 @@
 .crosshook-palette__row:hover {
   transform: translateY(-1px);
   border-color: rgba(74, 125, 181, 0.22);
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--crosshook-palette-border-on-dark);
   color: var(--crosshook-color-text);
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.22),
@@ -134,7 +145,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: currentColor;
+  color: currentcolor;
 }
 
 .crosshook-palette__row-copy {
@@ -169,7 +180,7 @@
   min-height: 30px;
   padding: 0 10px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--crosshook-palette-border-on-dark);
   background: rgba(255, 255, 255, 0.04);
   color: var(--crosshook-color-text-subtle);
   font-family: var(--crosshook-font-mono);

--- a/src/crosshook-native/src/styles/palette.css
+++ b/src/crosshook-native/src/styles/palette.css
@@ -1,0 +1,221 @@
+.crosshook-palette {
+  z-index: 1300;
+}
+
+.crosshook-palette__surface.crosshook-modal__surface,
+.crosshook-palette .crosshook-modal__surface {
+  width: min(760px, calc(100vw - var(--crosshook-modal-offset)));
+  height: auto;
+  min-height: 0;
+  max-height: min(720px, calc(100dvh - var(--crosshook-modal-offset)));
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.crosshook-palette__header {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  padding: 20px 24px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(13, 19, 34, 0.98), rgba(13, 19, 34, 0.9));
+}
+
+.crosshook-palette__header-copy {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.crosshook-palette__title {
+  margin: 0;
+  color: var(--crosshook-color-text);
+  font-size: clamp(1.2rem, 1.8vw, 1.55rem);
+  line-height: 1.12;
+}
+
+.crosshook-palette__description {
+  margin: 0;
+  color: var(--crosshook-color-text-muted);
+  line-height: 1.45;
+}
+
+.crosshook-palette__search {
+  width: 100%;
+  min-height: 50px;
+  padding: 0 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(74, 125, 181, 0.28);
+  background: rgba(8, 14, 26, 0.86);
+  color: var(--crosshook-color-text);
+  outline: none;
+  transition:
+    border-color var(--crosshook-transition-fast) ease,
+    box-shadow var(--crosshook-transition-fast) ease,
+    background var(--crosshook-transition-fast) ease;
+}
+
+.crosshook-palette__search::placeholder {
+  color: var(--crosshook-color-text-subtle);
+}
+
+.crosshook-palette__search:focus {
+  border-color: var(--crosshook-color-accent-strong);
+  box-shadow: 0 0 0 3px var(--crosshook-color-accent-soft);
+  background: rgba(10, 17, 30, 0.94);
+}
+
+.crosshook-palette__list {
+  min-height: 0;
+  margin: 0;
+  padding: 10px 12px 16px;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable both-edges;
+  background: radial-gradient(circle at top left, rgba(74, 125, 181, 0.08), transparent 26%), rgba(4, 8, 16, 0.18);
+}
+
+.crosshook-palette__row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: var(--crosshook-touch-target-min);
+  padding: 12px 14px;
+  border: 1px solid rgba(74, 125, 181, 0.12);
+  border-radius: var(--crosshook-radius-md);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--crosshook-color-text-muted);
+  cursor: pointer;
+  text-align: left;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition:
+    transform var(--crosshook-transition-fast) ease,
+    border-color var(--crosshook-transition-standard) ease,
+    background var(--crosshook-transition-standard) ease,
+    color var(--crosshook-transition-standard) ease,
+    box-shadow var(--crosshook-transition-standard) ease;
+}
+
+.crosshook-palette__row:hover {
+  transform: translateY(-1px);
+  border-color: rgba(74, 125, 181, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--crosshook-color-text);
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.crosshook-palette__row:focus-visible {
+  outline: none;
+  border-color: var(--crosshook-color-accent-strong);
+  box-shadow: 0 0 0 3px var(--crosshook-color-accent-soft);
+}
+
+.crosshook-palette__row--active,
+.crosshook-palette__row[data-state='active'],
+.crosshook-palette__row[aria-selected='true'] {
+  border-color: rgba(74, 125, 181, 0.45);
+  background: linear-gradient(135deg, rgba(74, 125, 181, 0.24), rgba(107, 163, 217, 0.12));
+  color: var(--crosshook-color-text);
+  box-shadow: 0 14px 24px rgba(74, 125, 181, 0.2);
+}
+
+.crosshook-palette__row-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: currentColor;
+}
+
+.crosshook-palette__row-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.crosshook-palette__row-label {
+  min-width: 0;
+  color: var(--crosshook-color-text);
+  font-weight: 700;
+  line-height: 1.25;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.crosshook-palette__row-description {
+  min-width: 0;
+  color: var(--crosshook-color-text-subtle);
+  font-size: 0.84rem;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crosshook-palette__hint-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--crosshook-color-text-subtle);
+  font-family: var(--crosshook-font-mono);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.crosshook-palette__row--active .crosshook-palette__hint-chip,
+.crosshook-palette__row[data-state='active'] .crosshook-palette__hint-chip,
+.crosshook-palette__row[aria-selected='true'] .crosshook-palette__hint-chip {
+  border-color: rgba(107, 163, 217, 0.35);
+  background: rgba(74, 125, 181, 0.18);
+  color: var(--crosshook-color-text);
+}
+
+.crosshook-palette__empty {
+  display: grid;
+  justify-items: start;
+  gap: 8px;
+  margin: 8px 0 0;
+  padding: 20px 18px;
+  border: 1px dashed var(--crosshook-color-border-muted);
+  border-radius: var(--crosshook-radius-md);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--crosshook-color-text-muted);
+  line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+  .crosshook-palette__header {
+    padding: 18px 18px 16px;
+  }
+
+  .crosshook-palette__list {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  .crosshook-palette__row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .crosshook-palette__hint-chip {
+    grid-column: 2;
+    justify-self: start;
+  }
+}

--- a/src/crosshook-native/src/styles/variables.css
+++ b/src/crosshook-native/src/styles/variables.css
@@ -173,6 +173,11 @@
   --crosshook-skeleton-duration: 1.8s;
   --crosshook-skeleton-color-from: var(--crosshook-color-surface);
   --crosshook-skeleton-color-to: var(--crosshook-color-bg-elevated);
+
+  /* Command palette (⌘K overlay): shared dark-surface rgba tokens (borders, subtle fills, header gradient) */
+  --crosshook-palette-border-on-dark: rgba(255, 255, 255, 0.08);
+  --crosshook-palette-bg-dark-98: rgba(13, 19, 34, 0.98);
+  --crosshook-palette-bg-dark-90: rgba(13, 19, 34, 0.9);
 }
 
 :root[data-crosshook-theme='high-contrast'] {

--- a/src/crosshook-native/tests/smoke.spec.ts
+++ b/src/crosshook-native/tests/smoke.spec.ts
@@ -172,3 +172,43 @@ test.describe('launch pipeline smoke', () => {
     expect(capture.errors).toEqual([]);
   });
 });
+
+test.describe('command palette smoke', () => {
+  test('opens with shortcut, executes a route command, and keeps capture clean', async ({ page }) => {
+    const capture = attachConsoleCapture(page);
+
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto('/?fixture=populated');
+
+    const libraryTab = page.getByRole('tab', { name: 'Library', exact: true });
+    await libraryTab.click();
+    await expect(libraryTab).toHaveAttribute('aria-current', 'page');
+
+    await page.keyboard.press('Control+KeyK');
+    const search = page.getByRole('searchbox', { name: 'Search commands' });
+    await expect(search).toBeVisible();
+
+    await search.fill('settings');
+    await search.press('Enter');
+
+    await expect(page.getByRole('tab', { name: 'Settings', exact: true })).toHaveAttribute('aria-current', 'page');
+
+    expect(capture.errors, `Command-palette execution errors:\n${capture.errors.join('\n')}`).toEqual([]);
+  });
+
+  test('opens and closes from toolbar trigger', async ({ page }) => {
+    const capture = attachConsoleCapture(page);
+
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto('/?fixture=populated');
+    await page.getByRole('button', { name: 'Open command palette' }).click();
+
+    const search = page.getByRole('searchbox', { name: 'Search commands' });
+    await expect(search).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(search).not.toBeVisible();
+
+    expect(capture.errors, `Command-palette toolbar errors:\n${capture.errors.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

This PR ships Phase 6 command palette functionality, moving the palette affordance out of a Library-only placeholder into a shared shell-level overlay opened from global Cmd/Ctrl+K.

## Changes

- Added a typed command catalog in `src/crosshook-native/src/lib/commands.ts` for route navigation and profile actions.
- Added `useCommandPalette` state/behavior hook in `src/crosshook-native/src/hooks/useCommandPalette.ts` for open/query/selection and keyboard execution.
- Added `CommandPalette` modal component with focus-trap integration, filtering, and Enter/arrow/Escape navigation.
- Integrated palette ownership in `AppShell`, including global shortcut registration and execution path that performs route/profile actions.
- Wired the existing Library toolbar trigger to delegate to the shared shell palette handler.
- Added scroll enhancement support and focused styling for palette interactions.
- Added unit tests for palette behavior, shell shortcut wiring, and Library callback delegation.
- Added phase-6 plan doc (`docs/prps/plans/unified-desktop-phase-6-command-palette.plan.md`).

## Testing

- `cd src/crosshook-native && npm run typecheck`
- `cd src/crosshook-native && npm test -- src/components/palette/__tests__/CommandPalette.test.tsx src/components/layout/__tests__/AppShell.test.tsx src/components/pages/__tests__/LibraryPage.test.tsx`
- `cd src/crosshook-native && npm run lint:fix -- src/components/palette/CommandPalette.tsx src/components/layout/AppShell.tsx` (via pre-commit hooks on commit)

## Related Issues

Closes #418
Closes #445

## Breaking Changes

- No breaking changes.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [ ] Documentation updated beyond plan artifact
- [x] All tests passing for covered unit paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global command palette (Cmd/Ctrl+K) with real-time search, arrow navigation, Enter execution, and focus restoration; integrates with routes and profile actions.

* **Tests**
  * Added unit, integration, and smoke tests covering open/close, keyboard navigation, execution, and focus behavior.

* **Documentation**
  * New plan document detailing design, behavior, and acceptance criteria.

* **Style**
  * New palette styles and theme variables for the command palette UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->