### PR TITLE
fix(profiles): stabilize auto-load after refresh

### DIFF
--- a/src/crosshook-native/src/context/__tests__/ProfileContext.test.tsx
+++ b/src/crosshook-native/src/context/__tests__/ProfileContext.test.tsx
@@ -1,0 +1,92 @@
+import { waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfileProvider, useProfileContext } from '@/context/ProfileContext';
+import { emitMockEvent } from '@/lib/events';
+import { makeProfileDraft } from '@/test/fixtures';
+import { renderWithMocks } from '@/test/render';
+
+vi.mock('@/lib/ipc', async () => {
+  const { mockCallCommand } = await import('@/test/render');
+  return { callCommand: mockCallCommand };
+});
+
+const baseOverrides = {
+  profile_list: async () => [],
+  profile_list_summaries: async () => [],
+  profile_list_favorites: async () => [],
+  get_optimization_catalog: async () => null,
+  settings_load: async () => ({
+    auto_load_last_profile: false,
+    last_used_profile: null,
+    auto_install_prefix_deps: false,
+    umu_preference: 'auto',
+    steamgriddb_api_key: null,
+    community_taps: [],
+    steam_client_install_path: null,
+  }),
+  settings_save: async () => null,
+  recent_files_load: async () => ({ game_paths: [], trainer_paths: [], dll_paths: [] }),
+  recent_files_save: async () => null,
+};
+
+function ProfileNameProbe() {
+  const { profileName, selectedProfile } = useProfileContext();
+  return (
+    <div>
+      <span data-testid="profile-name">{profileName}</span>
+      <span data-testid="selected-profile">{selectedProfile}</span>
+    </div>
+  );
+}
+
+describe('ProfileContext', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('auto-load-profile populates profile name after initial refreshProfiles completes', async () => {
+    const PROFILE_NAME = 'My New Game';
+
+    let profileListResolveFn: (() => void) | null = null;
+    const profileListCalled = new Promise<void>((resolve) => {
+      profileListResolveFn = resolve;
+    });
+
+    const { getByTestId } = renderWithMocks(
+      <ProfileProvider>
+        <ProfileNameProbe />
+      </ProfileProvider>,
+      {
+        handlerOverrides: {
+          ...baseOverrides,
+          profile_list: async () => {
+            profileListResolveFn?.();
+            return [];
+          },
+          profile_load: async () =>
+            makeProfileDraft({
+              game: { name: PROFILE_NAME, executable_path: '/mock/game.exe' },
+            }),
+        },
+      }
+    );
+
+    await profileListCalled;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    emitMockEvent('auto-load-profile', PROFILE_NAME);
+
+    await waitFor(
+      () => {
+        expect(getByTestId('profile-name').textContent).toBe(PROFILE_NAME);
+        expect(getByTestId('selected-profile').textContent).toBe(PROFILE_NAME);
+      },
+      { timeout: 3000 }
+    );
+  });
+});

--- a/src/crosshook-native/src/hooks/profile/useProfileCrud.ts
+++ b/src/crosshook-native/src/hooks/profile/useProfileCrud.ts
@@ -178,6 +178,12 @@ export function useProfileCrud({
       setProfiles(names);
 
       if (names.length === 0) {
+        // Preserve an in-flight or completed auto-load when the list is still empty
+        // (startup race: `auto-load-profile` can finish before `profile_list` returns).
+        if (selectedProfile.trim()) {
+          return;
+        }
+
         const empty = createEmptyProfile();
         setSelectedProfile('');
         setProfileName('');

--- a/src/crosshook-native/src/hooks/useProfile.ts
+++ b/src/crosshook-native/src/hooks/useProfile.ts
@@ -187,12 +187,23 @@ export function useProfile(options: UseProfileOptions = {}): UseProfileResult {
 
   const { refreshProfiles, loadFavorites, setError } = crud;
 
+  const refreshProfilesRef = useRef(refreshProfiles);
+  const loadFavoritesRef = useRef(loadFavorites);
+  const setErrorRef = useRef(setError);
+  refreshProfilesRef.current = refreshProfiles;
+  loadFavoritesRef.current = loadFavorites;
+  setErrorRef.current = setError;
+
+  // Run the initial list/favorites fetch once on mount. `refreshProfiles` changes
+  // identity when `selectedProfile` updates (e.g. after `auto-load-profile`), and
+  // re-running this effect would call `refreshProfiles` again with an empty list,
+  // wiping the auto-loaded profile state.
   useEffect(() => {
-    void refreshProfiles().catch((err: unknown) => {
-      setError(err instanceof Error ? err.message : String(err));
+    void refreshProfilesRef.current().catch((err: unknown) => {
+      setErrorRef.current(err instanceof Error ? err.message : String(err));
     });
-    void loadFavorites();
-  }, [loadFavorites, refreshProfiles, setError]);
+    void loadFavoritesRef.current();
+  }, []);
 
   useEffect(() => {
     let active = true;


### PR DESCRIPTION
## Summary

Fixes the flaky profile auto-load race reported in #484. `refreshProfiles` no longer re-runs on mount when `selectedProfile` changes after `auto-load-profile`, and an empty `profile_list` no longer wipes an already-selected profile during startup.

Closes #484

## Changes

- Run the initial `refreshProfiles` / `loadFavorites` fetch once on mount via refs in `useProfile`
- Skip empty-list reset in `refreshProfiles` when `selectedProfile` is already set
- Add `ProfileContext.test.tsx` regression coverage for the `auto-load-profile` flow

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

### Environment

- **Platform**: Linux (CachyOS)
- **Proton Version** (if applicable): n/a
- **Game / Trainer** (if applicable): n/a (Vitest unit test, happy-dom)

### Checklist

- [x] `./scripts/lint.sh` passes (or run `./scripts/format.sh` / `./scripts/lint.sh --fix`; same-repo PRs may get a formatting bot commit from `lint-autofix.yml`)
- [ ] `./scripts/build-native.sh --binary-only` builds without errors
- [ ] `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core` passes
- [ ] `./scripts/build-native.sh` produces a valid AppImage (if touching build/packaging)
- [ ] Tested on target platform (Linux desktop or Steam Deck)
- [ ] **If touching crates/crosshook-core/src/launch/**: Verified game and trainer launch works
- [ ] **If touching crates/crosshook-core/src/steam/**: Verified Steam auto-populate and Proton discovery
- [ ] **If touching crates/crosshook-core/src/profile/**: Verified profile save/load/import
- [x] **If touching src/components/ or src/hooks/**: Verified UI renders correctly
- [ ] **If touching runtime-helpers/**: Verified shell scripts work under Proton

**Vitest**

- `ProfileContext.test.tsx` — 10/10 consecutive passes (previously ~1-in-3 flake rate on deleted `ProfilesRoute.test.tsx`)
- Full suite — 427 tests passed

## Reviewer Notes

The deleted `ProfilesRoute.test.tsx` (removed in #496) exercised this path at the page level; coverage now lives at `ProfileContext` where the race actually occurred. Production impact: startup `auto-load-profile` (350ms delayed emit) could lose loaded state if `profile_list` returned empty or if a second mount refresh fired after selection.