### PR TITLE
feat(layout): add responsive console status bar

### DIFF
--- a/docs/features/console-status-bar.doc.md
+++ b/docs/features/console-status-bar.doc.md
@@ -1,0 +1,44 @@
+# Responsive runtime console
+
+CrossHook now switches the bottom console chrome between a **drawer** and a
+compact **status bar** based on the active shell size.
+
+## When the status bar appears
+
+- On **deck** and **narrow** breakpoints.
+- On **short desktop windows** where the shell height is at or below
+  **720px**, even if the width is still desktop-sized.
+
+## User flow
+
+1. Resize the window to a narrow or short shell.
+2. The full runtime console drawer is replaced by a **32px status bar**.
+3. The bar shows:
+   - current log line count
+   - host-readiness summary chips
+   - a `⌘K commands` hint
+4. Resize back to a larger desktop shell.
+5. The full drawer surface returns and can be expanded manually.
+
+## Drawer behavior on larger shells
+
+- The drawer remains available on desktop and ultrawide layouts.
+- Incoming log lines update the count, but **do not auto-open** the drawer.
+- The existing “start expanded” preference still applies only to the drawer
+  mode on larger shells.
+
+## Implementation files
+
+| Area                        | Path                                                                                                                                                                                                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shell breakpoint gate       | `src/crosshook-native/src/components/layout/AppShell.tsx`                                                                                                                                                                                                            |
+| Drawer/status UI            | `src/crosshook-native/src/components/layout/ConsoleDrawer.tsx`                                                                                                                                                                                                       |
+| Drawer/status styles        | `src/crosshook-native/src/styles/console-drawer.css`                                                                                                                                                                                                                 |
+| Compact shell layout        | `src/crosshook-native/src/styles/layout.css`                                                                                                                                                                                                                         |
+| User-facing copy updates    | `src/crosshook-native/src/components/settings/LoggingAndUiSection.tsx`, `src/crosshook-native/src/hooks/useRunExecutable.ts`, `src/crosshook-native/src/components/RunExecutablePanel.tsx`                                                                           |
+| Breakpoint fixtures + tests | `src/crosshook-native/src/test/breakpoint.ts`, `src/crosshook-native/src/test/__tests__/breakpoint.test.ts`, `src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx`, `src/crosshook-native/src/components/layout/__tests__/ConsoleDrawer.test.tsx` |
+
+## Limitations
+
+- The browser-dev Playwright smoke path still hits an existing `LibraryPage`
+  render-loop warning; targeted Vitest coverage covers the shell mode logic.

--- a/src/crosshook-native/package-lock.json
+++ b/src/crosshook-native/package-lock.json
@@ -34,6 +34,9 @@
         "typescript": "^5.6.3",
         "vite": "^8.0.5",
         "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/crosshook-native/src/components/RunExecutablePanel.tsx
+++ b/src/crosshook-native/src/components/RunExecutablePanel.tsx
@@ -241,7 +241,7 @@ export function RunExecutablePanel({ protonInstalls, protonInstallsError }: RunE
           >
             <h4 id="run-executable-confirm-title">Run {fileNameFromPath(request.executable_path)} through Proton?</h4>
             <p id="run-executable-confirm-body">
-              This will spawn the executable inside {prefixHint} and stream its output to the console drawer.
+              This will spawn the executable inside {prefixHint} and stream its output to the runtime console.
             </p>
             <div className="crosshook-modal-actions">
               <button

--- a/src/crosshook-native/src/components/layout/AppShell.tsx
+++ b/src/crosshook-native/src/components/layout/AppShell.tsx
@@ -5,7 +5,7 @@ import { Group, Panel, type PanelImperativeHandle, Separator } from 'react-resiz
 import { CollectionEditModal } from '@/components/collections/CollectionEditModal';
 import { CollectionViewModal } from '@/components/collections/CollectionViewModal';
 import { useCollectionViewModalState } from '@/components/collections/useCollectionViewModalState';
-import ConsoleDrawer from '@/components/layout/ConsoleDrawer';
+import ConsoleDrawer, { type ConsoleMode } from '@/components/layout/ConsoleDrawer';
 import ContentArea from '@/components/layout/ContentArea';
 import ControllerPrompts from '@/components/layout/ControllerPrompts';
 import { Inspector } from '@/components/layout/Inspector';
@@ -36,19 +36,24 @@ import { inspectorWidthForBreakpoint } from './inspectorVariants';
 import { ROUTE_METADATA } from './routeMetadata';
 import { sidebarVariantFromBreakpoint, sidebarWidthForVariant } from './sidebarVariants';
 
-function ConsoleDock({ panelRef }: { panelRef: RefObject<PanelImperativeHandle | null> }) {
+const COMPACT_CONSOLE_MAX_HEIGHT = 720;
+
+function ConsoleDock({ panelRef, mode }: { panelRef: RefObject<PanelImperativeHandle | null>; mode: ConsoleMode }) {
   const { settings } = usePreferencesContext();
   const defaultCollapsed = settings.console_drawer_collapsed_default;
 
   useEffect(() => {
+    if (mode !== 'drawer') {
+      return;
+    }
     if (defaultCollapsed) {
       panelRef.current?.collapse();
     } else {
       panelRef.current?.expand();
     }
-  }, [defaultCollapsed, panelRef]);
+  }, [defaultCollapsed, mode, panelRef]);
 
-  return <ConsoleDrawer panelRef={panelRef} defaultCollapsed={defaultCollapsed} />;
+  return <ConsoleDrawer panelRef={panelRef} mode={mode} defaultCollapsed={defaultCollapsed} />;
 }
 
 function AccessibilityThemeSync() {
@@ -68,6 +73,8 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
   const paletteRestoreTargetRef = useRef<HTMLElement | null>(null);
   const [showOnboarding, setShowOnboarding] = useState(false);
   const breakpoint = useBreakpoint(shellRef);
+  const consoleMode: ConsoleMode =
+    breakpoint.isDeck || breakpoint.isNarrow || breakpoint.height <= COMPACT_CONSOLE_MAX_HEIGHT ? 'status' : 'drawer';
   const sidebarVariant = sidebarVariantFromBreakpoint(breakpoint.size, breakpoint.height);
   const sidebarWidth = sidebarWidthForVariant(sidebarVariant);
   const inspectorWidthBase = inspectorWidthForBreakpoint(breakpoint.size);
@@ -352,27 +359,38 @@ export function AppShell({ controllerMode }: { controllerMode: boolean }) {
                   />
                 </Panel>
                 <Panel className="crosshook-shell-panel" minSize="28%">
-                  <Group
-                    className="crosshook-shell-group"
-                    orientation="vertical"
-                    resizeTargetMinimumSize={{ coarse: 36, fine: 12 }}
-                  >
-                    <Panel className="crosshook-shell-panel" defaultSize="80%" minSize="28%">
-                      <ContentArea route={route} onNavigate={setRoute} onOpenCommandPalette={openPalette} />
-                    </Panel>
-                    <Separator className="crosshook-resize-handle crosshook-resize-handle--horizontal" />
-                    <Panel
-                      className="crosshook-shell-panel"
-                      panelRef={consolePanelRef}
-                      collapsible
-                      collapsedSize="40px"
-                      defaultSize="60%"
-                      minSize="25%"
-                      maxSize="75%"
+                  {consoleMode === 'drawer' ? (
+                    <Group
+                      className="crosshook-shell-group"
+                      orientation="vertical"
+                      resizeTargetMinimumSize={{ coarse: 36, fine: 12 }}
                     >
-                      <ConsoleDock panelRef={consolePanelRef} />
-                    </Panel>
-                  </Group>
+                      <Panel className="crosshook-shell-panel" defaultSize="80%" minSize="28%">
+                        <ContentArea route={route} onNavigate={setRoute} onOpenCommandPalette={openPalette} />
+                      </Panel>
+                      <Separator className="crosshook-resize-handle crosshook-resize-handle--horizontal" />
+                      <Panel
+                        className="crosshook-shell-panel"
+                        panelRef={consolePanelRef}
+                        collapsible
+                        collapsedSize="40px"
+                        defaultSize="60%"
+                        minSize="25%"
+                        maxSize="75%"
+                      >
+                        <ConsoleDock panelRef={consolePanelRef} mode={consoleMode} />
+                      </Panel>
+                    </Group>
+                  ) : (
+                    <div className="crosshook-shell-stack">
+                      <div className="crosshook-shell-stack__content">
+                        <ContentArea route={route} onNavigate={setRoute} onOpenCommandPalette={openPalette} />
+                      </div>
+                      <div className="crosshook-shell-stack__footer">
+                        <ConsoleDock panelRef={consolePanelRef} mode={consoleMode} />
+                      </div>
+                    </div>
+                  )}
                 </Panel>
                 {inspectorWidth > 0 ? (
                   <Panel

--- a/src/crosshook-native/src/components/layout/ConsoleDrawer.tsx
+++ b/src/crosshook-native/src/components/layout/ConsoleDrawer.tsx
@@ -1,6 +1,8 @@
-import { type RefObject, useEffect, useId, useState } from 'react';
+import { type RefObject, useEffect, useId, useMemo, useState } from 'react';
 import type { PanelImperativeHandle } from 'react-resizable-panels';
+import { useHostReadinessContext } from '@/context/HostReadinessContext';
 import { subscribeEvent } from '@/lib/events';
+import type { Capability } from '@/types/onboarding';
 import { type LogPayload, normalizeLogMessage } from '../../utils/log';
 import ConsoleView from '../ConsoleView';
 
@@ -17,20 +19,59 @@ function formatLineCount(count: number): string {
   return count === 1 ? '1 line' : `${count} lines`;
 }
 
+function resolveCountTone(readyCount: number, totalCount: number): 'success' | 'warning' | 'danger' | 'muted' {
+  if (totalCount === 0) {
+    return 'muted';
+  }
+  if (readyCount >= totalCount) {
+    return 'success';
+  }
+  if (readyCount === 0) {
+    return 'danger';
+  }
+  return 'warning';
+}
+
+function countAvailableCapabilities(capabilities: Capability[]): number {
+  return capabilities.filter((capability) => capability.state === 'available').length;
+}
+
+export type ConsoleMode = 'drawer' | 'status';
+
 interface ConsoleDrawerProps {
   panelRef: RefObject<PanelImperativeHandle | null>;
-  /** When true (default), the drawer starts collapsed until logs arrive. */
+  mode?: ConsoleMode;
+  /** When true (default), the drawer starts collapsed until the user expands it. */
   defaultCollapsed?: boolean;
 }
 
-export function ConsoleDrawer({ panelRef, defaultCollapsed = true }: ConsoleDrawerProps) {
+export function ConsoleDrawer({ panelRef, mode = 'drawer', defaultCollapsed = true }: ConsoleDrawerProps) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [lineCount, setLineCount] = useState(0);
   const bodyId = useId();
+  const { snapshot, capabilities, isStale, isRefreshing, error } = useHostReadinessContext();
+
+  const readinessSummary = useMemo(() => {
+    const toolChecks = snapshot?.tool_checks ?? [];
+    const requiredTotal = toolChecks.filter((tool) => tool.is_required).length;
+    const requiredReady = toolChecks.filter((tool) => tool.is_required && tool.is_available).length;
+    const optionalTotal = capabilities.length;
+    const optionalAvailable = countAvailableCapabilities(capabilities);
+    return {
+      requiredReady,
+      requiredTotal,
+      optionalAvailable,
+      optionalTotal,
+      requiredTone: resolveCountTone(requiredReady, requiredTotal),
+      optionalTone: resolveCountTone(optionalAvailable, optionalTotal),
+    };
+  }, [capabilities, snapshot?.tool_checks]);
 
   useEffect(() => {
-    setCollapsed(defaultCollapsed);
-  }, [defaultCollapsed]);
+    if (mode === 'drawer') {
+      setCollapsed(defaultCollapsed);
+    }
+  }, [defaultCollapsed, mode]);
 
   const collapse = () => {
     setCollapsed(true);
@@ -60,13 +101,6 @@ export function ConsoleDrawer({ panelRef, defaultCollapsed = true }: ConsoleDraw
         return;
       }
 
-      setCollapsed((current) => {
-        if (current) {
-          panelRef.current?.expand();
-          return false;
-        }
-        return current;
-      });
       setLineCount((current) => current + nextLineCount);
     };
 
@@ -78,12 +112,52 @@ export function ConsoleDrawer({ panelRef, defaultCollapsed = true }: ConsoleDraw
       void unlistenLaunch.then((unlisten) => unlisten());
       void unlistenUpdate.then((unlisten) => unlisten());
     };
-  }, [panelRef]);
+  }, []);
+
+  if (mode === 'status') {
+    return (
+      <section
+        aria-label="Runtime console status"
+        className="crosshook-console-drawer crosshook-console-drawer--status"
+        data-testid="console-status-bar"
+      >
+        <div className="crosshook-console-drawer__status-inner">
+          <span className="crosshook-console-drawer__status-label">Runtime console</span>
+          <div className="crosshook-console-drawer__status-chips" role="status" aria-live="polite">
+            <span className="crosshook-status-chip crosshook-status-chip--muted">{formatLineCount(lineCount)}</span>
+            {error ? (
+              <span className="crosshook-status-chip crosshook-status-chip--warning">Host tools unavailable</span>
+            ) : snapshot === null && isRefreshing ? (
+              <span className="crosshook-status-chip crosshook-status-chip--muted">Checking host tools</span>
+            ) : (
+              <>
+                <span className={`crosshook-status-chip crosshook-status-chip--${readinessSummary.requiredTone}`}>
+                  {readinessSummary.requiredTotal > 0
+                    ? `${readinessSummary.requiredReady}/${readinessSummary.requiredTotal} required`
+                    : 'Required tools ready'}
+                </span>
+                <span className={`crosshook-status-chip crosshook-status-chip--${readinessSummary.optionalTone}`}>
+                  {readinessSummary.optionalTotal > 0
+                    ? `${readinessSummary.optionalAvailable}/${readinessSummary.optionalTotal} capabilities`
+                    : 'No capabilities'}
+                </span>
+                {isStale ? (
+                  <span className="crosshook-status-chip crosshook-status-chip--warning">Stale data</span>
+                ) : null}
+              </>
+            )}
+          </div>
+          <span className="crosshook-console-drawer__status-tip">⌘K commands</span>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section
       aria-label="Runtime console"
       className={`crosshook-console-drawer${collapsed ? ' crosshook-console-drawer--collapsed' : ''}`}
+      data-testid="console-drawer"
     >
       <button
         type="button"

--- a/src/crosshook-native/src/components/layout/ConsoleDrawer.tsx
+++ b/src/crosshook-native/src/components/layout/ConsoleDrawer.tsx
@@ -20,8 +20,9 @@ function formatLineCount(count: number): string {
 }
 
 function resolveCountTone(readyCount: number, totalCount: number): 'success' | 'warning' | 'danger' | 'muted' {
+  // Match CapabilitySummaryStrip: zero total means nothing to wait on (treated as available/success).
   if (totalCount === 0) {
-    return 'muted';
+    return 'success';
   }
   if (readyCount >= totalCount) {
     return 'success';
@@ -38,17 +39,7 @@ function countAvailableCapabilities(capabilities: Capability[]): number {
 
 export type ConsoleMode = 'drawer' | 'status';
 
-interface ConsoleDrawerProps {
-  panelRef: RefObject<PanelImperativeHandle | null>;
-  mode?: ConsoleMode;
-  /** When true (default), the drawer starts collapsed until the user expands it. */
-  defaultCollapsed?: boolean;
-}
-
-export function ConsoleDrawer({ panelRef, mode = 'drawer', defaultCollapsed = true }: ConsoleDrawerProps) {
-  const [collapsed, setCollapsed] = useState(defaultCollapsed);
-  const [lineCount, setLineCount] = useState(0);
-  const bodyId = useId();
+function ConsoleStatusBar({ lineCount }: { lineCount: number }) {
   const { snapshot, capabilities, isStale, isRefreshing, error } = useHostReadinessContext();
 
   const readinessSummary = useMemo(() => {
@@ -66,6 +57,56 @@ export function ConsoleDrawer({ panelRef, mode = 'drawer', defaultCollapsed = tr
       optionalTone: resolveCountTone(optionalAvailable, optionalTotal),
     };
   }, [capabilities, snapshot?.tool_checks]);
+
+  return (
+    <section
+      aria-label="Runtime console status"
+      className="crosshook-console-drawer crosshook-console-drawer--status"
+      data-testid="console-status-bar"
+    >
+      <div className="crosshook-console-drawer__status-inner">
+        <span className="crosshook-console-drawer__status-label">Runtime console</span>
+        <div className="crosshook-console-drawer__status-chips" role="status" aria-live="polite">
+          <span className="crosshook-status-chip crosshook-status-chip--muted">{formatLineCount(lineCount)}</span>
+          {error ? (
+            <span className="crosshook-status-chip crosshook-status-chip--warning">Host tools unavailable</span>
+          ) : snapshot === null && isRefreshing ? (
+            <span className="crosshook-status-chip crosshook-status-chip--muted">Checking host tools</span>
+          ) : (
+            <>
+              <span className={`crosshook-status-chip crosshook-status-chip--${readinessSummary.requiredTone}`}>
+                {readinessSummary.requiredTotal > 0
+                  ? `${readinessSummary.requiredReady}/${readinessSummary.requiredTotal} required`
+                  : 'Required tools ready'}
+              </span>
+              <span className={`crosshook-status-chip crosshook-status-chip--${readinessSummary.optionalTone}`}>
+                {readinessSummary.optionalTotal > 0
+                  ? `${readinessSummary.optionalAvailable}/${readinessSummary.optionalTotal} capabilities`
+                  : 'No capabilities'}
+              </span>
+              {isStale ? (
+                <span className="crosshook-status-chip crosshook-status-chip--warning">Stale data</span>
+              ) : null}
+            </>
+          )}
+        </div>
+        <span className="crosshook-console-drawer__status-tip">⌘K commands</span>
+      </div>
+    </section>
+  );
+}
+
+interface ConsoleDrawerProps {
+  panelRef: RefObject<PanelImperativeHandle | null>;
+  mode?: ConsoleMode;
+  /** When true (default), the drawer starts collapsed until the user expands it. */
+  defaultCollapsed?: boolean;
+}
+
+export function ConsoleDrawer({ panelRef, mode = 'drawer', defaultCollapsed = true }: ConsoleDrawerProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const [lineCount, setLineCount] = useState(0);
+  const bodyId = useId();
 
   useEffect(() => {
     if (mode === 'drawer') {
@@ -115,42 +156,7 @@ export function ConsoleDrawer({ panelRef, mode = 'drawer', defaultCollapsed = tr
   }, []);
 
   if (mode === 'status') {
-    return (
-      <section
-        aria-label="Runtime console status"
-        className="crosshook-console-drawer crosshook-console-drawer--status"
-        data-testid="console-status-bar"
-      >
-        <div className="crosshook-console-drawer__status-inner">
-          <span className="crosshook-console-drawer__status-label">Runtime console</span>
-          <div className="crosshook-console-drawer__status-chips" role="status" aria-live="polite">
-            <span className="crosshook-status-chip crosshook-status-chip--muted">{formatLineCount(lineCount)}</span>
-            {error ? (
-              <span className="crosshook-status-chip crosshook-status-chip--warning">Host tools unavailable</span>
-            ) : snapshot === null && isRefreshing ? (
-              <span className="crosshook-status-chip crosshook-status-chip--muted">Checking host tools</span>
-            ) : (
-              <>
-                <span className={`crosshook-status-chip crosshook-status-chip--${readinessSummary.requiredTone}`}>
-                  {readinessSummary.requiredTotal > 0
-                    ? `${readinessSummary.requiredReady}/${readinessSummary.requiredTotal} required`
-                    : 'Required tools ready'}
-                </span>
-                <span className={`crosshook-status-chip crosshook-status-chip--${readinessSummary.optionalTone}`}>
-                  {readinessSummary.optionalTotal > 0
-                    ? `${readinessSummary.optionalAvailable}/${readinessSummary.optionalTotal} capabilities`
-                    : 'No capabilities'}
-                </span>
-                {isStale ? (
-                  <span className="crosshook-status-chip crosshook-status-chip--warning">Stale data</span>
-                ) : null}
-              </>
-            )}
-          </div>
-          <span className="crosshook-console-drawer__status-tip">⌘K commands</span>
-        </div>
-      </section>
-    );
+    return <ConsoleStatusBar lineCount={lineCount} />;
   }
 
   return (

--- a/src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx
+++ b/src/crosshook-native/src/components/layout/__tests__/AppShell.test.tsx
@@ -7,6 +7,7 @@ import { HostReadinessProvider } from '@/context/HostReadinessContext';
 import { InspectorSelectionProvider } from '@/context/InspectorSelectionContext';
 import { ProfileProvider } from '@/context/ProfileContext';
 import { ProfileHealthProvider } from '@/context/ProfileHealthContext';
+import { emitMockEvent } from '@/lib/events';
 import { renderWithMocks } from '@/test/render';
 
 function AppShellInAppProviders() {
@@ -164,6 +165,62 @@ describe('AppShell (integration)', () => {
         expect(screen.getByTestId('sidebar')).toBeInTheDocument();
         expect(screen.queryByTestId('inspector')).not.toBeInTheDocument();
       });
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('renders the compact status bar instead of the drawer on narrow shells', async () => {
+    setInnerWidth(1280);
+    setInnerHeight(800);
+    const rectSpy = mockAppShellRect(1280, 800);
+    try {
+      renderWithMocks(<AppShellInAppProviders />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('console-status-bar')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('console-drawer')).not.toBeInTheDocument();
+      expect(screen.getByText('⌘K commands')).toBeInTheDocument();
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('renders the compact status bar on short desktop-height shells', async () => {
+    setInnerWidth(1920);
+    setInnerHeight(600);
+    const rectSpy = mockAppShellRect(1920, 600);
+    try {
+      renderWithMocks(<AppShellInAppProviders />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('console-status-bar')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('console-drawer')).not.toBeInTheDocument();
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('keeps the drawer on desktop shells and does not auto-open on log events', async () => {
+    setInnerWidth(1920);
+    setInnerHeight(1080);
+    const rectSpy = mockAppShellRect(1920, 1080);
+    try {
+      renderWithMocks(<AppShellInAppProviders />);
+
+      const toggle = await screen.findByRole('button', { name: /runtime console/i });
+      expect(screen.getByTestId('console-drawer')).toBeInTheDocument();
+      expect(screen.queryByTestId('console-status-bar')).not.toBeInTheDocument();
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+      emitMockEvent('launch-log', 'one line');
+
+      await waitFor(() => {
+        expect(screen.getByText('1 line')).toBeInTheDocument();
+      });
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
     } finally {
       rectSpy.mockRestore();
     }

--- a/src/crosshook-native/src/components/layout/__tests__/ConsoleDrawer.test.tsx
+++ b/src/crosshook-native/src/components/layout/__tests__/ConsoleDrawer.test.tsx
@@ -1,0 +1,62 @@
+import { act, screen, waitFor } from '@testing-library/react';
+import type { PanelImperativeHandle } from 'react-resizable-panels';
+import { describe, expect, it, vi } from 'vitest';
+import { HostReadinessProvider } from '@/context/HostReadinessContext';
+import { emitMockEvent } from '@/lib/events';
+import { renderWithMocks } from '@/test/render';
+import { ConsoleDrawer } from '../ConsoleDrawer';
+
+function createPanelRef() {
+  return {
+    current: {
+      collapse: vi.fn(),
+      expand: vi.fn(),
+    } as unknown as PanelImperativeHandle,
+  };
+}
+
+describe('ConsoleDrawer', () => {
+  it('renders the compact status bar on narrow layouts', async () => {
+    const panelRef = createPanelRef();
+
+    renderWithMocks(
+      <HostReadinessProvider>
+        <ConsoleDrawer panelRef={panelRef} mode="status" />
+      </HostReadinessProvider>
+    );
+
+    expect(screen.getByTestId('console-status-bar')).toBeInTheDocument();
+    expect(screen.getByText('Runtime console')).toBeInTheDocument();
+    expect(screen.getByText('⌘K commands')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/required/i)).toBeInTheDocument();
+      expect(screen.getByText(/capabilities/i)).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the wide drawer collapsed when log events arrive', async () => {
+    const panelRef = createPanelRef();
+
+    renderWithMocks(
+      <HostReadinessProvider>
+        <ConsoleDrawer panelRef={panelRef} mode="drawer" />
+      </HostReadinessProvider>
+    );
+
+    const toggle = screen.getByRole('button', { name: /runtime console/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      emitMockEvent('launch-log', 'first line\nsecond line');
+    });
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('2 lines')).toBeInTheDocument();
+    expect(panelRef.current.expand).not.toHaveBeenCalled();
+  });
+});

--- a/src/crosshook-native/src/components/pages/LibraryPage.tsx
+++ b/src/crosshook-native/src/components/pages/LibraryPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useInspectorSelection } from '@/context/InspectorSelectionContext';
 import { useCollections } from '@/hooks/useCollections';
 import { useProfileContext } from '../../context/ProfileContext';
@@ -71,6 +71,15 @@ export function LibraryPage({ onNavigate, onOpenCommandPalette }: LibraryPagePro
   const [createCollectionFromMenuOpen, setCreateCollectionFromMenuOpen] = useState(false);
   const [createCollectionSessionError, setCreateCollectionSessionError] = useState<string | null>(null);
   const { createCollection } = useCollections();
+  const activeCollectionIdRef = useRef(activeCollectionId);
+  const activeCollectionMemberNamesRef = useRef(activeCollectionMemberNames);
+  const activeCollectionMembersFetchedForRef = useRef(activeCollectionMembersFetchedFor);
+  const activeCollectionMembersLoadingRef = useRef(activeCollectionMembersLoading);
+
+  activeCollectionIdRef.current = activeCollectionId;
+  activeCollectionMemberNamesRef.current = activeCollectionMemberNames;
+  activeCollectionMembersFetchedForRef.current = activeCollectionMembersFetchedFor;
+  activeCollectionMembersLoadingRef.current = activeCollectionMembersLoading;
 
   // Refresh profile list from context on mount
   useEffect(() => {
@@ -123,26 +132,20 @@ export function LibraryPage({ onNavigate, onOpenCommandPalette }: LibraryPagePro
     async (name: string) => {
       setLaunchingName(name);
       try {
+        const currentCollectionId = activeCollectionIdRef.current;
         const membersReady =
-          activeCollectionId !== null &&
-          !activeCollectionMembersLoading &&
-          activeCollectionMembersFetchedFor === activeCollectionId;
-        const profileIsInActiveCollection = membersReady && activeCollectionMemberNames.includes(name);
-        const collectionIdForLoad = profileIsInActiveCollection ? (activeCollectionId ?? undefined) : undefined;
+          currentCollectionId !== null &&
+          !activeCollectionMembersLoadingRef.current &&
+          activeCollectionMembersFetchedForRef.current === currentCollectionId;
+        const profileIsInActiveCollection = membersReady && activeCollectionMemberNamesRef.current.includes(name);
+        const collectionIdForLoad = profileIsInActiveCollection ? (currentCollectionId ?? undefined) : undefined;
         await selectProfile(name, { collectionId: collectionIdForLoad });
         onNavigate?.('launch');
       } finally {
         setLaunchingName(undefined);
       }
     },
-    [
-      selectProfile,
-      onNavigate,
-      activeCollectionId,
-      activeCollectionMemberNames,
-      activeCollectionMembersFetchedFor,
-      activeCollectionMembersLoading,
-    ]
+    [selectProfile, onNavigate]
   );
 
   // Edit handler: select profile then navigate to profiles page

--- a/src/crosshook-native/src/components/settings/LoggingAndUiSection.tsx
+++ b/src/crosshook-native/src/components/settings/LoggingAndUiSection.tsx
@@ -51,7 +51,7 @@ export function LoggingAndUiSection({ settings, onPersistSettings }: LoggingAndU
         <span>
           <span className="crosshook-label">Start with console drawer expanded</span>
           <p className="crosshook-muted crosshook-settings-note">
-            When off, the drawer starts collapsed until launch logs arrive.
+            Applies on desktop and ultrawide layouts only. Narrow and deck layouts use the compact status bar.
           </p>
         </span>
       </label>

--- a/src/crosshook-native/src/components/settings/LoggingAndUiSection.tsx
+++ b/src/crosshook-native/src/components/settings/LoggingAndUiSection.tsx
@@ -51,7 +51,9 @@ export function LoggingAndUiSection({ settings, onPersistSettings }: LoggingAndU
         <span>
           <span className="crosshook-label">Start with console drawer expanded</span>
           <p className="crosshook-muted crosshook-settings-note">
-            Applies on desktop and ultrawide layouts only. Narrow and deck layouts use the compact status bar.
+            Applies on desktop and ultrawide layouts when the shell is tall enough. Narrow, deck, or short-height shells
+            (window height ≤ 720px) use the compact status bar instead—AppShell switches to status mode below that
+            threshold.
           </p>
         </span>
       </label>

--- a/src/crosshook-native/src/context/InspectorSelectionContext.tsx
+++ b/src/crosshook-native/src/context/InspectorSelectionContext.tsx
@@ -28,8 +28,21 @@ const InspectorSelectionContext = createContext<InspectorSelectionContextValue |
 
 export function InspectorSelectionProvider({ children }: { children: ReactNode }) {
   const [inspectorSelection, setInspectorSelection] = useState<SelectedGame | undefined>();
-  const [libraryInspectorHandlers, setLibraryInspectorHandlers] = useState<LibraryInspectorHandlers | undefined>();
+  const [libraryInspectorHandlers, setLibraryInspectorHandlersState] = useState<LibraryInspectorHandlers | undefined>();
   const [libraryShellMode, setLibraryShellModeState] = useState<LibraryShellMode>('library');
+
+  const setLibraryInspectorHandlers = useCallback((handlers: LibraryInspectorHandlers | undefined) => {
+    setLibraryInspectorHandlersState((prev) => {
+      if (
+        prev?.onLaunch === handlers?.onLaunch &&
+        prev?.onEditProfile === handlers?.onEditProfile &&
+        prev?.onToggleFavorite === handlers?.onToggleFavorite
+      ) {
+        return prev;
+      }
+      return handlers;
+    });
+  }, []);
 
   const setLibraryShellMode = useCallback<Dispatch<SetStateAction<LibraryShellMode>>>((update) => {
     setLibraryShellModeState((prev) => {
@@ -47,7 +60,7 @@ export function InspectorSelectionProvider({ children }: { children: ReactNode }
       libraryShellMode,
       setLibraryShellMode,
     }),
-    [inspectorSelection, libraryInspectorHandlers, libraryShellMode, setLibraryShellMode]
+    [inspectorSelection, libraryInspectorHandlers, libraryShellMode, setLibraryInspectorHandlers, setLibraryShellMode]
   );
 
   return <InspectorSelectionContext.Provider value={value}>{children}</InspectorSelectionContext.Provider>;

--- a/src/crosshook-native/src/hooks/useRunExecutable.ts
+++ b/src/crosshook-native/src/hooks/useRunExecutable.ts
@@ -260,11 +260,11 @@ export function useRunExecutable(): UseRunExecutableResult {
   const hintText = (() => {
     switch (stage) {
       case 'running':
-        return 'Check the console drawer for live output.';
+        return 'Check the runtime console for live output.';
       case 'complete':
         return 'The executable finished. Review the log for details.';
       case 'failed':
-        return 'Check the console drawer log for details.';
+        return 'Check the runtime console log for details.';
       default:
         return '';
     }

--- a/src/crosshook-native/src/styles/console-drawer.css
+++ b/src/crosshook-native/src/styles/console-drawer.css
@@ -9,6 +9,61 @@
   overflow: hidden;
 }
 
+.crosshook-console-drawer--status {
+  height: 32px;
+  display: flex;
+  align-items: stretch;
+  border-top: 1px solid var(--crosshook-color-border);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 55%),
+    linear-gradient(90deg, rgba(74, 125, 181, 0.08), transparent 22%),
+    var(--crosshook-color-surface);
+}
+
+.crosshook-console-drawer__status-inner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-width: 0;
+  padding: 0 12px;
+}
+
+.crosshook-console-drawer__status-label,
+.crosshook-console-drawer__status-tip {
+  color: var(--crosshook-color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.crosshook-console-drawer__status-chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  overscroll-behavior: contain;
+}
+
+.crosshook-console-drawer__status-chips::-webkit-scrollbar {
+  display: none;
+}
+
+.crosshook-console-drawer__status-chips .crosshook-status-chip {
+  flex: 0 0 auto;
+  padding: 4px 9px;
+  font-size: 0.7rem;
+}
+
+.crosshook-console-drawer__status-tip {
+  margin-left: auto;
+}
+
 .crosshook-console-drawer--collapsed {
   grid-template-rows: auto 0fr;
 }
@@ -35,4 +90,16 @@
 .crosshook-console-drawer--collapsed .crosshook-console-drawer__body {
   overflow: hidden;
   pointer-events: none;
+}
+
+@media (max-width: 1240px) {
+  .crosshook-console-drawer__status-label {
+    display: none;
+  }
+}
+
+@media (max-width: 920px) {
+  .crosshook-console-drawer__status-tip {
+    display: none;
+  }
 }

--- a/src/crosshook-native/src/styles/layout.css
+++ b/src/crosshook-native/src/styles/layout.css
@@ -31,6 +31,27 @@
   overflow: hidden;
 }
 
+.crosshook-shell-stack {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.crosshook-shell-stack__content {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.crosshook-shell-stack__footer {
+  flex: 0 0 auto;
+  min-width: 0;
+}
+
 .crosshook-content-area {
   min-width: 0;
   min-height: 0;

--- a/src/crosshook-native/src/test/__tests__/breakpoint.test.ts
+++ b/src/crosshook-native/src/test/__tests__/breakpoint.test.ts
@@ -4,8 +4,21 @@ import { BREAKPOINT_PX, breakpointResult } from '../breakpoint';
 describe('breakpointResult', () => {
   it('marks deck flags for deck size', () => {
     expect(breakpointResult('deck').isDeck).toBe(true);
+    expect(breakpointResult('deck').isNarrow).toBe(false);
     expect(breakpointResult('deck').isUw).toBe(false);
     expect(breakpointResult('deck').width).toBe(BREAKPOINT_PX.deck);
+  });
+
+  it('marks narrow flags for narrow size', () => {
+    expect(breakpointResult('narrow').isNarrow).toBe(true);
+    expect(breakpointResult('narrow').isDeck).toBe(false);
+    expect(breakpointResult('narrow').width).toBe(BREAKPOINT_PX.narrow);
+  });
+
+  it('marks desk flags for desk size', () => {
+    expect(breakpointResult('desk').isDesk).toBe(true);
+    expect(breakpointResult('desk').isDeck).toBe(false);
+    expect(breakpointResult('desk').width).toBe(BREAKPOINT_PX.desk);
   });
 
   it('marks uw flags for uw size', () => {

--- a/src/crosshook-native/src/test/breakpoint.ts
+++ b/src/crosshook-native/src/test/breakpoint.ts
@@ -1,7 +1,7 @@
 import type { BreakpointSize, UseBreakpointResult } from '@/hooks/useBreakpoint';
 
-/** Deterministic shell widths for unit tests (match typical viewports per bucket). */
-export const BREAKPOINT_PX = { uw: 2560, desk: 1920, narrow: 1440, deck: 1280 } as const;
+/** Deterministic shell widths for unit tests (match the actual breakpoint buckets). */
+export const BREAKPOINT_PX = { uw: 2560, desk: 1920, narrow: 1280, deck: 1024 } as const;
 
 function flagsFor(size: BreakpointSize): Pick<UseBreakpointResult, 'isDeck' | 'isNarrow' | 'isDesk' | 'isUw'> {
   return {

--- a/src/crosshook-native/tests/smoke.spec.ts
+++ b/src/crosshook-native/tests/smoke.spec.ts
@@ -212,3 +212,40 @@ test.describe('command palette smoke', () => {
     expect(capture.errors, `Command-palette toolbar errors:\n${capture.errors.join('\n')}`).toEqual([]);
   });
 });
+
+test.describe('console chrome smoke', () => {
+  test('renders the compact status bar at narrow width', async ({ page }) => {
+    const capture = attachConsoleCapture(page);
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto('/?fixture=populated');
+
+    await expect(page.getByTestId('console-status-bar')).toBeVisible();
+    await expect(page.getByTestId('console-drawer')).toHaveCount(0);
+    await expect(page.getByText('⌘K commands')).toBeVisible();
+
+    expect(capture.errors, `Narrow console chrome errors:\n${capture.errors.join('\n')}`).toEqual([]);
+  });
+
+  test('keeps the drawer collapsed on desktop after log output arrives', async ({ page }) => {
+    const capture = attachConsoleCapture(page);
+
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await page.goto('/?fixture=populated');
+
+    const drawer = page.getByTestId('console-drawer');
+    const toggle = page.getByRole('button', { name: 'Runtime console' });
+    await expect(drawer).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    const launchTab = page.getByRole('tab', { name: 'Launch', exact: true });
+    await launchTab.click();
+    await expect(launchTab).toHaveAttribute('aria-current', 'page');
+    await page.getByRole('button', { name: 'Launch Game' }).click();
+
+    await expect(page.getByText(/^[0-9]+ lines?$/)).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    expect(capture.errors, `Desktop console chrome errors:\n${capture.errors.join('\n')}`).toEqual([]);
+  });
+});

--- a/src/crosshook-native/tests/smoke.spec.ts
+++ b/src/crosshook-native/tests/smoke.spec.ts
@@ -238,16 +238,32 @@ test.describe('console chrome smoke', () => {
     await expect(drawer).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
-    const libraryTab = page.getByRole('tab', { name: 'Library', exact: true });
-    await libraryTab.click();
-    await expect(libraryTab).toHaveAttribute('aria-current', 'page');
-    await page.getByRole('button', { name: 'Launch Test Game Alpha' }).click();
-
     const launchTab = page.getByRole('tab', { name: 'Launch', exact: true });
+    await launchTab.click();
     await expect(launchTab).toHaveAttribute('aria-current', 'page');
-    await page.getByRole('button', { name: 'Launch Game' }).click();
 
-    await expect(page.getByText(/^[0-9]+ lines?$/)).toBeVisible();
+    const profileSelect = page.locator('#launch-profile-selector');
+    await expect(profileSelect).toBeVisible();
+    await profileSelect.click();
+    await page.getByRole('option', { name: 'Test Game Alpha', exact: true }).click();
+    await expect(profileSelect).toContainText('Test Game Alpha');
+
+    const profilesTab = page.getByRole('tab', { name: 'Profiles', exact: true });
+    await profilesTab.click();
+    await expect(profilesTab).toHaveAttribute('aria-current', 'page');
+
+    const gamePathField = page.getByLabel('Game Path', { exact: true });
+    await expect(gamePathField).toBeVisible();
+    await gamePathField.fill('/home/devuser/Games/TestGameAlpha/game.exe');
+
+    await launchTab.click();
+    await expect(launchTab).toHaveAttribute('aria-current', 'page');
+
+    const launchGameButton = page.getByRole('button', { name: /^launch game$/i });
+    await expect(launchGameButton).toBeEnabled();
+    await launchGameButton.click();
+
+    await expect(page.getByText(/^[1-9][0-9]* lines?$/)).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
     expect(capture.errors, `Desktop console chrome errors:\n${capture.errors.join('\n')}`).toEqual([]);

--- a/src/crosshook-native/tests/smoke.spec.ts
+++ b/src/crosshook-native/tests/smoke.spec.ts
@@ -238,8 +238,12 @@ test.describe('console chrome smoke', () => {
     await expect(drawer).toBeVisible();
     await expect(toggle).toHaveAttribute('aria-expanded', 'false');
 
+    const libraryTab = page.getByRole('tab', { name: 'Library', exact: true });
+    await libraryTab.click();
+    await expect(libraryTab).toHaveAttribute('aria-current', 'page');
+    await page.getByRole('button', { name: 'Launch Test Game Alpha' }).click();
+
     const launchTab = page.getByRole('tab', { name: 'Launch', exact: true });
-    await launchTab.click();
     await expect(launchTab).toHaveAttribute('aria-current', 'page');
     await page.getByRole('button', { name: 'Launch Game' }).click();
 


### PR DESCRIPTION
## Summary

Implement Phase 8 of the unified desktop redesign by replacing the bottom runtime console drawer with a responsive status bar on narrow or short shells while keeping the full drawer on larger shells.

Closes #420
Closes #447

## Changes

- switch the shell bottom chrome between drawer and 32px status bar based on width and height
- remove log-driven auto-open behavior from the wide drawer and keep it explicit-toggle only
- surface host-readiness chips, line count, and the command-palette hint in the compact status bar
- update related user-facing copy and add feature docs plus breakpoint and shell regression tests
- stabilize library inspector handler registration to reduce browser-dev render churn while exercising the new shell path

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Build / CI
- [ ] Compatibility (new game/trainer/platform support)

## Testing

### Environment

- **Platform**: Linux desktop
- **Proton Version** (if applicable): N/A
- **Game / Trainer** (if applicable): N/A

### Checklist

- [x] `./scripts/lint.sh` passes (or run `./scripts/format.sh` / `./scripts/lint.sh --fix`; same-repo PRs may get a formatting bot commit from `lint-autofix.yml`)
- [x] `./scripts/build-native.sh --binary-only` builds without errors
- [x] `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core` passes
- [x] `./scripts/build-native.sh` produces a valid AppImage (if touching build/packaging)
- [x] Tested on target platform (Linux desktop or Steam Deck)
- [ ] **If touching crates/crosshook-core/src/launch/**: Verified game and trainer launch works
- [ ] **If touching crates/crosshook-core/src/steam/**: Verified Steam auto-populate and Proton discovery
- [ ] **If touching crates/crosshook-core/src/profile/**: Verified profile save/load/import
- [x] **If touching src/components/ or src/hooks/**: Verified UI renders correctly
- [ ] **If touching runtime-helpers/**: Verified shell scripts work under Proton

### Commands run

- `cd src/crosshook-native && npm run test -- --run src/components/layout/__tests__/AppShell.test.tsx src/components/layout/__tests__/ConsoleDrawer.test.tsx src/test/__tests__/breakpoint.test.ts src/hooks/__tests__/useBreakpoint.test.tsx`
- `cd src/crosshook-native && npm run typecheck`
- `cd src/crosshook-native && npm run lint`

## Reviewer Notes

- The compact console mode now applies to short desktop-height shells as well as narrow widths.
- A focused Playwright smoke attempt still hit a browser-dev `LibraryPage` render-loop warning, so this PR relies on targeted Vitest coverage for the new shell logic instead of a clean end-to-end smoke pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive console UI: compact 32px status bar on narrow/short shells; full console drawer on larger displays. Status bar shows runtime log line count, host-readiness chips, and a “⌘K commands” hint.

* **Bug Fixes**
  * Console no longer auto-opens on new logs; expansion remains manual.

* **Documentation**
  * Added docs describing status-bar behavior and updated UI text to reference the “runtime console.”

* **UX Improvements**
  * Clarified settings/help text and execution dialog wording to reference the runtime console.

* **Tests**
  * Added integration and smoke tests validating responsive behavior and no-console-error expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->