### PR TITLE
feat(launch): add command arguments sub-tab and catalog

### DIFF
--- a/docs/features/steam-proton-trainer-launch.doc.md
+++ b/docs/features/steam-proton-trainer-launch.doc.md
@@ -10,6 +10,8 @@ This guide covers the three launch methods, auto-discovery, launcher export, and
 
 - [Overview](#overview)
 - [Launch methods](#launch-methods)
+- [Launch Optimizations](#launch-optimizations)
+- [Command arguments](#command-arguments)
 - [Custom environment variables](#custom-environment-variables)
 - [ProtonDB guidance](#protondb-guidance)
 - [Auto-populate and Steam discovery](#auto-populate-and-steam-discovery)
@@ -50,7 +52,7 @@ This is the primary mode for Steam-managed games. The workflow has two phases:
 1. **Game launch**: CrossHook runs `steam -applaunch <appid>` to start the game. Steam initializes DRM, the Steam overlay, and the correct Proton runtime.
 2. **Trainer launch**: Once the game process is detected, CrossHook launches the trainer through Proton with a clean environment. By default, it runs the trainer from its original host directory so stateful bundles such as Aurora keep one shared install. When needed, you can switch the profile to `Copy into prefix`, which stages the trainer into `pfx/drive_c/CrossHook/StagedTrainers/` before launch.
 
-**Steam Launch Options (optional):** For the same curated toggles as direct Proton launches, use the **Steam launch options** panel in the main view. CrossHook does not write into Steam; copy the generated single line into the game’s **Properties → General → Launch Options** in the Steam client. The line uses the same env vars and wrapper order as `proton_run` (for example `PROTON_*=1` assignments, then `mangohud` / `gamemoderun` / `game-performance` when enabled) and always ends with `%command%`. If the profile defines **custom environment variables**, their `KEY=value` tokens are merged on the same line after optimization env assignments and before wrappers, so a custom value wins when a key overlaps an optimization.
+**Steam Launch Options (optional):** For the same curated toggles as direct Proton launches, use the **Steam launch options** panel in the main view. CrossHook does not write into Steam — not for launch optimizations, custom environment variables, or **command arguments**. After you edit any of those settings, copy the generated single line into the game’s **Properties → General → Launch Options** in the Steam client. The line uses the same env vars and wrapper order as `proton_run` (for example `PROTON_*=1` assignments, then `mangohud` / `gamemoderun` / `game-performance` when enabled), then `%command%`, then any **command arguments** you configured. If the profile defines **custom environment variables**, their `KEY=value` tokens are merged on the same line after optimization env assignments and before wrappers, so a custom value wins when a key overlaps an optimization.
 
 Required profile fields:
 
@@ -102,10 +104,29 @@ The **Launch Optimizations** panel appears in the right column for `proton_run` 
 
 - It presents curated toggles instead of raw env-var editing, using the same mapping to Proton env vars and host wrappers as the `proton_run` launch path.
 - For **`proton_run`**, selections apply when CrossHook builds the game/trainer `proton run` commands.
-- For **`steam_applaunch`**, CrossHook does not apply those settings to the `steam -applaunch` step automatically. Use the **Steam launch options** panel to copy a one-line string into Steam’s per-game Launch Options; it ends with `%command%` so Steam prepends your env vars and wrappers correctly.
+- For **`steam_applaunch`**, CrossHook does not apply those settings to the `steam -applaunch` step automatically. Use the **Steam launch options** panel to copy a one-line string into Steam’s per-game Launch Options; env vars and wrappers come before `%command%`, and any **command arguments** come after `%command%`.
 - Option labels stay grouped by area (input, performance, display, graphics, compatibility). Every visible option has an info icon with help text.
 - Saved profiles autosave this section after a short debounce; new profiles show a save-first warning until they are written once.
 - Advanced and community-documented entries stay visually separated. Wrapper-based toggles require the matching binaries on `PATH`; the Steam line generator surfaces a clear error if a dependency is missing.
+
+## Command arguments
+
+The **Command Arguments** panel sits in the same launch configuration surface as **Launch Optimizations** for `proton_run` and `steam_applaunch` profiles. Command arguments are separate from launch optimizations: optimizations produce environment variables and host wrappers; command arguments produce argv tokens passed to the **game executable**, not to the trainer.
+
+- **Curated toggles:** CrossHook ships a conservative catalog (for example renderer switches and launcher-skip flags). Each entry has help text and may be gated by launch method or conflict with other entries.
+- **Custom token rows:** Add ordered one-token-per-row arguments (for example `-nologos` or `+fps_max 60`). Tokens are stored as structured strings, not a single shell line, so CrossHook can append them safely with `Command::arg`.
+- **Placement for `proton_run`:** Resolved tokens appear immediately after the game executable in CrossHook-built `proton run` or `umu-run` commands — wrappers and Proton/umu setup come first, then the game path, then the arguments. The same rule applies when CrossHook routes through `umu-run` under a `proton_run` profile.
+- **Placement for `steam_applaunch`:** The **Steam launch options** preview appends resolved tokens after `%command%`. Env vars and wrappers stay before `%command%`; game arguments stay after it.
+- **No trainer inheritance:** Game command arguments apply only to the game launch path. Trainer launches (including trainer-only) do not receive the profile’s game argument tokens.
+- **Profile TOML persistence:** Selections are saved under `[launch.command_arguments]` in the profile file. The section is omitted when empty.
+
+```toml
+[launch.command_arguments]
+enabled_argument_ids = ["force_vulkan", "skip_launcher"]
+custom_args = ["-nologos"]
+```
+
+Saved profiles autosave this section after a short debounce, like launch optimizations. For **`steam_applaunch`**, editing command arguments updates the copy/paste Steam line in the UI only — CrossHook still does not write into Steam; paste the new line into Steam’s Launch Options yourself. For **`proton_run`**, the same tokens are applied when CrossHook builds the real game command. **`native`** profiles do not support command arguments in the current implementation.
 
 ## Custom environment variables
 
@@ -131,7 +152,7 @@ CrossHook supports a dry run mode that shows exactly what commands, environment 
 - Debugging launch configurations that fail silently.
 - Sharing your launch configuration with others for troubleshooting.
 
-The dry run output includes the full `proton run` command line, all exported environment variables (including merged **Profile custom** entries), and the trainer staging steps (if applicable).
+The dry run output includes the full `proton run` command line (with **command arguments** after the game executable when configured), the generated Steam launch-options string (with arguments after `%command%` when applicable), all exported environment variables (including merged **Profile custom** entries), and the trainer staging steps (if applicable). Trainer-only previews omit game command arguments.
 
 ## Auto-Populate and Steam Discovery
 
@@ -358,6 +379,8 @@ The Health Dashboard uses the SQLite metadata layer for persistent tracking acro
 - **No macOS support yet.** The native application currently targets Linux. macOS support is planned for a future release.
 - **Trainer compatibility depends on the Proton version.** A trainer that fails under one Proton version may work under a different one (especially GE-Proton). CrossHook does not control Proton compatibility.
 - **Native mode does not support trainers.** The `native` launch method runs Linux-native executables only and does not include a trainer step.
+- **Command arguments are not supported for `native` launches.** Use `steam_applaunch` or `proton_run` for curated or custom game argv tokens.
+- **CrossHook does not modify Steam launch options automatically.** For `steam_applaunch`, env vars, wrappers, and command arguments appear only in the generated copy/paste line until you paste it into Steam.
 
 ## Troubleshooting
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -18,27 +18,28 @@ If you want the deeper Steam-specific workflow details, jump to the [Steam / Pro
    7. [First Launch](#first-launch)
    8. [Create a Profile](#create-a-profile)
    9. [Custom environment variables](#custom-environment-variables)
-   10. [ProtonDB guidance](#protondb-guidance)
-   11. [Launch a Game with a Trainer](#launch-a-game-with-a-trainer)
-   12. [Dry Run / Preview Mode](#dry-run--preview-mode)
-   13. [Launch Modes](#launch-modes)
+   10. [Command arguments](#command-arguments)
+   11. [ProtonDB guidance](#protondb-guidance)
+   12. [Launch a Game with a Trainer](#launch-a-game-with-a-trainer)
+   13. [Dry Run / Preview Mode](#dry-run--preview-mode)
+   14. [Launch Modes](#launch-modes)
        1. [Steam App Launch (`steam_applaunch`)](#steam-app-launch-steam_applaunch)
        2. [Proton Run (`proton_run`)](#proton-run-proton_run)
        3. [Native (`native`)](#native-native)
-   14. [External Launcher Export](#external-launcher-export)
-   15. [Community Profiles](#community-profiles)
-   16. [Pinned Profiles](#pinned-profiles)
-   17. [Health Dashboard](#health-dashboard)
-   18. [Diagnostic Export](#diagnostic-export)
-   19. [Using the CLI](#using-the-cli)
+   15. [External Launcher Export](#external-launcher-export)
+   16. [Community Profiles](#community-profiles)
+   17. [Pinned Profiles](#pinned-profiles)
+   18. [Health Dashboard](#health-dashboard)
+   19. [Diagnostic Export](#diagnostic-export)
+   20. [Using the CLI](#using-the-cli)
        1. [Check system status](#check-system-status)
        2. [Manage profiles](#manage-profiles)
        3. [Steam discovery](#steam-discovery)
        4. [Launch a game](#launch-a-game)
        5. [Generate shell completions](#generate-shell-completions)
        6. [Export diagnostics](#export-diagnostics)
-   20. [Troubleshooting](#troubleshooting)
-   21. [Related Guides](#related-guides)
+   21. [Troubleshooting](#troubleshooting)
+   22. [Related Guides](#related-guides)
 
 ## Supported Environments
 
@@ -150,7 +151,7 @@ proton_path = "/mnt/games/SteamLibrary/steamapps/common/Proton 9.0-4/proton"
 method = "steam_applaunch"
 ```
 
-When a profile uses `proton_run`, the Profile editor also shows a `Launch Optimizations` panel in the right column. The panel is limited to `proton_run` profiles, and each visible option has an info tooltip that explains what it does, when it helps, and the main caveat. Existing saved profiles autosave only the optimization section, while new unsaved profiles show `Save profile first to enable autosave` until you save them once.
+When a profile uses `proton_run` or `steam_applaunch`, the Profile editor shows **Launch Optimizations** and **Command Arguments** in the launch configuration surface. Launch optimizations are curated env/wrapper toggles; command arguments are curated or custom argv tokens for the game executable. For **`proton_run`**, both apply when CrossHook builds `proton run` commands. For **`steam_applaunch`**, CrossHook does not write into Steam — use the **Steam launch options** panel to copy a one-line string (env vars and wrappers before `%command%`, game arguments after `%command%`) into Steam’s per-game Launch Options. Each visible optimization and catalog argument has an info tooltip. Saved profiles autosave both sections after a short debounce; new unsaved profiles show a save-first warning until you save once.
 
 If the profile has a Steam App ID, the Profile editor also shows a **ProtonDB Guidance** card. It displays the exact ProtonDB tier (`platinum`, `gold`, `silver`, `bronze`, `borked`, and any future upstream labels), a freshness indicator, and normalized community suggestions. When CrossHook can safely normalize env-var tweaks, you can copy them or apply them into the profile’s custom env map; raw launch strings stay copy-only.
 
@@ -170,6 +171,28 @@ In the Profile editor and in the **Profile Setup Wizard** (New Profile / Edit in
 **Syntax rules:** Keys must be non-empty, must not contain `=`, and neither keys nor values may contain NUL bytes. Duplicate keys are avoided by the editor shape; invalid entries are surfaced in validation.
 
 **Troubleshooting:** If a variable does not appear to take effect, use dry run and check the environment list — entries sourced from the profile show as **Profile custom**. For Steam games, confirm you pasted an updated launch options line after changing custom vars. For more Steam-specific detail, see the [Steam / Proton feature guide](../features/steam-proton-trainer-launch.doc.md#custom-environment-variables).
+
+## Command arguments
+
+For **`proton_run`** and **`steam_applaunch`** profiles, **Command Arguments** lets you pass argv tokens to the **game** — not the trainer — using curated catalog toggles and ordered custom token rows.
+
+**What they are**
+
+- **Launch optimizations** set environment variables and optional wrappers (MangoHud, gamemode, and similar).
+- **Command arguments** set switches such as `-dx11` or `+fps_max 60` that the game reads from its command line.
+
+**Where tokens go**
+
+- **`proton_run`:** CrossHook appends resolved tokens immediately after the game executable in built `proton run` / `umu-run` commands.
+- **`steam_applaunch`:** The **Steam launch options** preview places tokens after `%command%`. CrossHook does not write into Steam; copy the updated line into the game’s Launch Options after you change arguments.
+
+**Persistence and scope**
+
+- Selections are stored in profile TOML under `[launch.command_arguments]` as `enabled_argument_ids` and `custom_args`.
+- Trainer launches do not inherit the profile’s game command arguments.
+- **`native`** profiles do not support command arguments today.
+
+**Troubleshooting:** Use dry run to confirm argument placement in the effective command or Steam line. For full behavior and TOML examples, see the [Steam / Proton feature guide](../features/steam-proton-trainer-launch.doc.md#command-arguments).
 
 ## ProtonDB guidance
 
@@ -193,7 +216,7 @@ The console view in CrossHook streams the runner output in real-time so you can 
 
 ## Dry Run / Preview Mode
 
-Before launching, you can preview exactly what commands CrossHook will execute. Use the dry run option to see the full command line, environment variables, and launch sequence without starting any processes. This is useful for debugging launch configurations or verifying that paths are correct. The environment list is merged the same way as a real launch (including [custom environment variables](#custom-environment-variables)), and shows which values come from **Profile custom** versus optimizations.
+Before launching, you can preview exactly what commands CrossHook will execute. Use the dry run option to see the full command line, environment variables, and launch sequence without starting any processes. This is useful for debugging launch configurations or verifying that paths are correct. The environment list is merged the same way as a real launch (including [custom environment variables](#custom-environment-variables)), and shows which values come from **Profile custom** versus optimizations. When command arguments are configured, the preview shows them after the game executable for `proton_run` and after `%command%` in the Steam launch-options string for `steam_applaunch`; trainer-only previews omit game arguments.
 
 ## Launch Modes
 
@@ -205,6 +228,7 @@ The default mode for games installed through Steam.
 
 - CrossHook launches the game using `steam -applaunch <appid>`, which lets Steam handle DRM, the overlay, and the Proton runtime.
 - The trainer is then launched separately against the same prefix using Proton directly.
+- **Launch Optimizations** and **Command Arguments** are edited in CrossHook; for Steam-owned game launches you copy the generated **Steam launch options** line into Steam (CrossHook does not modify Steam automatically).
 - The Trainer section lets you choose `Run from current directory` or `Copy into prefix`. The default source-directory mode is better for stateful trainers such as Aurora.
 - Requires: Steam App ID, compatdata path, Proton path, Steam client install path. All of these are auto-populated by CrossHook's Steam discovery.
 
@@ -217,7 +241,7 @@ For launching games and trainers directly through Proton without going through t
 - Useful for non-Steam games that use a standalone Proton/WINE prefix, or when you need full control over the prefix path.
 - Requires: a WINE/Proton prefix path and the Proton runner path.
 - The `Install Game` flow uses the same direct Proton path, then opens a review modal for the generated profile before save. Saving the modal draft opens the Profile tab with the saved profile selected.
-- The `Launch Optimizations` panel is available here and nowhere else; it stays scoped to `proton_run`, shows per-option help icons, and only autosaves after the profile already exists.
+- **Launch Optimizations** and **Command Arguments** apply directly to CrossHook-built game commands in this mode (no Steam copy/paste step).
 
 ### Native (`native`)
 

--- a/src/crosshook-native/Cargo.lock
+++ b/src/crosshook-native/Cargo.lock
@@ -636,7 +636,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crosshook-cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "crosshook-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "crosshook-native"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "crosshook-core",

--- a/src/crosshook-native/assets/default_command_argument_catalog.toml
+++ b/src/crosshook-native/assets/default_command_argument_catalog.toml
@@ -1,0 +1,61 @@
+catalog_version = 1
+
+[[command_argument]]
+id = "force_vulkan"
+tokens = ["-force_vulkan"]
+label = "Force Vulkan renderer"
+description = "Pass a Vulkan-forcing switch when the game supports it."
+help_text = "Some Unity and native builds accept -force_vulkan. Many titles ignore it or crash — verify per game before relying on it."
+category = "graphics"
+advanced = false
+community = false
+applicable_methods = ["proton_run", "steam_applaunch"]
+conflicts_with = ["force_dx11", "force_dx12", "force_opengl"]
+
+[[command_argument]]
+id = "force_dx11"
+tokens = ["-dx11"]
+label = "Force DirectX 11"
+description = "Request a DirectX 11 code path when the game reads launch switches."
+help_text = "Common on Source and some Unreal titles, but not universal. Wrong switches can prevent startup or leave you on an unintended renderer."
+category = "graphics"
+advanced = false
+community = false
+applicable_methods = ["proton_run", "steam_applaunch"]
+conflicts_with = ["force_vulkan", "force_dx12", "force_opengl"]
+
+[[command_argument]]
+id = "force_dx12"
+tokens = ["-dx12"]
+label = "Force DirectX 12"
+description = "Request a DirectX 12 code path when the game reads launch switches."
+help_text = "Only helps when the game actually exposes a DX12 switch. On Proton/Wine paths DX12 support varies by title and driver stack."
+category = "graphics"
+advanced = false
+community = false
+applicable_methods = ["proton_run", "steam_applaunch"]
+conflicts_with = ["force_vulkan", "force_dx11", "force_opengl"]
+
+[[command_argument]]
+id = "skip_launcher"
+tokens = ["-skip_launcher"]
+label = "Skip in-game launcher"
+description = "Skip a publisher launcher when the game honors the switch."
+help_text = "Works on some Unity and older PC builds. Useless or harmful on titles without a separate launcher step."
+category = "compatibility"
+advanced = false
+community = false
+applicable_methods = ["proton_run", "steam_applaunch"]
+conflicts_with = []
+
+[[command_argument]]
+id = "force_opengl"
+tokens = ["-force_opengl"]
+label = "Force OpenGL renderer"
+description = "Pass an OpenGL-forcing switch when supported."
+help_text = "Occasionally stabilizes older Unity builds on Linux/Proton. Most modern Windows-first titles ignore or mishandle it."
+category = "graphics"
+advanced = true
+community = false
+applicable_methods = ["proton_run", "steam_applaunch"]
+conflicts_with = ["force_vulkan", "force_dx11", "force_dx12"]

--- a/src/crosshook-native/crates/crosshook-cli/src/launch.rs
+++ b/src/crosshook-native/crates/crosshook-cli/src/launch.rs
@@ -5,7 +5,7 @@ use std::process::Stdio;
 use crate::args::{GlobalOptions, LaunchCommand};
 use crate::cli_error::CliError;
 use crate::store::profile_store;
-use crosshook_core::launch::request::LaunchOptimizationsRequest;
+use crosshook_core::launch::request::{LaunchCommandArgumentsRequest, LaunchOptimizationsRequest};
 use crosshook_core::launch::{
     self, build_launch_preview, LaunchRequest, RuntimeLaunchConfig, SteamLaunchConfig,
     ValidationSeverity, METHOD_NATIVE, METHOD_PROTON_RUN, METHOD_STEAM_APPLAUNCH,
@@ -233,6 +233,14 @@ fn launch_request_from_profile(
         },
         optimizations: LaunchOptimizationsRequest {
             enabled_option_ids: profile.launch.optimizations.enabled_option_ids.clone(),
+        },
+        command_arguments: LaunchCommandArgumentsRequest {
+            enabled_argument_ids: profile
+                .launch
+                .command_arguments
+                .enabled_argument_ids
+                .clone(),
+            custom_args: profile.launch.command_arguments.custom_args.clone(),
         },
         launch_trainer_only: false,
         launch_game_only: true,

--- a/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/catalog.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/catalog.rs
@@ -1,0 +1,241 @@
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+/// The default command-argument catalog TOML, embedded at compile time.
+pub const DEFAULT_CATALOG_TOML: &str =
+    include_str!("../../../../../assets/default_command_argument_catalog.toml");
+
+/// A single command-argument catalog entry (argv tokens plus UI metadata).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommandArgumentEntry {
+    pub id: String,
+    #[serde(default)]
+    pub tokens: Vec<String>,
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub help_text: String,
+    #[serde(default)]
+    pub category: String,
+    #[serde(default)]
+    pub advanced: bool,
+    #[serde(default)]
+    pub community: bool,
+    #[serde(default)]
+    pub applicable_methods: Vec<String>,
+    #[serde(default)]
+    pub conflicts_with: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCatalogFile {
+    #[serde(default)]
+    #[allow(dead_code)]
+    catalog_version: u32,
+    #[serde(rename = "command_argument", default)]
+    arguments: Vec<CommandArgumentEntry>,
+}
+
+/// Validated, merged, in-memory command-argument catalog.
+#[derive(Debug, Clone)]
+pub struct CommandArgumentCatalog {
+    pub catalog_version: u32,
+    pub entries: Vec<CommandArgumentEntry>,
+}
+
+impl CommandArgumentCatalog {
+    pub fn from_entries(entries: Vec<CommandArgumentEntry>) -> Self {
+        Self {
+            catalog_version: 1,
+            entries,
+        }
+    }
+
+    pub fn is_known_id(&self, id: &str) -> bool {
+        self.entries.iter().any(|e| e.id == id)
+    }
+
+    pub fn find_by_id(&self, id: &str) -> Option<&CommandArgumentEntry> {
+        self.entries.iter().find(|e| e.id == id)
+    }
+}
+
+const VALID_CATEGORIES: &[&str] = &[
+    "input",
+    "performance",
+    "display",
+    "graphics",
+    "compatibility",
+];
+
+/// Parses a TOML catalog text, validates each entry, and returns valid entries
+/// plus warning strings for skipped entries.
+pub fn parse_catalog_toml(
+    toml_text: &str,
+    source_label: &str,
+) -> (Vec<CommandArgumentEntry>, Vec<String>) {
+    let mut warnings: Vec<String> = Vec::new();
+
+    let raw: RawCatalogFile = match toml::from_str(toml_text) {
+        Ok(raw) => raw,
+        Err(err) => {
+            warnings.push(format!("catalog '{source_label}' failed to parse: {err}"));
+            return (Vec::new(), warnings);
+        }
+    };
+
+    let mut valid = Vec::new();
+    let mut seen_ids = HashSet::new();
+
+    for entry in raw.arguments {
+        if entry.id.is_empty() {
+            warnings.push("skipping command_argument entry with empty id".to_string());
+            continue;
+        }
+        if !seen_ids.insert(entry.id.clone()) {
+            warnings.push(format!(
+                "skipping duplicate command_argument id: {}",
+                entry.id
+            ));
+            continue;
+        }
+        if entry.label.is_empty() {
+            warnings.push(format!(
+                "skipping command_argument '{}': empty label",
+                entry.id
+            ));
+            continue;
+        }
+        if entry.category.is_empty() {
+            warnings.push(format!(
+                "skipping command_argument '{}': empty category",
+                entry.id
+            ));
+            continue;
+        }
+        if !VALID_CATEGORIES.contains(&entry.category.as_str()) {
+            warnings.push(format!(
+                "skipping command_argument '{}': unrecognized category '{}'",
+                entry.id, entry.category
+            ));
+            continue;
+        }
+        if entry.tokens.is_empty() {
+            warnings.push(format!(
+                "skipping command_argument '{}': empty tokens",
+                entry.id
+            ));
+            continue;
+        }
+        if entry.tokens.iter().any(std::string::String::is_empty) {
+            warnings.push(format!(
+                "skipping command_argument '{}': token entry is empty",
+                entry.id
+            ));
+            continue;
+        }
+        if entry.applicable_methods.is_empty() {
+            warnings.push(format!(
+                "skipping command_argument '{}': empty applicable_methods",
+                entry.id
+            ));
+            continue;
+        }
+        valid.push(entry);
+    }
+
+    (valid, warnings)
+}
+
+/// Merge default entries with user overrides.
+///
+/// User entries whose `id` matches a default entry replace it in-place,
+/// preserving its original position. User entries with novel IDs are appended.
+pub fn merge_catalogs(
+    default_entries: Vec<CommandArgumentEntry>,
+    override_entries: Vec<CommandArgumentEntry>,
+) -> Vec<CommandArgumentEntry> {
+    let mut result = default_entries;
+    for over in override_entries {
+        if let Some(pos) = result.iter().position(|e| e.id == over.id) {
+            result[pos] = over;
+        } else {
+            result.push(over);
+        }
+    }
+    result
+}
+
+/// Load the command-argument catalog from:
+///  1. Embedded default TOML (compile-time fallback, always present)
+///  2. Community tap catalog texts (optional, merged in order)
+///  3. User override file at `config_dir/command_argument_catalog.toml` (optional, highest priority)
+pub fn load_catalog(
+    user_config_dir: Option<&Path>,
+    tap_catalog_texts: &[(&str, &str)],
+) -> CommandArgumentCatalog {
+    let (default_entries, default_warnings) =
+        parse_catalog_toml(DEFAULT_CATALOG_TOML, "embedded default");
+    for w in &default_warnings {
+        tracing::warn!(warning = %w, "default command argument catalog warning");
+    }
+
+    let mut merged = default_entries;
+
+    for (tap_label, tap_text) in tap_catalog_texts {
+        let (mut tap_entries, tap_warnings) = parse_catalog_toml(tap_text, tap_label);
+        for w in &tap_warnings {
+            tracing::warn!(warning = %w, tap = %tap_label, "tap command argument catalog warning");
+        }
+        for entry in &mut tap_entries {
+            entry.community = true;
+        }
+        merged = merge_catalogs(merged, tap_entries);
+    }
+
+    let user_entries = user_config_dir
+        .map(|dir| dir.join("command_argument_catalog.toml"))
+        .filter(|p| p.exists())
+        .and_then(|path| {
+            std::fs::read_to_string(&path)
+                .map_err(|err| {
+                    tracing::warn!(
+                        path = %path.display(),
+                        %err,
+                        "failed to read user command argument catalog"
+                    );
+                })
+                .ok()
+        })
+        .map(|text| {
+            let (entries, warnings) = parse_catalog_toml(&text, "user override");
+            for w in &warnings {
+                tracing::warn!(warning = %w, "user command argument catalog warning");
+            }
+            entries
+        })
+        .unwrap_or_default();
+
+    merged = merge_catalogs(merged, user_entries);
+
+    CommandArgumentCatalog::from_entries(merged)
+}
+
+static GLOBAL_CATALOG: OnceLock<CommandArgumentCatalog> = OnceLock::new();
+
+pub fn initialize_catalog(catalog: CommandArgumentCatalog) {
+    let _ = GLOBAL_CATALOG.set(catalog);
+}
+
+/// Returns a reference to the process-global command-argument catalog.
+pub fn global_catalog() -> &'static CommandArgumentCatalog {
+    GLOBAL_CATALOG.get_or_init(|| {
+        let (entries, _) = parse_catalog_toml(DEFAULT_CATALOG_TOML, "fallback default");
+        CommandArgumentCatalog::from_entries(entries)
+    })
+}

--- a/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/mod.rs
@@ -1,0 +1,16 @@
+//! Curated game argv tokens and resolution for supported launch methods.
+
+mod catalog;
+mod resolver;
+
+#[cfg(test)]
+mod tests;
+
+pub use catalog::{
+    global_catalog, initialize_catalog, load_catalog, parse_catalog_toml, CommandArgumentCatalog,
+    CommandArgumentEntry, DEFAULT_CATALOG_TOML,
+};
+pub use resolver::{
+    is_known_command_argument_id, resolve_command_arguments, resolve_command_arguments_for_method,
+    CommandArgumentResolveError, ResolvedCommandArguments,
+};

--- a/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/resolver.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/resolver.rs
@@ -1,0 +1,135 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use super::super::request::{
+    LaunchRequest, METHOD_NATIVE, METHOD_PROTON_RUN, METHOD_STEAM_APPLAUNCH,
+};
+use super::catalog::{global_catalog, CommandArgumentCatalog};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ResolvedCommandArguments {
+    pub tokens: Vec<String>,
+}
+
+impl ResolvedCommandArguments {
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandArgumentResolveError {
+    Unknown(String),
+    Duplicate(String),
+    NotSupportedForMethod { argument_id: String, method: String },
+    Incompatible { first: String, second: String },
+    UnsupportedLaunchMethod(String),
+}
+
+pub fn is_known_command_argument_id(argument_id: &str) -> bool {
+    global_catalog().is_known_id(argument_id)
+}
+
+/// Resolves command arguments for a launch method using the global catalog.
+pub fn resolve_command_arguments_for_method(
+    enabled_argument_ids: &[String],
+    custom_args: &[String],
+    resolved_method: &str,
+) -> Result<ResolvedCommandArguments, CommandArgumentResolveError> {
+    resolve_command_arguments_with_catalog(
+        enabled_argument_ids,
+        custom_args,
+        resolved_method,
+        global_catalog(),
+    )
+}
+
+/// Resolves command arguments against a specific catalog (for tests).
+pub(crate) fn resolve_command_arguments_with_catalog(
+    enabled_argument_ids: &[String],
+    custom_args: &[String],
+    resolved_method: &str,
+    catalog: &CommandArgumentCatalog,
+) -> Result<ResolvedCommandArguments, CommandArgumentResolveError> {
+    if enabled_argument_ids.is_empty() && custom_args.is_empty() {
+        return Ok(ResolvedCommandArguments::default());
+    }
+
+    let mut seen_ids = HashSet::new();
+    for argument_id in enabled_argument_ids {
+        if !seen_ids.insert(argument_id.as_str()) {
+            return Err(CommandArgumentResolveError::Duplicate(argument_id.clone()));
+        }
+
+        if !catalog.is_known_id(argument_id) {
+            return Err(CommandArgumentResolveError::Unknown(argument_id.clone()));
+        }
+    }
+
+    let selected_ids = seen_ids;
+    let mut tokens = Vec::new();
+
+    for entry in &catalog.entries {
+        if !selected_ids.contains(entry.id.as_str()) {
+            continue;
+        }
+
+        if !entry
+            .applicable_methods
+            .iter()
+            .any(|method| method == resolved_method)
+        {
+            return Err(CommandArgumentResolveError::NotSupportedForMethod {
+                argument_id: entry.id.clone(),
+                method: resolved_method.to_string(),
+            });
+        }
+
+        for conflicting_id in &entry.conflicts_with {
+            if selected_ids.contains(conflicting_id.as_str()) {
+                return Err(CommandArgumentResolveError::Incompatible {
+                    first: entry.id.clone(),
+                    second: conflicting_id.clone(),
+                });
+            }
+        }
+
+        for token in &entry.tokens {
+            tokens.push(token.clone());
+        }
+    }
+
+    for custom_arg in custom_args {
+        tokens.push(custom_arg.clone());
+    }
+
+    Ok(ResolvedCommandArguments { tokens })
+}
+
+/// Resolves command arguments from a launch request.
+pub fn resolve_command_arguments(
+    request: &LaunchRequest,
+) -> Result<ResolvedCommandArguments, CommandArgumentResolveError> {
+    let enabled_argument_ids = &request.command_arguments.enabled_argument_ids;
+    let custom_args = &request.command_arguments.custom_args;
+
+    if enabled_argument_ids.is_empty() && custom_args.is_empty() {
+        return Ok(ResolvedCommandArguments::default());
+    }
+
+    let resolved_method = request.resolved_method();
+    if resolved_method == METHOD_NATIVE {
+        return Err(CommandArgumentResolveError::UnsupportedLaunchMethod(
+            resolved_method.to_string(),
+        ));
+    }
+
+    if resolved_method != METHOD_PROTON_RUN && resolved_method != METHOD_STEAM_APPLAUNCH {
+        return Err(CommandArgumentResolveError::UnsupportedLaunchMethod(
+            resolved_method.to_string(),
+        ));
+    }
+
+    resolve_command_arguments_for_method(enabled_argument_ids, custom_args, resolved_method)
+}

--- a/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/tests.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/command_arguments/tests.rs
@@ -1,0 +1,239 @@
+use super::catalog::{
+    parse_catalog_toml, CommandArgumentCatalog, CommandArgumentEntry, DEFAULT_CATALOG_TOML,
+};
+use super::resolver::{
+    resolve_command_arguments_with_catalog, CommandArgumentResolveError, ResolvedCommandArguments,
+};
+use crate::launch::request::{METHOD_NATIVE, METHOD_PROTON_RUN, METHOD_STEAM_APPLAUNCH};
+
+fn make_test_catalog() -> CommandArgumentCatalog {
+    let (entries, warnings) = parse_catalog_toml(DEFAULT_CATALOG_TOML, "test");
+    assert!(
+        warnings.is_empty(),
+        "default command argument catalog must parse cleanly: {warnings:?}"
+    );
+    CommandArgumentCatalog::from_entries(entries)
+}
+
+fn make_toml_entry(id: &str, label: &str, category: &str, tokens: &[&str]) -> String {
+    let token_list = tokens
+        .iter()
+        .map(|token| format!("\"{token}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "[[command_argument]]\nid = \"{id}\"\nlabel = \"{label}\"\ncategory = \"{category}\"\ntokens = [{token_list}]\napplicable_methods = [\"proton_run\", \"steam_applaunch\"]\n"
+    )
+}
+
+#[test]
+fn default_catalog_toml_parses_with_no_warnings() {
+    let (entries, warnings) = parse_catalog_toml(DEFAULT_CATALOG_TOML, "embedded default");
+    assert!(
+        warnings.is_empty(),
+        "default catalog had warnings: {warnings:?}"
+    );
+    assert!(!entries.is_empty(), "default catalog should have entries");
+}
+
+#[test]
+fn default_catalog_has_five_entries() {
+    let (entries, _) = parse_catalog_toml(DEFAULT_CATALOG_TOML, "embedded default");
+    assert_eq!(
+        entries.len(),
+        5,
+        "expected exactly 5 entries in the default catalog"
+    );
+}
+
+#[test]
+fn parse_skips_entry_with_empty_id() {
+    let toml = "[[command_argument]]\nid = \"\"\nlabel = \"Something\"\ncategory = \"graphics\"\ntokens = [\"-foo\"]\napplicable_methods = [\"proton_run\"]\n";
+    let (entries, warnings) = parse_catalog_toml(toml, "test");
+    assert!(entries.is_empty());
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("empty id"));
+}
+
+#[test]
+fn parse_skips_entry_with_unrecognized_category() {
+    let toml = make_toml_entry("my_arg", "My Arg", "bogus", &["-foo"]);
+    let (entries, warnings) = parse_catalog_toml(&toml, "test");
+    assert!(entries.is_empty());
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("unrecognized category"));
+}
+
+#[test]
+fn parse_skips_entry_with_empty_tokens() {
+    let toml = "[[command_argument]]\nid = \"no_tokens\"\nlabel = \"No Tokens\"\ncategory = \"graphics\"\ntokens = []\napplicable_methods = [\"proton_run\"]\n";
+    let (entries, warnings) = parse_catalog_toml(toml, "test");
+    assert!(entries.is_empty());
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("empty tokens"));
+}
+
+#[test]
+fn parse_skips_duplicate_ids_keeping_first() {
+    let toml = format!(
+        "{}{}",
+        make_toml_entry("dup_id", "First", "graphics", &["-a"]),
+        make_toml_entry("dup_id", "Second", "graphics", &["-b"]),
+    );
+    let (entries, warnings) = parse_catalog_toml(&toml, "test");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].tokens, vec!["-a".to_string()]);
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("duplicate"));
+}
+
+#[test]
+fn parse_returns_empty_on_invalid_toml() {
+    let (entries, warnings) = parse_catalog_toml("not toml !!!", "test");
+    assert!(entries.is_empty());
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].contains("failed to parse"));
+}
+
+#[test]
+fn rejects_unknown_argument_id() {
+    let catalog = make_test_catalog();
+    let ids = vec!["not_a_real_id".to_string()];
+    let error = resolve_command_arguments_with_catalog(&ids, &[], METHOD_PROTON_RUN, &catalog)
+        .expect_err("unknown id should fail");
+
+    assert_eq!(
+        error,
+        CommandArgumentResolveError::Unknown("not_a_real_id".to_string())
+    );
+}
+
+#[test]
+fn rejects_duplicate_selected_ids() {
+    let catalog = make_test_catalog();
+    let ids = vec!["force_vulkan".to_string(), "force_vulkan".to_string()];
+    let error = resolve_command_arguments_with_catalog(&ids, &[], METHOD_PROTON_RUN, &catalog)
+        .expect_err("duplicate id should fail");
+
+    assert_eq!(
+        error,
+        CommandArgumentResolveError::Duplicate("force_vulkan".to_string())
+    );
+}
+
+#[test]
+fn rejects_incompatible_argument_pair() {
+    let catalog = make_test_catalog();
+    let ids = vec!["force_vulkan".to_string(), "force_dx11".to_string()];
+    let error = resolve_command_arguments_with_catalog(&ids, &[], METHOD_PROTON_RUN, &catalog)
+        .expect_err("conflicting ids should fail");
+
+    assert_eq!(
+        error,
+        CommandArgumentResolveError::Incompatible {
+            first: "force_vulkan".to_string(),
+            second: "force_dx11".to_string(),
+        }
+    );
+}
+
+#[test]
+fn rejects_method_gated_argument_on_native() {
+    let catalog = make_test_catalog();
+    let ids = vec!["force_vulkan".to_string()];
+    let error = resolve_command_arguments_with_catalog(&ids, &[], METHOD_NATIVE, &catalog)
+        .expect_err("native method should fail for proton-only entry");
+
+    assert_eq!(
+        error,
+        CommandArgumentResolveError::NotSupportedForMethod {
+            argument_id: "force_vulkan".to_string(),
+            method: METHOD_NATIVE.to_string(),
+        }
+    );
+}
+
+#[test]
+fn resolves_curated_tokens_in_catalog_order() {
+    let catalog = make_test_catalog();
+    let ids = vec!["skip_launcher".to_string(), "force_vulkan".to_string()];
+    let resolved = resolve_command_arguments_with_catalog(&ids, &[], METHOD_PROTON_RUN, &catalog)
+        .expect("resolve arguments");
+
+    assert_eq!(
+        resolved,
+        ResolvedCommandArguments {
+            tokens: vec!["-force_vulkan".to_string(), "-skip_launcher".to_string()],
+        }
+    );
+}
+
+#[test]
+fn appends_custom_args_after_curated_tokens_in_user_order() {
+    let catalog = make_test_catalog();
+    let ids = vec!["force_vulkan".to_string()];
+    let custom = vec!["-dx11".to_string(), "+set cl_showfps 1".to_string()];
+    let resolved =
+        resolve_command_arguments_with_catalog(&ids, &custom, METHOD_PROTON_RUN, &catalog)
+            .expect("resolve arguments");
+
+    assert_eq!(
+        resolved.tokens,
+        vec![
+            "-force_vulkan".to_string(),
+            "-dx11".to_string(),
+            "+set cl_showfps 1".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn custom_args_only_preserves_user_order() {
+    let catalog = make_test_catalog();
+    let custom = vec![
+        "--flag=value".to_string(),
+        "/path/with spaces/game.cfg".to_string(),
+    ];
+    let resolved =
+        resolve_command_arguments_with_catalog(&[], &custom, METHOD_STEAM_APPLAUNCH, &catalog)
+            .expect("resolve custom-only arguments");
+
+    assert_eq!(resolved.tokens, custom);
+}
+
+#[test]
+fn steam_applaunch_method_resolves_supported_entries() {
+    let catalog = make_test_catalog();
+    let ids = vec!["skip_launcher".to_string()];
+    let resolved =
+        resolve_command_arguments_with_catalog(&ids, &[], METHOD_STEAM_APPLAUNCH, &catalog)
+            .expect("steam applaunch should resolve");
+
+    assert_eq!(resolved.tokens, vec!["-skip_launcher".to_string()]);
+}
+
+#[test]
+fn multi_token_entry_emits_all_catalog_tokens() {
+    let catalog = CommandArgumentCatalog::from_entries(vec![CommandArgumentEntry {
+        id: "combo".to_string(),
+        tokens: vec!["-a".to_string(), "-b".to_string()],
+        label: "Combo".to_string(),
+        description: String::new(),
+        help_text: String::new(),
+        category: "graphics".to_string(),
+        advanced: false,
+        community: false,
+        applicable_methods: vec![METHOD_PROTON_RUN.to_string()],
+        conflicts_with: Vec::new(),
+    }]);
+
+    let resolved = resolve_command_arguments_with_catalog(
+        &["combo".to_string()],
+        &[],
+        METHOD_PROTON_RUN,
+        &catalog,
+    )
+    .expect("resolve multi-token entry");
+
+    assert_eq!(resolved.tokens, vec!["-a".to_string(), "-b".to_string()]);
+}

--- a/src/crosshook-native/crates/crosshook-core/src/launch/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/mod.rs
@@ -3,6 +3,7 @@
 use crate::profile::GamescopeConfig;
 
 pub mod catalog;
+pub mod command_arguments;
 pub mod diagnostics;
 pub mod env;
 pub mod hooks;
@@ -21,6 +22,13 @@ pub mod watchdog;
 
 pub use catalog::{
     global_catalog, initialize_catalog, load_catalog, OptimizationCatalog, OptimizationEntry,
+};
+pub use command_arguments::{
+    global_catalog as global_command_argument_catalog,
+    initialize_catalog as initialize_command_argument_catalog, is_known_command_argument_id,
+    load_catalog as load_command_argument_catalog, resolve_command_arguments,
+    resolve_command_arguments_for_method, CommandArgumentCatalog, CommandArgumentEntry,
+    CommandArgumentResolveError, ResolvedCommandArguments,
 };
 pub use diagnostics::{analyze, should_surface_report, DiagnosticReport};
 pub use env::{

--- a/src/crosshook-native/crates/crosshook-core/src/launch/optimizations/steam_options.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/optimizations/steam_options.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeMap;
 use crate::profile::GamescopeConfig;
 
 use super::super::{
-    request::{ValidationError, METHOD_PROTON_RUN},
+    command_arguments::{resolve_command_arguments_for_method, CommandArgumentResolveError},
+    request::{ValidationError, METHOD_PROTON_RUN, METHOD_STEAM_APPLAUNCH},
     runtime_helpers::build_gamescope_args,
 };
 use super::directives::resolve_launch_directives_for_method;
@@ -44,7 +45,57 @@ pub fn escape_steam_token(value: &str) -> String {
     out
 }
 
-/// Builds a single-line Steam per-game "Launch Options" string: `KEY=val ... wrappers %command%`.
+fn command_argument_resolve_error(error: CommandArgumentResolveError) -> ValidationError {
+    match error {
+        CommandArgumentResolveError::Unknown(argument_id) => {
+            ValidationError::UnknownCommandArgument(argument_id)
+        }
+        CommandArgumentResolveError::Duplicate(argument_id) => {
+            ValidationError::DuplicateCommandArgument(argument_id)
+        }
+        CommandArgumentResolveError::NotSupportedForMethod {
+            argument_id,
+            method,
+        } => ValidationError::CommandArgumentNotSupportedForMethod {
+            argument_id,
+            method,
+        },
+        CommandArgumentResolveError::Incompatible { first, second } => {
+            ValidationError::IncompatibleCommandArguments { first, second }
+        }
+        CommandArgumentResolveError::UnsupportedLaunchMethod(method) => {
+            ValidationError::CommandArgumentsUnsupportedForMethod(method)
+        }
+    }
+}
+
+fn resolve_steam_command_argument_tokens(
+    enabled_argument_ids: Option<&[String]>,
+    custom_command_args: Option<&[String]>,
+    resolved_argument_tokens: Option<&[String]>,
+) -> Result<Vec<String>, ValidationError> {
+    if let Some(tokens) = resolved_argument_tokens {
+        return Ok(tokens.to_vec());
+    }
+
+    let enabled_argument_ids = enabled_argument_ids.unwrap_or(&[]);
+    let custom_command_args = custom_command_args.unwrap_or(&[]);
+
+    if enabled_argument_ids.is_empty() && custom_command_args.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let resolved = resolve_command_arguments_for_method(
+        enabled_argument_ids,
+        custom_command_args,
+        METHOD_STEAM_APPLAUNCH,
+    )
+    .map_err(command_argument_resolve_error)?;
+
+    Ok(resolved.tokens)
+}
+
+/// Builds a single-line Steam per-game "Launch Options" string: `KEY=val ... wrappers %command% [args]`.
 ///
 /// Uses the same option-ID → env/wrapper mapping as `proton_run` launches, then appends
 /// `custom_env_vars` as `KEY=value` tokens so profile custom values override optimization keys
@@ -58,6 +109,29 @@ pub fn build_steam_launch_options_command(
     enabled_option_ids: &[String],
     custom_env_vars: &BTreeMap<String, String>,
     gamescope: Option<&GamescopeConfig>,
+) -> Result<String, ValidationError> {
+    build_steam_launch_options_command_with_arguments(
+        enabled_option_ids,
+        custom_env_vars,
+        gamescope,
+        None,
+        None,
+        None,
+    )
+}
+
+/// Like [`build_steam_launch_options_command`], but appends resolved game argv tokens after `%command%`.
+///
+/// Pass `resolved_argument_tokens` when the caller has already resolved IDs/custom args; otherwise
+/// supply `enabled_argument_ids` / `custom_command_args` and this function resolves them for
+/// `steam_applaunch`.
+pub fn build_steam_launch_options_command_with_arguments(
+    enabled_option_ids: &[String],
+    custom_env_vars: &BTreeMap<String, String>,
+    gamescope: Option<&GamescopeConfig>,
+    enabled_argument_ids: Option<&[String]>,
+    custom_command_args: Option<&[String]>,
+    resolved_argument_tokens: Option<&[String]>,
 ) -> Result<String, ValidationError> {
     let directives = resolve_launch_directives_for_method(enabled_option_ids, METHOD_PROTON_RUN)?;
     let mut parts: Vec<String> = directives
@@ -111,6 +185,16 @@ pub fn build_steam_launch_options_command(
     }
 
     parts.push("%command%".to_string());
+
+    let argument_tokens = resolve_steam_command_argument_tokens(
+        enabled_argument_ids,
+        custom_command_args,
+        resolved_argument_tokens,
+    )?;
+    for token in argument_tokens {
+        parts.push(escape_steam_token(&token));
+    }
+
     Ok(parts.join(" "))
 }
 
@@ -228,5 +312,133 @@ mod tests {
         let command = build_steam_launch_options_command(&[], &BTreeMap::new(), Some(&cfg))
             .expect("steam command with extra args");
         assert_eq!(command, "gamescope \"--some flag\" -- %command%");
+    }
+
+    #[test]
+    fn steam_launch_options_with_empty_command_arguments_unchanged() {
+        let command = build_steam_launch_options_command_with_arguments(
+            &[],
+            &BTreeMap::new(),
+            None,
+            Some(&[]),
+            Some(&[]),
+            None,
+        )
+        .expect("steam command");
+        assert_eq!(command, "%command%");
+    }
+
+    #[test]
+    fn steam_launch_options_curated_command_argument_after_percent_command() {
+        let enabled_argument_ids = vec!["force_vulkan".to_string()];
+        let command = build_steam_launch_options_command_with_arguments(
+            &[],
+            &BTreeMap::new(),
+            None,
+            Some(&enabled_argument_ids),
+            Some(&[]),
+            None,
+        )
+        .expect("steam command with curated arg");
+        assert_eq!(command, "%command% -force_vulkan");
+    }
+
+    #[test]
+    fn steam_launch_options_custom_command_argument_after_percent_command() {
+        let custom_args = vec!["-windowed".to_string()];
+        let command = build_steam_launch_options_command_with_arguments(
+            &[],
+            &BTreeMap::new(),
+            None,
+            Some(&[]),
+            Some(&custom_args),
+            None,
+        )
+        .expect("steam command with custom arg");
+        assert_eq!(command, "%command% -windowed");
+    }
+
+    #[test]
+    fn steam_launch_options_curated_then_custom_argument_ordering() {
+        let enabled_argument_ids = vec!["force_dx11".to_string()];
+        let custom_args = vec![
+            "+set".to_string(),
+            "com_skipIntroVideo".to_string(),
+            "1".to_string(),
+        ];
+        let command = build_steam_launch_options_command_with_arguments(
+            &[],
+            &BTreeMap::new(),
+            None,
+            Some(&enabled_argument_ids),
+            Some(&custom_args),
+            None,
+        )
+        .expect("steam command with curated and custom args");
+        assert_eq!(command, "%command% -dx11 +set com_skipIntroVideo 1");
+    }
+
+    #[test]
+    fn steam_launch_options_command_argument_quoting_for_spaces_and_metacharacters() {
+        let custom_args = vec!["--cfg=\"C:\\My Games\\config.ini\"".to_string()];
+        let command = build_steam_launch_options_command_with_arguments(
+            &[],
+            &BTreeMap::new(),
+            None,
+            Some(&[]),
+            Some(&custom_args),
+            None,
+        )
+        .expect("steam command with quoted custom arg");
+        assert_eq!(
+            command,
+            "%command% \"--cfg=\\\"C:\\\\My Games\\\\config.ini\\\"\""
+        );
+    }
+
+    #[test]
+    fn steam_launch_options_resolved_argument_tokens_bypass_resolution() {
+        let resolved = vec!["-skip_launcher".to_string(), "extra flag".to_string()];
+        let command = build_steam_launch_options_command_with_arguments(
+            &[],
+            &BTreeMap::new(),
+            None,
+            None,
+            None,
+            Some(&resolved),
+        )
+        .expect("steam command with pre-resolved args");
+        assert_eq!(command, "%command% -skip_launcher \"extra flag\"");
+    }
+
+    #[test]
+    fn steam_launch_options_gamescope_mangohud_wrapper_ordering_with_command_arguments() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let mangohud_path = temp_dir.path().join("mangohud");
+        write_executable_file(&mangohud_path);
+        let _command_search_path =
+            crate::launch::test_support::ScopedCommandSearchPath::new(temp_dir.path());
+
+        let cfg = GamescopeConfig {
+            enabled: true,
+            fullscreen: true,
+            ..Default::default()
+        };
+        let ids = vec!["show_mangohud_overlay".to_string()];
+        let enabled_argument_ids = vec!["skip_launcher".to_string()];
+        let custom_args = vec!["-nolog".to_string()];
+        let command = build_steam_launch_options_command_with_arguments(
+            &ids,
+            &BTreeMap::new(),
+            Some(&cfg),
+            Some(&enabled_argument_ids),
+            Some(&custom_args),
+            None,
+        )
+        .expect("steam command with gamescope, mangohud, and args");
+        assert_eq!(
+            command,
+            "gamescope -f --mangoapp -- %command% -skip_launcher -nolog"
+        );
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/preview/builder.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/preview/builder.rs
@@ -1,4 +1,4 @@
-use super::command::build_effective_command_string;
+use super::command::{append_preview_steam_command_arguments, build_effective_command_string};
 use super::environment::{
     collect_host_environment, collect_runtime_proton_environment, collect_steam_proton_environment,
     inject_mangohud_config_preview_env, merge_custom_preview_env_only,
@@ -6,13 +6,14 @@ use super::environment::{
 };
 use super::sections::{build_proton_setup, build_trainer_info, resolve_working_directory};
 use super::types::{LaunchPreview, PreviewValidation, ResolvedLaunchMethod, UmuDecisionPreview};
+use crate::launch::command_arguments::{resolve_command_arguments, CommandArgumentResolveError};
 use crate::launch::env::WINE_ENV_VARS_TO_CLEAR;
 use crate::launch::optimizations::{
     build_steam_launch_options_command, resolve_launch_directives,
     resolve_launch_directives_for_method,
 };
 use crate::launch::request::{
-    is_inside_gamescope_session, validate_all, LaunchRequest, METHOD_PROTON_RUN,
+    is_inside_gamescope_session, validate_all, LaunchRequest, ValidationError, METHOD_PROTON_RUN,
     METHOD_STEAM_APPLAUNCH,
 };
 use crate::launch::runtime_helpers::is_unshare_net_available;
@@ -29,6 +30,9 @@ pub fn build_launch_preview(request: &LaunchRequest) -> Result<LaunchPreview, St
 
     let gamescope_active = gamescope_config.enabled
         && (gamescope_config.allow_nested || !is_inside_gamescope_session());
+
+    let (resolved_argument_tokens, command_arguments_error) =
+        resolve_preview_command_arguments(request);
 
     // Resolve launch directives (wrappers + optimization env).
     // `steam_applaunch` uses the same optimization catalog as `proton_run` for Steam Launch Options,
@@ -48,6 +52,12 @@ pub fn build_launch_preview(request: &LaunchRequest) -> Result<LaunchPreview, St
             Err(e) => (None, Some(e.to_string())),
         },
     };
+
+    if let Some(error) = command_arguments_error {
+        append_preview_error(&mut directives_error, error);
+    }
+
+    let argument_tokens = resolved_argument_tokens.as_deref();
 
     // Environment and command depend on successful directive resolution.
     let (environment, wrappers, effective_command) = match &directives {
@@ -92,6 +102,7 @@ pub fn build_launch_preview(request: &LaunchRequest) -> Result<LaunchPreview, St
                 &effective_wrappers,
                 &gamescope_config,
                 gamescope_active,
+                argument_tokens,
             ) {
                 Ok(command) => Some(command),
                 Err(error) => {
@@ -116,7 +127,9 @@ pub fn build_launch_preview(request: &LaunchRequest) -> Result<LaunchPreview, St
             &request.optimizations.enabled_option_ids,
             &request.custom_env_vars,
             gamescope_param.as_ref(),
-        ) {
+        )
+        .map(|command| append_preview_steam_command_arguments(command, argument_tokens))
+        {
             Ok(command) => Some(command),
             Err(error) => {
                 append_preview_error(&mut directives_error, error.to_string());
@@ -219,5 +232,47 @@ fn append_preview_error(target: &mut Option<String>, message: String) {
             }
         }
         None => *target = Some(message),
+    }
+}
+
+fn resolve_preview_command_arguments(
+    request: &LaunchRequest,
+) -> (Option<Vec<String>>, Option<String>) {
+    if request.launch_trainer_only || request.command_arguments.is_empty() {
+        return (None, None);
+    }
+
+    match resolve_command_arguments(request) {
+        Ok(resolved) if resolved.is_empty() => (None, None),
+        Ok(resolved) => (Some(resolved.tokens), None),
+        Err(error) => (None, Some(command_argument_preview_error(error))),
+    }
+}
+
+fn command_argument_preview_error(error: CommandArgumentResolveError) -> String {
+    command_argument_resolve_error(error).to_string()
+}
+
+fn command_argument_resolve_error(error: CommandArgumentResolveError) -> ValidationError {
+    match error {
+        CommandArgumentResolveError::Unknown(argument_id) => {
+            ValidationError::UnknownCommandArgument(argument_id)
+        }
+        CommandArgumentResolveError::Duplicate(argument_id) => {
+            ValidationError::DuplicateCommandArgument(argument_id)
+        }
+        CommandArgumentResolveError::NotSupportedForMethod {
+            argument_id,
+            method,
+        } => ValidationError::CommandArgumentNotSupportedForMethod {
+            argument_id,
+            method,
+        },
+        CommandArgumentResolveError::Incompatible { first, second } => {
+            ValidationError::IncompatibleCommandArguments { first, second }
+        }
+        CommandArgumentResolveError::UnsupportedLaunchMethod(method) => {
+            ValidationError::CommandArgumentsUnsupportedForMethod(method)
+        }
     }
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/preview/command.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/preview/command.rs
@@ -1,4 +1,4 @@
-use super::super::optimizations::build_steam_launch_options_command;
+use super::super::optimizations::{build_steam_launch_options_command, escape_steam_token};
 use super::super::request::LaunchRequest;
 use super::super::runtime_helpers::build_gamescope_args;
 use super::super::script_runner::{force_no_umu_for_launch_request, should_use_umu};
@@ -13,6 +13,7 @@ pub(super) fn build_effective_command_string(
     effective_wrappers: &[String],
     gamescope_config: &GamescopeConfig,
     gamescope_active: bool,
+    resolved_argument_tokens: Option<&[String]>,
 ) -> Result<String, String> {
     match method {
         ResolvedLaunchMethod::ProtonRun => {
@@ -56,6 +57,9 @@ pub(super) fn build_effective_command_string(
                 parts.push(resolve_trainer_launch_path_for_preview(request));
             } else {
                 parts.push(request.game_path.trim().to_string());
+                if let Some(tokens) = resolved_argument_tokens {
+                    parts.extend(tokens.iter().cloned());
+                }
             }
             Ok(parts.join(" "))
         }
@@ -70,6 +74,9 @@ pub(super) fn build_effective_command_string(
                 &request.custom_env_vars,
                 gs,
             )
+            .map(|command| {
+                append_preview_steam_command_arguments(command, resolved_argument_tokens)
+            })
             .map_err(|error| error.to_string())
         }
         ResolvedLaunchMethod::Native => Ok(request.game_path.trim().to_string()),
@@ -84,4 +91,17 @@ pub(super) fn resolve_trainer_launch_path_for_preview(request: &LaunchRequest) -
                 .unwrap_or_else(|| request.trainer_host_path.trim().to_string())
         }
     }
+}
+
+pub(super) fn append_preview_steam_command_arguments(
+    mut command: String,
+    resolved_argument_tokens: Option<&[String]>,
+) -> String {
+    if let Some(tokens) = resolved_argument_tokens {
+        for token in tokens {
+            command.push(' ');
+            command.push_str(&escape_steam_token(token));
+        }
+    }
+    command
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/preview/tests/command_string.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/preview/tests/command_string.rs
@@ -2,8 +2,8 @@
 
 use super::super::*;
 use super::fixtures::*;
-use crate::launch::optimizations::build_steam_launch_options_command;
-use crate::launch::request::{LaunchRequest, METHOD_PROTON_RUN};
+use crate::launch::optimizations::{build_steam_launch_options_command, escape_steam_token};
+use crate::launch::request::{LaunchCommandArgumentsRequest, LaunchRequest, METHOD_PROTON_RUN};
 use crate::settings::UmuPreference;
 
 #[test]
@@ -293,4 +293,133 @@ fn preview_proton_setup_umu_run_path_none_when_preference_is_proton() {
 
     let preview = build_launch_preview(&request).unwrap();
     assert!(preview.proton_setup.unwrap().umu_run_path.is_none());
+}
+
+#[test]
+fn preview_proton_includes_command_arguments_after_game_executable() {
+    let (_td, mut request) = proton_request();
+    request.command_arguments = LaunchCommandArgumentsRequest {
+        enabled_argument_ids: vec!["force_vulkan".to_string()],
+        custom_args: vec!["+set sv_cheats 1".to_string()],
+    };
+
+    let preview = build_launch_preview(&request).expect("preview");
+    let command = preview
+        .effective_command
+        .as_deref()
+        .expect("effective command");
+
+    let game_path = request.game_path.trim();
+    let game_idx = command
+        .find(game_path)
+        .expect("game path should appear in command");
+    let after_game = &command[game_idx + game_path.len()..];
+    assert!(
+        after_game.contains("-force_vulkan"),
+        "curated arg should follow game executable: {command}"
+    );
+    assert!(
+        after_game.contains("+set sv_cheats 1"),
+        "custom arg should follow game executable: {command}"
+    );
+}
+
+#[test]
+fn preview_umu_includes_command_arguments_after_game_executable() {
+    let dir = tempfile::tempdir().unwrap();
+    let umu_stub = dir.path().join("umu-run");
+    std::fs::write(&umu_stub, "#!/bin/sh\nexit 0\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&umu_stub, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let _guard = crate::launch::test_support::ScopedCommandSearchPath::new(dir.path());
+
+    let mut request = LaunchRequest {
+        method: METHOD_PROTON_RUN.to_string(),
+        game_path: "/tmp/game.exe".to_string(),
+        umu_preference: UmuPreference::Umu,
+        command_arguments: LaunchCommandArgumentsRequest {
+            enabled_argument_ids: vec!["skip_launcher".to_string()],
+            custom_args: vec!["-windowed".to_string()],
+        },
+        ..Default::default()
+    };
+    request.runtime.proton_path = "/opt/proton/GE-Proton9-20/proton".to_string();
+
+    let preview = build_launch_preview(&request).unwrap();
+    let command = preview.effective_command.expect("effective command");
+    assert!(
+        command.contains("umu-run /tmp/game.exe -skip_launcher -windowed"),
+        "expected umu args after game executable, got: {command}"
+    );
+    assert!(
+        !command.contains(" run /tmp/game.exe"),
+        "umu preview should not insert proton run subcommand: {command}"
+    );
+}
+
+#[test]
+fn preview_steam_includes_command_arguments_after_percent_command() {
+    let (_td, mut request) = steam_request();
+    request.command_arguments = LaunchCommandArgumentsRequest {
+        enabled_argument_ids: vec!["force_dx11".to_string()],
+        custom_args: vec!["+set com_skipIntroVideo 1".to_string()],
+    };
+
+    let preview = build_launch_preview(&request).expect("preview");
+    let mut expected = build_steam_launch_options_command(
+        &request.optimizations.enabled_option_ids,
+        &request.custom_env_vars,
+        None,
+    )
+    .expect("steam line");
+    for token in ["-dx11", "+set com_skipIntroVideo 1"] {
+        expected.push(' ');
+        expected.push_str(&escape_steam_token(token));
+    }
+
+    assert_eq!(
+        preview.steam_launch_options.as_deref(),
+        Some(expected.as_str())
+    );
+    assert_eq!(
+        preview.effective_command.as_deref(),
+        Some(expected.as_str())
+    );
+    assert!(
+        preview
+            .steam_launch_options
+            .as_deref()
+            .is_some_and(|line| line.starts_with("%command% -dx11")),
+        "steam launch options should append args after %command%"
+    );
+}
+
+#[test]
+fn preview_trainer_only_does_not_include_command_arguments() {
+    let (_td, mut request) = proton_request();
+    request.launch_trainer_only = true;
+    request.launch_game_only = false;
+    request.command_arguments = LaunchCommandArgumentsRequest {
+        enabled_argument_ids: vec!["force_vulkan".to_string()],
+        custom_args: vec!["-windowed".to_string()],
+    };
+
+    let preview = build_launch_preview(&request).expect("preview");
+    let command = preview
+        .effective_command
+        .as_deref()
+        .expect("effective command");
+
+    assert!(
+        command.contains(request.trainer_host_path.as_str()),
+        "trainer-only preview should launch trainer: {command}"
+    );
+    assert!(
+        !command.contains("-force_vulkan"),
+        "trainer-only preview must not inherit curated game args: {command}"
+    );
+    assert!(
+        !command.contains("-windowed"),
+        "trainer-only preview must not inherit custom game args: {command}"
+    );
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/error.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/error.rs
@@ -81,6 +81,29 @@ pub enum ValidationError {
         threshold_mb: u64,
         mount_path: String,
     },
+    UnknownCommandArgument(String),
+    DuplicateCommandArgument(String),
+    CommandArgumentsUnsupportedForMethod(String),
+    CommandArgumentNotSupportedForMethod {
+        argument_id: String,
+        method: String,
+    },
+    IncompatibleCommandArguments {
+        first: String,
+        second: String,
+    },
+    /// Custom command-argument token is empty or only whitespace.
+    CommandArgumentCustomTokenEmpty,
+    /// Custom command-argument token contains a NUL byte or other control character.
+    CommandArgumentCustomTokenContainsControlCharacter,
+    /// A command-argument token exceeds the maximum allowed length.
+    CommandArgumentTokenTooLong {
+        max_len: usize,
+    },
+    /// Resolved command-argument token count exceeds the maximum allowed.
+    CommandArgumentTokenCountExceeded {
+        max_count: usize,
+    },
 }
 
 impl ValidationError {
@@ -145,6 +168,23 @@ impl ValidationError {
             Self::OfflineReadinessInsufficient { .. } => "offline_readiness_insufficient",
             Self::UnshareNetUnavailable => "unshare_net_unavailable",
             Self::LowDiskSpaceAdvisory { .. } => "low_disk_space_advisory",
+            Self::UnknownCommandArgument(_) => "unknown_command_argument",
+            Self::DuplicateCommandArgument(_) => "duplicate_command_argument",
+            Self::CommandArgumentsUnsupportedForMethod(_) => {
+                "command_arguments_unsupported_for_method"
+            }
+            Self::CommandArgumentNotSupportedForMethod { .. } => {
+                "command_argument_not_supported_for_method"
+            }
+            Self::IncompatibleCommandArguments { .. } => "incompatible_command_arguments",
+            Self::CommandArgumentCustomTokenEmpty => "command_argument_custom_token_empty",
+            Self::CommandArgumentCustomTokenContainsControlCharacter => {
+                "command_argument_custom_token_contains_control_character"
+            }
+            Self::CommandArgumentTokenTooLong { .. } => "command_argument_token_too_long",
+            Self::CommandArgumentTokenCountExceeded { .. } => {
+                "command_argument_token_count_exceeded"
+            }
         }
     }
 

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/error_text.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/error_text.rs
@@ -138,6 +138,38 @@ impl ValidationError {
             } => format!(
                 "Low disk space detected: {available_mb} MiB available (recommended minimum {threshold_mb} MiB)."
             ),
+            Self::UnknownCommandArgument(argument_id) => {
+                format!("Unknown command argument '{argument_id}'.")
+            }
+            Self::DuplicateCommandArgument(argument_id) => {
+                format!("Command argument '{argument_id}' was selected more than once.")
+            }
+            Self::CommandArgumentsUnsupportedForMethod(method) => {
+                format!(
+                    "Command arguments are only supported for proton_run or steam_applaunch launches, not '{method}'."
+                )
+            }
+            Self::CommandArgumentNotSupportedForMethod { argument_id, method } => {
+                format!(
+                    "Command argument '{argument_id}' is not supported for '{method}' launches."
+                )
+            }
+            Self::IncompatibleCommandArguments { first, second } => {
+                format!("Command arguments '{first}' and '{second}' cannot be enabled together.")
+            }
+            Self::CommandArgumentCustomTokenEmpty => {
+                "A custom command-argument token cannot be empty.".to_string()
+            }
+            Self::CommandArgumentCustomTokenContainsControlCharacter => {
+                "Custom command-argument tokens cannot contain NUL bytes or other control characters."
+                    .to_string()
+            }
+            Self::CommandArgumentTokenTooLong { max_len } => {
+                format!("A command-argument token exceeds the maximum length of {max_len} characters.")
+            }
+            Self::CommandArgumentTokenCountExceeded { max_count } => {
+                format!("Command arguments exceed the maximum of {max_count} resolved tokens.")
+            }
         }
     }
 
@@ -320,6 +352,46 @@ impl ValidationError {
             Self::LowDiskSpaceAdvisory { mount_path, .. } => {
                 format!(
                     "Free up space on the filesystem backing '{mount_path}' before launching to reduce crash and staging failures. This warning is informational."
+                )
+            }
+            Self::UnknownCommandArgument(argument_id) => {
+                format!(
+                    "Remove '{argument_id}' from the profile or update CrossHook to a version that supports it."
+                )
+            }
+            Self::DuplicateCommandArgument(argument_id) => {
+                format!(
+                    "Open Command Arguments and keep '{argument_id}' selected only once."
+                )
+            }
+            Self::CommandArgumentsUnsupportedForMethod(method) => {
+                format!(
+                    "Switch the profile to 'proton_run' or 'steam_applaunch' to use command arguments, or clear command arguments for '{method}'."
+                )
+            }
+            Self::CommandArgumentNotSupportedForMethod { argument_id, method } => {
+                format!(
+                    "Disable '{argument_id}' or change the profile to a launch method that supports it instead of '{method}'."
+                )
+            }
+            Self::IncompatibleCommandArguments { first, second } => {
+                format!("Disable either '{first}' or '{second}' before launching.")
+            }
+            Self::CommandArgumentCustomTokenEmpty => {
+                "Remove the empty custom argument row or enter a valid argv token.".to_string()
+            }
+            Self::CommandArgumentCustomTokenContainsControlCharacter => {
+                "Remove NUL bytes and other control characters from the custom argument token; paste plain text only."
+                    .to_string()
+            }
+            Self::CommandArgumentTokenTooLong { max_len } => {
+                format!(
+                    "Shorten the token to {max_len} characters or fewer, or split it into separate argv tokens if appropriate."
+                )
+            }
+            Self::CommandArgumentTokenCountExceeded { max_count } => {
+                format!(
+                    "Reduce the number of curated selections and custom tokens to {max_count} or fewer resolved argv tokens."
                 )
             }
         }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/mod.rs
@@ -11,9 +11,10 @@ mod tests;
 pub use error::ValidationError;
 pub use issues::{LaunchValidationIssue, ValidationSeverity};
 pub use models::{
-    is_inside_gamescope_session, LaunchOptimizationsRequest, LaunchRequest, RuntimeLaunchConfig,
-    SteamLaunchConfig, SteamLaunchRequest, UmuGameIdLookupKey, UmuGameIdResolution,
-    UmuGameIdResolutionSource, METHOD_NATIVE, METHOD_PROTON_RUN, METHOD_STEAM_APPLAUNCH,
+    is_inside_gamescope_session, LaunchCommandArgumentsRequest, LaunchOptimizationsRequest,
+    LaunchRequest, RuntimeLaunchConfig, SteamLaunchConfig, SteamLaunchRequest, UmuGameIdLookupKey,
+    UmuGameIdResolution, UmuGameIdResolutionSource, METHOD_NATIVE, METHOD_PROTON_RUN,
+    METHOD_STEAM_APPLAUNCH,
 };
 pub use validation::{validate, validate_all};
 

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/models.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/models.rs
@@ -36,6 +36,11 @@ pub struct LaunchRequest {
     pub runtime: RuntimeLaunchConfig,
     #[serde(default)]
     pub optimizations: LaunchOptimizationsRequest,
+    #[serde(
+        default,
+        skip_serializing_if = "LaunchCommandArgumentsRequest::is_empty"
+    )]
+    pub command_arguments: LaunchCommandArgumentsRequest,
     #[serde(default)]
     pub launch_trainer_only: bool,
     #[serde(default)]
@@ -168,6 +173,24 @@ pub struct LaunchOptimizationsRequest {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub enabled_option_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct LaunchCommandArgumentsRequest {
+    #[serde(
+        rename = "enabled_argument_ids",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub enabled_argument_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_args: Vec<String>,
+}
+
+impl LaunchCommandArgumentsRequest {
+    pub fn is_empty(&self) -> bool {
+        self.enabled_argument_ids.is_empty() && self.custom_args.is_empty()
+    }
 }
 
 impl LaunchRequest {

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/tests/method_validation.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/tests/method_validation.rs
@@ -1,8 +1,21 @@
 use std::fs;
 
+use crate::launch::request::models::LaunchCommandArgumentsRequest;
 use crate::launch::request::{validate, validate_all, ValidationError, METHOD_NATIVE};
 
 use super::support::{native_request, proton_request, steam_request};
+
+fn with_command_arguments(
+    mut request: crate::launch::request::LaunchRequest,
+    enabled_argument_ids: Vec<String>,
+    custom_args: Vec<String>,
+) -> crate::launch::request::LaunchRequest {
+    request.command_arguments = LaunchCommandArgumentsRequest {
+        enabled_argument_ids,
+        custom_args,
+    };
+    request
+}
 
 #[test]
 fn validates_steam_applaunch_request() {
@@ -237,5 +250,197 @@ fn validate_all_proton_collects_directive_error_alongside_path_issues() {
             .iter()
             .any(|issue| issue.code.as_deref() == Some("unknown_launch_optimization")),
         "expected directive error issue in: {issues:?}"
+    );
+}
+
+#[test]
+fn proton_run_accepts_valid_command_arguments() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(
+        request,
+        vec!["force_vulkan".to_string()],
+        vec![
+            "--flag=value".to_string(),
+            "+set".to_string(),
+            "-dx11".to_string(),
+            "/path/with spaces/game.exe".to_string(),
+        ],
+    );
+
+    assert_eq!(validate(&request), Ok(()));
+    assert!(validate_all(&request).is_empty());
+}
+
+#[test]
+fn steam_applaunch_accepts_valid_command_arguments() {
+    let (_temp_dir, request) = steam_request();
+    let request = with_command_arguments(
+        request,
+        vec!["skip_launcher".to_string()],
+        vec!["-windowed".to_string()],
+    );
+
+    assert_eq!(validate(&request), Ok(()));
+}
+
+#[test]
+fn proton_run_rejects_unknown_command_argument() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(request, vec!["not_a_real_argument".to_string()], vec![]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::UnknownCommandArgument(
+            "not_a_real_argument".to_string()
+        ))
+    );
+}
+
+#[test]
+fn proton_run_rejects_duplicate_command_arguments() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(
+        request,
+        vec!["force_vulkan".to_string(), "force_vulkan".to_string()],
+        vec![],
+    );
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::DuplicateCommandArgument(
+            "force_vulkan".to_string()
+        ))
+    );
+}
+
+#[test]
+fn proton_run_rejects_incompatible_command_arguments() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(
+        request,
+        vec!["force_vulkan".to_string(), "force_dx11".to_string()],
+        vec![],
+    );
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::IncompatibleCommandArguments {
+            first: "force_vulkan".to_string(),
+            second: "force_dx11".to_string(),
+        })
+    );
+}
+
+#[test]
+fn native_rejects_nonempty_command_arguments() {
+    let (_temp_dir, request) = native_request();
+    let request = with_command_arguments(request, vec![], vec!["-windowed".to_string()]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentsUnsupportedForMethod(
+            METHOD_NATIVE.to_string()
+        ))
+    );
+}
+
+#[test]
+fn native_rejects_curated_command_arguments() {
+    let (_temp_dir, request) = native_request();
+    let request = with_command_arguments(request, vec!["force_vulkan".to_string()], vec![]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentsUnsupportedForMethod(
+            METHOD_NATIVE.to_string()
+        ))
+    );
+}
+
+#[test]
+fn proton_run_rejects_empty_custom_command_argument_token() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(request, vec![], vec!["   ".to_string()]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentCustomTokenEmpty)
+    );
+}
+
+#[test]
+fn proton_run_rejects_control_characters_in_custom_command_argument() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(request, vec![], vec!["bad\x07arg".to_string()]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentCustomTokenContainsControlCharacter)
+    );
+}
+
+#[test]
+fn proton_run_rejects_nul_in_custom_command_argument() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(request, vec![], vec!["bad\x00arg".to_string()]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentCustomTokenContainsControlCharacter)
+    );
+}
+
+#[test]
+fn proton_run_rejects_excessive_custom_command_argument_length() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(request, vec![], vec!["a".repeat(513)]);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentTokenTooLong { max_len: 512 })
+    );
+}
+
+#[test]
+fn proton_run_rejects_excessive_command_argument_token_count() {
+    let (_temp_dir, request) = proton_request();
+    let custom_args = (0..65).map(|index| format!("-arg{index}")).collect();
+
+    let request = with_command_arguments(request, vec![], custom_args);
+
+    assert_eq!(
+        validate(&request),
+        Err(ValidationError::CommandArgumentTokenCountExceeded { max_count: 64 })
+    );
+}
+
+#[test]
+fn validate_all_collects_command_argument_issues() {
+    let (_temp_dir, request) = proton_request();
+    let request = with_command_arguments(
+        request,
+        vec!["unknown_argument".to_string()],
+        vec!["   ".to_string(), "bad\x00arg".to_string()],
+    );
+
+    let issues = validate_all(&request);
+    assert!(
+        issues
+            .iter()
+            .any(|issue| issue.code.as_deref() == Some("unknown_command_argument")),
+        "expected unknown command argument issue in: {issues:?}"
+    );
+    assert!(
+        issues
+            .iter()
+            .any(|issue| issue.code.as_deref() == Some("command_argument_custom_token_empty")),
+        "expected empty custom token issue in: {issues:?}"
+    );
+    assert!(
+        issues.iter().any(|issue| {
+            issue.code.as_deref()
+                == Some("command_argument_custom_token_contains_control_character")
+        }),
+        "expected control character issue in: {issues:?}"
     );
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/tests/serde_roundtrip.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/tests/serde_roundtrip.rs
@@ -1,3 +1,4 @@
+use crate::launch::request::models::LaunchCommandArgumentsRequest;
 use crate::launch::request::{LaunchRequest, RuntimeLaunchConfig};
 
 #[test]
@@ -24,4 +25,46 @@ fn launch_request_runtime_umu_game_id_roundtrip() {
     let parsed: LaunchRequest = toml::from_str(&serialized).unwrap();
     assert_eq!(parsed.umu_preference, UmuPreference::Umu);
     assert_eq!(parsed.runtime.umu_game_id, "custom-7");
+}
+
+#[test]
+fn launch_request_command_arguments_absent_deserializes_to_empty_defaults() {
+    let toml = "method = \"proton_run\"\n";
+    let req: LaunchRequest = toml::from_str(toml).unwrap();
+    assert!(req.command_arguments.is_empty());
+    assert!(req.command_arguments.enabled_argument_ids.is_empty());
+    assert!(req.command_arguments.custom_args.is_empty());
+}
+
+#[test]
+fn launch_request_command_arguments_empty_omitted_from_toml_and_roundtrips() {
+    let req = LaunchRequest {
+        method: "proton_run".to_string(),
+        ..Default::default()
+    };
+    let serialized = toml::to_string(&req).unwrap();
+    assert!(
+        !serialized.contains("command_arguments"),
+        "expected empty command arguments skipped: {serialized}"
+    );
+    let parsed: LaunchRequest = toml::from_str(&serialized).unwrap();
+    assert!(parsed.command_arguments.is_empty());
+}
+
+#[test]
+fn launch_request_command_arguments_nonempty_toml_roundtrip() {
+    let req = LaunchRequest {
+        method: "proton_run".to_string(),
+        command_arguments: LaunchCommandArgumentsRequest {
+            enabled_argument_ids: vec!["force_vulkan".to_string(), "skip_launcher".to_string()],
+            custom_args: vec!["-dx11".to_string(), "+set cl_showfps 1".to_string()],
+        },
+        ..Default::default()
+    };
+    let serialized = toml::to_string(&req).unwrap();
+    assert!(serialized.contains("command_arguments"));
+    assert!(serialized.contains("enabled_argument_ids"));
+    assert!(serialized.contains("custom_args"));
+    let parsed: LaunchRequest = toml::from_str(&serialized).unwrap();
+    assert_eq!(parsed.command_arguments, req.command_arguments);
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/request/validation.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/request/validation.rs
@@ -8,6 +8,9 @@ use super::path_probe::{
     path_exists_visible_or_host, path_is_file_visible_or_host, require_directory,
     require_executable_file,
 };
+use crate::launch::command_arguments::{
+    resolve_command_arguments_for_method, CommandArgumentResolveError,
+};
 use crate::launch::optimizations::{
     is_command_available, resolve_launch_directives, resolve_launch_directives_for_method,
 };
@@ -19,6 +22,9 @@ const RESERVED_CUSTOM_ENV_KEYS: &[&str] = &[
     "STEAM_COMPAT_DATA_PATH",
     "STEAM_COMPAT_CLIENT_INSTALL_PATH",
 ];
+
+const MAX_COMMAND_ARGUMENT_TOKEN_LEN: usize = 512;
+const MAX_COMMAND_ARGUMENT_TOKENS: usize = 64;
 
 /// Validates one custom env entry and returns the canonical **trimmed** key for emission paths.
 fn validate_custom_env_entry(key: &str, value: &str) -> Result<String, ValidationError> {
@@ -55,6 +61,129 @@ fn collect_custom_env_issues(request: &LaunchRequest, issues: &mut Vec<LaunchVal
         if let Err(err) = validate_custom_env_entry(key, value) {
             issues.push(err.issue());
         }
+    }
+}
+
+fn command_argument_token_has_control_character(token: &str) -> bool {
+    token.contains('\0') || token.chars().any(char::is_control)
+}
+
+fn validate_command_argument_token_length(token: &str) -> Result<(), ValidationError> {
+    if token.len() > MAX_COMMAND_ARGUMENT_TOKEN_LEN {
+        return Err(ValidationError::CommandArgumentTokenTooLong {
+            max_len: MAX_COMMAND_ARGUMENT_TOKEN_LEN,
+        });
+    }
+    Ok(())
+}
+
+fn validate_custom_command_argument_token(token: &str) -> Result<(), ValidationError> {
+    if token.trim().is_empty() {
+        return Err(ValidationError::CommandArgumentCustomTokenEmpty);
+    }
+    if command_argument_token_has_control_character(token) {
+        return Err(ValidationError::CommandArgumentCustomTokenContainsControlCharacter);
+    }
+    validate_command_argument_token_length(token)
+}
+
+fn command_argument_resolve_error(error: CommandArgumentResolveError) -> ValidationError {
+    match error {
+        CommandArgumentResolveError::Unknown(argument_id) => {
+            ValidationError::UnknownCommandArgument(argument_id)
+        }
+        CommandArgumentResolveError::Duplicate(argument_id) => {
+            ValidationError::DuplicateCommandArgument(argument_id)
+        }
+        CommandArgumentResolveError::NotSupportedForMethod {
+            argument_id,
+            method,
+        } => ValidationError::CommandArgumentNotSupportedForMethod {
+            argument_id,
+            method,
+        },
+        CommandArgumentResolveError::Incompatible { first, second } => {
+            ValidationError::IncompatibleCommandArguments { first, second }
+        }
+        CommandArgumentResolveError::UnsupportedLaunchMethod(method) => {
+            ValidationError::CommandArgumentsUnsupportedForMethod(method)
+        }
+    }
+}
+
+fn validate_resolved_command_argument_tokens(tokens: &[String]) -> Result<(), ValidationError> {
+    if tokens.len() > MAX_COMMAND_ARGUMENT_TOKENS {
+        return Err(ValidationError::CommandArgumentTokenCountExceeded {
+            max_count: MAX_COMMAND_ARGUMENT_TOKENS,
+        });
+    }
+
+    for token in tokens {
+        validate_command_argument_token_length(token)?;
+    }
+
+    Ok(())
+}
+
+fn validate_command_arguments(request: &LaunchRequest) -> Result<(), ValidationError> {
+    if request.command_arguments.is_empty() || request.launch_trainer_only {
+        return Ok(());
+    }
+
+    let method = request.resolved_method();
+    if method == METHOD_NATIVE {
+        return Err(ValidationError::CommandArgumentsUnsupportedForMethod(
+            method.to_string(),
+        ));
+    }
+
+    for custom_arg in &request.command_arguments.custom_args {
+        validate_custom_command_argument_token(custom_arg)?;
+    }
+
+    let resolved = resolve_command_arguments_for_method(
+        &request.command_arguments.enabled_argument_ids,
+        &request.command_arguments.custom_args,
+        method,
+    )
+    .map_err(command_argument_resolve_error)?;
+
+    validate_resolved_command_argument_tokens(&resolved.tokens)
+}
+
+fn collect_command_argument_issues(
+    request: &LaunchRequest,
+    issues: &mut Vec<LaunchValidationIssue>,
+) {
+    if request.command_arguments.is_empty() || request.launch_trainer_only {
+        return;
+    }
+
+    let method = request.resolved_method();
+    if method == METHOD_NATIVE {
+        issues.push(
+            ValidationError::CommandArgumentsUnsupportedForMethod(method.to_string()).issue(),
+        );
+        return;
+    }
+
+    for custom_arg in &request.command_arguments.custom_args {
+        if let Err(err) = validate_custom_command_argument_token(custom_arg) {
+            issues.push(err.issue());
+        }
+    }
+
+    match resolve_command_arguments_for_method(
+        &request.command_arguments.enabled_argument_ids,
+        &request.command_arguments.custom_args,
+        method,
+    ) {
+        Ok(resolved) => {
+            if let Err(err) = validate_resolved_command_argument_tokens(&resolved.tokens) {
+                issues.push(err.issue());
+            }
+        }
+        Err(err) => issues.push(command_argument_resolve_error(err).issue()),
     }
 }
 
@@ -118,6 +247,7 @@ pub fn validate_all(request: &LaunchRequest) -> Vec<LaunchValidationIssue> {
 
     let mut issues = Vec::new();
     collect_custom_env_issues(request, &mut issues);
+    collect_command_argument_issues(request, &mut issues);
     match request.resolved_method() {
         METHOD_STEAM_APPLAUNCH => collect_steam_issues(request, &mut issues),
         METHOD_PROTON_RUN => collect_proton_issues(request, &mut issues),
@@ -138,6 +268,7 @@ pub fn validate(request: &LaunchRequest) -> Result<(), ValidationError> {
     }
 
     validate_custom_env(request)?;
+    validate_command_arguments(request)?;
 
     match request.resolved_method() {
         METHOD_STEAM_APPLAUNCH => validate_steam_applaunch(request),

--- a/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/proton_game.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/proton_game.rs
@@ -19,8 +19,17 @@ use crate::launch::runtime_helpers::{
     host_environment_map, merge_optimization_and_custom_into_map, merge_runtime_proton_into_map,
     resolve_effective_working_directory,
 };
-use crate::launch::{resolve_launch_directives, LaunchRequest};
+use crate::launch::{
+    resolve_command_arguments, resolve_launch_directives, CommandArgumentResolveError,
+    LaunchRequest,
+};
 use crate::platform::{self, normalize_flatpak_host_path};
+
+fn command_argument_resolve_error_to_io_error(
+    error: CommandArgumentResolveError,
+) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{error:?}"))
+}
 
 pub fn build_proton_game_command(
     request: &LaunchRequest,
@@ -142,6 +151,11 @@ pub fn build_proton_game_command(
             use_umu,
         )
     };
+    let resolved_command_arguments =
+        resolve_command_arguments(request).map_err(command_argument_resolve_error_to_io_error)?;
     command.arg(normalized_game_path.trim());
+    for token in &resolved_command_arguments.tokens {
+        command.arg(token);
+    }
     Ok(command)
 }

--- a/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/tests/proton_game.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/tests/proton_game.rs
@@ -419,3 +419,191 @@ fn proton_game_command_does_not_include_unshare_net() {
         "game command args must not contain --net"
     );
 }
+
+#[test]
+fn proton_game_command_appends_curated_and_custom_arguments_after_game_executable() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let prefix_path = temp_dir.path().join("prefix");
+    let proton_path = temp_dir.path().join("proton");
+    let game_path = temp_dir.path().join("game.exe");
+    let log_path = temp_dir.path().join("game.log");
+    let steam_client_path = temp_dir.path().join("steam-client");
+
+    fs::create_dir_all(&prefix_path).expect("prefix dir");
+    fs::create_dir_all(&steam_client_path).expect("steam client dir");
+    write_executable_file(&proton_path);
+    fs::write(&game_path, b"game").expect("game exe");
+
+    let request = LaunchRequest {
+        method: crate::launch::METHOD_PROTON_RUN.to_string(),
+        game_path: game_path.to_string_lossy().into_owned(),
+        trainer_path: String::new(),
+        trainer_host_path: String::new(),
+        trainer_loading_mode: crate::profile::TrainerLoadingMode::SourceDirectory,
+        steam: crate::launch::SteamLaunchConfig {
+            app_id: String::new(),
+            compatdata_path: String::new(),
+            proton_path: String::new(),
+            steam_client_install_path: steam_client_path.to_string_lossy().into_owned(),
+        },
+        runtime: crate::launch::RuntimeLaunchConfig {
+            prefix_path: prefix_path.to_string_lossy().into_owned(),
+            proton_path: proton_path.to_string_lossy().into_owned(),
+            working_directory: String::new(),
+            steam_app_id: String::new(),
+            umu_game_id: String::new(),
+            umu_store: String::new(),
+            umu_codename: String::new(),
+        },
+        optimizations: crate::launch::request::LaunchOptimizationsRequest::default(),
+        command_arguments: crate::launch::request::LaunchCommandArgumentsRequest {
+            enabled_argument_ids: vec!["force_vulkan".to_string()],
+            custom_args: vec!["+set sv_cheats 1".to_string()],
+        },
+        launch_trainer_only: false,
+        launch_game_only: true,
+        profile_name: None,
+        umu_preference: crate::settings::UmuPreference::Proton,
+        ..Default::default()
+    };
+
+    let command = build_proton_game_command(&request, &log_path).expect("game command");
+    let args = command
+        .as_std()
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    let game_path_str = game_path.to_string_lossy().into_owned();
+    let game_idx = args
+        .iter()
+        .position(|arg| arg == &game_path_str)
+        .expect("game executable path in args");
+
+    assert_eq!(
+        command.as_std().get_program().to_string_lossy(),
+        proton_path.to_string_lossy()
+    );
+    assert_eq!(
+        args,
+        vec![
+            "run".to_string(),
+            game_path_str.clone(),
+            "-force_vulkan".to_string(),
+            "+set sv_cheats 1".to_string(),
+        ]
+    );
+    assert!(
+        args[game_idx + 1..]
+            .iter()
+            .any(|arg| arg == "-force_vulkan"),
+        "curated args must follow game executable"
+    );
+    assert!(
+        args[game_idx + 1..]
+            .iter()
+            .any(|arg| arg == "+set sv_cheats 1"),
+        "custom args must follow game executable"
+    );
+}
+
+#[test]
+fn proton_game_command_appends_arguments_after_game_executable_with_gamescope() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let wrapper_dir = temp_dir.path().join("wrappers");
+    let prefix_path = temp_dir.path().join("prefix");
+    let proton_path = temp_dir.path().join("proton");
+    let game_path = temp_dir.path().join("game.exe");
+    let log_path = temp_dir.path().join("game.log");
+    let steam_client_path = temp_dir.path().join("steam-client");
+
+    fs::create_dir_all(&wrapper_dir).expect("wrapper dir");
+    fs::create_dir_all(&prefix_path).expect("prefix dir");
+    fs::create_dir_all(&steam_client_path).expect("steam client dir");
+    write_executable_file(&wrapper_dir.join("mangohud"));
+    write_executable_file(&proton_path);
+    fs::write(&game_path, b"game").expect("game exe");
+
+    let _command_search_path =
+        crate::launch::test_support::ScopedCommandSearchPath::new(&wrapper_dir);
+    let request = LaunchRequest {
+        method: crate::launch::METHOD_PROTON_RUN.to_string(),
+        game_path: game_path.to_string_lossy().into_owned(),
+        trainer_path: String::new(),
+        trainer_host_path: String::new(),
+        trainer_loading_mode: crate::profile::TrainerLoadingMode::SourceDirectory,
+        steam: crate::launch::SteamLaunchConfig {
+            app_id: String::new(),
+            compatdata_path: String::new(),
+            proton_path: String::new(),
+            steam_client_install_path: steam_client_path.to_string_lossy().into_owned(),
+        },
+        runtime: crate::launch::RuntimeLaunchConfig {
+            prefix_path: prefix_path.to_string_lossy().into_owned(),
+            proton_path: proton_path.to_string_lossy().into_owned(),
+            working_directory: String::new(),
+            steam_app_id: String::new(),
+            umu_game_id: String::new(),
+            umu_store: String::new(),
+            umu_codename: String::new(),
+        },
+        optimizations: crate::launch::request::LaunchOptimizationsRequest {
+            enabled_option_ids: vec!["show_mangohud_overlay".to_string()],
+        },
+        command_arguments: crate::launch::request::LaunchCommandArgumentsRequest {
+            enabled_argument_ids: vec!["skip_launcher".to_string()],
+            custom_args: vec!["-windowed".to_string()],
+        },
+        gamescope: crate::profile::GamescopeConfig {
+            enabled: true,
+            fullscreen: true,
+            ..Default::default()
+        },
+        launch_trainer_only: false,
+        launch_game_only: true,
+        profile_name: None,
+        umu_preference: crate::settings::UmuPreference::Proton,
+        ..Default::default()
+    };
+
+    let command = build_proton_game_command(&request, &log_path).expect("game command");
+    let args = command
+        .as_std()
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        command.as_std().get_program().to_string_lossy(),
+        "gamescope"
+    );
+    let game_path_str = game_path.to_string_lossy().into_owned();
+    let double_dash_idx = args
+        .iter()
+        .position(|arg| arg == "--")
+        .expect("gamescope --");
+    let game_idx = args
+        .iter()
+        .position(|arg| arg == &game_path_str)
+        .expect("game executable path in args");
+    let skip_launcher_idx = args
+        .iter()
+        .position(|arg| arg == "-skip_launcher")
+        .expect("-skip_launcher arg");
+    let windowed_idx = args
+        .iter()
+        .position(|arg| arg == "-windowed")
+        .expect("-windowed custom arg");
+
+    assert!(
+        double_dash_idx < game_idx,
+        "game exe must follow gamescope --"
+    );
+    assert!(
+        skip_launcher_idx > game_idx && windowed_idx > game_idx,
+        "command args must follow game executable, not gamescope/wrapper tokens"
+    );
+    assert!(
+        skip_launcher_idx > double_dash_idx && windowed_idx > double_dash_idx,
+        "command args must not appear before gamescope -- separator"
+    );
+}

--- a/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/tests/proton_game_umu.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/tests/proton_game_umu.rs
@@ -183,3 +183,47 @@ fn proton_preference_always_uses_direct_proton() {
         .into_owned();
     assert!(!program.ends_with("umu-run"));
 }
+
+#[test]
+fn proton_game_command_appends_arguments_after_game_executable_with_umu() {
+    let dir = tempfile::tempdir().unwrap();
+    write_executable_file_with_contents(
+        dir.path().join("umu-run").as_path(),
+        b"#!/bin/sh\nexit 0\n",
+    );
+    let _guard = crate::launch::test_support::ScopedCommandSearchPath::new(dir.path());
+
+    use crate::settings::UmuPreference;
+    let mut request = LaunchRequest {
+        method: crate::launch::METHOD_PROTON_RUN.to_string(),
+        game_path: "/tmp/game.exe".to_string(),
+        umu_preference: UmuPreference::Umu,
+        command_arguments: crate::launch::request::LaunchCommandArgumentsRequest {
+            enabled_argument_ids: vec!["force_dx11".to_string()],
+            custom_args: vec!["-nolauncher".to_string()],
+        },
+        ..Default::default()
+    };
+    request.runtime.proton_path = "/opt/proton/GE-Proton9-20/proton".to_string();
+
+    let log_dir = tempfile::tempdir().unwrap();
+    let log_path = log_dir.path().join("test.log");
+    let command = build_proton_game_command(&request, &log_path).unwrap();
+
+    let args: Vec<String> = command
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    let game_idx = args
+        .iter()
+        .position(|arg| arg == "/tmp/game.exe")
+        .expect("game executable path in args");
+
+    assert!(
+        !args.contains(&"run".to_string()),
+        "umu-run must not receive \"run\" subcommand arg; args: {args:?}"
+    );
+    assert_eq!(args[game_idx + 1], "-dx11");
+    assert_eq!(args[game_idx + 2], "-nolauncher");
+}

--- a/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/tests/proton_trainer.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/launch/script_runner/tests/proton_trainer.rs
@@ -108,6 +108,78 @@ fn proton_trainer_command_ignores_game_optimization_wrappers_and_env() {
 }
 
 #[test]
+fn proton_trainer_command_does_not_inherit_game_command_arguments() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let prefix_path = temp_dir.path().join("prefix");
+    let proton_path = temp_dir.path().join("proton");
+    let trainer_source_dir = temp_dir.path().join("trainer");
+    let trainer_host_path = trainer_source_dir.join("sample.exe");
+    let log_path = temp_dir.path().join("trainer.log");
+    let workspace_dir = prefix_path.join("workspace");
+    let wine_prefix_path = prefix_path.join("pfx");
+
+    fs::create_dir_all(wine_prefix_path.join("drive_c")).expect("wine prefix dir");
+    fs::create_dir_all(&trainer_source_dir).expect("trainer dir");
+    fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    write_executable_file(&proton_path);
+    fs::write(&trainer_host_path, b"trainer").expect("trainer exe");
+
+    let request = LaunchRequest {
+        method: crate::launch::METHOD_PROTON_RUN.to_string(),
+        game_path: temp_dir
+            .path()
+            .join("game.exe")
+            .to_string_lossy()
+            .into_owned(),
+        trainer_path: trainer_host_path.to_string_lossy().into_owned(),
+        trainer_host_path: trainer_host_path.to_string_lossy().into_owned(),
+        trainer_loading_mode: crate::profile::TrainerLoadingMode::CopyToPrefix,
+        steam: crate::launch::SteamLaunchConfig::default(),
+        runtime: crate::launch::RuntimeLaunchConfig {
+            prefix_path: prefix_path.to_string_lossy().into_owned(),
+            proton_path: proton_path.to_string_lossy().into_owned(),
+            working_directory: workspace_dir.to_string_lossy().into_owned(),
+            steam_app_id: String::new(),
+            umu_game_id: String::new(),
+            umu_store: String::new(),
+            umu_codename: String::new(),
+        },
+        command_arguments: crate::launch::request::LaunchCommandArgumentsRequest {
+            enabled_argument_ids: vec!["force_vulkan".to_string()],
+            custom_args: vec!["-windowed".to_string()],
+        },
+        launch_trainer_only: true,
+        launch_game_only: false,
+        profile_name: None,
+        umu_preference: crate::settings::UmuPreference::Proton,
+        ..Default::default()
+    };
+
+    let command = build_proton_trainer_command(&request, &log_path).expect("trainer command");
+    let args = command
+        .as_std()
+        .get_args()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        args,
+        vec![
+            "run".to_string(),
+            "C:\\CrossHook\\StagedTrainers\\sample\\sample.exe".to_string(),
+        ]
+    );
+    assert!(
+        !args.iter().any(|arg| arg == "-force_vulkan"),
+        "trainer launch must not inherit curated game command arguments"
+    );
+    assert!(
+        !args.iter().any(|arg| arg == "-windowed"),
+        "trainer launch must not inherit custom game command arguments"
+    );
+}
+
+#[test]
 fn proton_trainer_command_sets_proton_verb_to_runinprefix() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let prefix_path = temp_dir.path().join("prefix");

--- a/src/crosshook-native/crates/crosshook-core/src/metadata/models.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/metadata/models.rs
@@ -395,6 +395,7 @@ impl VersionCorrelationStatus {
 pub enum ConfigRevisionSource {
     ManualSave,
     LaunchOptimizationSave,
+    LaunchCommandArgumentsSave,
     PresetApply,
     RollbackApply,
     Import,
@@ -407,6 +408,7 @@ impl ConfigRevisionSource {
         match self {
             Self::ManualSave => "manual_save",
             Self::LaunchOptimizationSave => "launch_optimization_save",
+            Self::LaunchCommandArgumentsSave => "launch_command_arguments_save",
             Self::PresetApply => "preset_apply",
             Self::RollbackApply => "rollback_apply",
             Self::Import => "import",

--- a/src/crosshook-native/crates/crosshook-core/src/profile/models/launch.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/profile/models/launch.rs
@@ -20,6 +20,24 @@ impl LaunchOptimizationsSection {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct LaunchCommandArgumentsSection {
+    #[serde(
+        rename = "enabled_argument_ids",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub enabled_argument_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_args: Vec<String>,
+}
+
+impl LaunchCommandArgumentsSection {
+    pub fn is_empty(&self) -> bool {
+        self.enabled_argument_ids.is_empty() && self.custom_args.is_empty()
+    }
+}
+
 fn default_network_isolation() -> bool {
     true
 }
@@ -34,6 +52,13 @@ pub struct LaunchSection {
     pub method: String,
     #[serde(default, skip_serializing_if = "LaunchOptimizationsSection::is_empty")]
     pub optimizations: LaunchOptimizationsSection,
+    /// Curated command-argument IDs and custom argv tokens for supported launch methods.
+    #[serde(
+        rename = "command_arguments",
+        default,
+        skip_serializing_if = "LaunchCommandArgumentsSection::is_empty"
+    )]
+    pub command_arguments: LaunchCommandArgumentsSection,
     /// Named optimization bundles (`[launch.presets.<name>]` in TOML).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub presets: BTreeMap<String, LaunchOptimizationsSection>,
@@ -76,6 +101,7 @@ impl Default for LaunchSection {
         Self {
             method: String::new(),
             optimizations: LaunchOptimizationsSection::default(),
+            command_arguments: LaunchCommandArgumentsSection::default(),
             presets: BTreeMap::new(),
             active_preset: String::new(),
             custom_env_vars: BTreeMap::new(),

--- a/src/crosshook-native/crates/crosshook-core/src/profile/models/tests/launch_section.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/profile/models/tests/launch_section.rs
@@ -300,3 +300,60 @@ fn launch_section_default_has_network_isolation_true() {
     let launch = LaunchSection::default();
     assert!(launch.network_isolation);
 }
+
+#[test]
+fn command_arguments_empty_omitted_from_toml_and_roundtrips() {
+    let profile = sample_profile();
+    let serialized = toml::to_string_pretty(&profile).expect("serialize");
+    assert!(
+        !serialized.contains("command_arguments"),
+        "expected empty command arguments skipped: {serialized}"
+    );
+    let parsed: GameProfile = toml::from_str(&serialized).expect("deserialize");
+    assert!(parsed.launch.command_arguments.is_empty());
+    assert!(parsed
+        .launch
+        .command_arguments
+        .enabled_argument_ids
+        .is_empty());
+    assert!(parsed.launch.command_arguments.custom_args.is_empty());
+}
+
+#[test]
+fn command_arguments_nonempty_toml_roundtrip() {
+    let mut profile = sample_profile();
+    profile.launch.command_arguments.enabled_argument_ids =
+        vec!["force_vulkan".to_string(), "skip_launcher".to_string()];
+    profile.launch.command_arguments.custom_args =
+        vec!["-dx11".to_string(), "+set cl_showfps 1".to_string()];
+    let serialized = toml::to_string_pretty(&profile).expect("serialize");
+    assert!(serialized.contains("command_arguments"));
+    assert!(serialized.contains("enabled_argument_ids"));
+    assert!(serialized.contains("custom_args"));
+    let parsed: GameProfile = toml::from_str(&serialized).expect("deserialize");
+    assert_eq!(
+        parsed.launch.command_arguments,
+        profile.launch.command_arguments
+    );
+}
+
+#[test]
+fn command_arguments_absent_from_toml_deserializes_to_empty_defaults() {
+    let toml = r#"
+[game]
+executable_path = "/games/x.exe"
+[trainer]
+path = "/t/y.exe"
+type = "fling"
+[launch]
+"#;
+    let toml = toml.to_string() + &format!(r#"method = "{METHOD_PROTON_RUN}""#);
+    let parsed: GameProfile = toml::from_str(&toml).expect("deserialize");
+    assert!(parsed.launch.command_arguments.is_empty());
+    assert!(parsed
+        .launch
+        .command_arguments
+        .enabled_argument_ids
+        .is_empty());
+    assert!(parsed.launch.command_arguments.custom_args.is_empty());
+}

--- a/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/error.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/error.rs
@@ -1,11 +1,15 @@
 use std::fmt;
 
+use crate::launch::request::ValidationError;
+
 #[derive(Debug)]
 pub enum ProfileStoreError {
     InvalidName(String),
     NotFound(std::path::PathBuf),
     AlreadyExists(String),
     InvalidLaunchOptimizationId(String),
+    InvalidCommandArgumentId(String),
+    CommandArgumentValidation(ValidationError),
     LaunchPresetNotFound(String),
     ReservedLaunchPresetName(String),
     InvalidLaunchPresetName(String),
@@ -24,6 +28,12 @@ impl fmt::Display for ProfileStoreError {
             }
             Self::InvalidLaunchOptimizationId(id) => {
                 write!(f, "unknown launch optimization id: {id}")
+            }
+            Self::InvalidCommandArgumentId(id) => {
+                write!(f, "unknown command argument id: {id}")
+            }
+            Self::CommandArgumentValidation(error) => {
+                write!(f, "{error}")
             }
             Self::LaunchPresetNotFound(name) => {
                 write!(f, "launch optimization preset not found: {name}")

--- a/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/store.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/store.rs
@@ -4,7 +4,13 @@ use std::path::{Path, PathBuf};
 use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
 
+use crate::launch::command_arguments::{
+    resolve_command_arguments_for_method, CommandArgumentResolveError,
+};
 use crate::launch::is_known_launch_optimization_id;
+use crate::launch::request::{
+    ValidationError, METHOD_NATIVE, METHOD_PROTON_RUN, METHOD_STEAM_APPLAUNCH,
+};
 use crate::profile::models::{LaunchOptimizationsSection, LocalOverrideSection};
 use crate::profile::{legacy, GameProfile};
 use crate::settings::{resolve_profiles_directory_from_config, AppSettingsData};
@@ -164,6 +170,41 @@ impl ProfileStore {
                 }
             }
         }
+
+        self.save(name, &profile)
+    }
+
+    /// Loads the profile, replaces `launch.command_arguments`, and saves. Concurrent writes for
+    /// the same profile are not synchronized; the last completed write wins.
+    pub fn save_command_arguments(
+        &self,
+        name: &str,
+        enabled_argument_ids: Vec<String>,
+        custom_args: Vec<String>,
+    ) -> Result<(), ProfileStoreError> {
+        let mut profile = self.load(name)?;
+
+        let enabled_argument_ids: Vec<String> = enabled_argument_ids
+            .into_iter()
+            .filter_map(|raw| {
+                let id = raw.trim();
+                (!id.is_empty()).then(|| id.to_string())
+            })
+            .collect();
+
+        let custom_args: Vec<String> = custom_args
+            .into_iter()
+            .map(|raw| raw.trim().to_string())
+            .collect();
+
+        validate_profile_command_arguments(
+            profile.launch.method.as_str(),
+            &enabled_argument_ids,
+            &custom_args,
+        )?;
+
+        profile.launch.command_arguments.enabled_argument_ids = enabled_argument_ids;
+        profile.launch.command_arguments.custom_args = custom_args;
 
         self.save(name, &profile)
     }
@@ -416,4 +457,116 @@ impl ProfileStore {
             Err(_) => false,
         }
     }
+}
+
+const MAX_COMMAND_ARGUMENT_TOKEN_LEN: usize = 512;
+const MAX_COMMAND_ARGUMENT_TOKENS: usize = 64;
+
+fn resolved_launch_method(method: &str) -> &str {
+    match method.trim() {
+        METHOD_STEAM_APPLAUNCH => METHOD_STEAM_APPLAUNCH,
+        METHOD_PROTON_RUN => METHOD_PROTON_RUN,
+        METHOD_NATIVE => METHOD_NATIVE,
+        other => other,
+    }
+}
+
+fn command_argument_token_has_control_character(token: &str) -> bool {
+    token.contains('\0') || token.chars().any(char::is_control)
+}
+
+fn validate_custom_command_argument_token(token: &str) -> Result<(), ValidationError> {
+    if token.is_empty() {
+        return Err(ValidationError::CommandArgumentCustomTokenEmpty);
+    }
+    if command_argument_token_has_control_character(token) {
+        return Err(ValidationError::CommandArgumentCustomTokenContainsControlCharacter);
+    }
+    if token.len() > MAX_COMMAND_ARGUMENT_TOKEN_LEN {
+        return Err(ValidationError::CommandArgumentTokenTooLong {
+            max_len: MAX_COMMAND_ARGUMENT_TOKEN_LEN,
+        });
+    }
+    Ok(())
+}
+
+fn command_argument_resolve_error(error: CommandArgumentResolveError) -> ProfileStoreError {
+    match error {
+        CommandArgumentResolveError::Unknown(argument_id) => {
+            ProfileStoreError::InvalidCommandArgumentId(argument_id)
+        }
+        CommandArgumentResolveError::Duplicate(argument_id) => {
+            ProfileStoreError::CommandArgumentValidation(ValidationError::DuplicateCommandArgument(
+                argument_id,
+            ))
+        }
+        CommandArgumentResolveError::NotSupportedForMethod {
+            argument_id,
+            method,
+        } => ProfileStoreError::CommandArgumentValidation(
+            ValidationError::CommandArgumentNotSupportedForMethod {
+                argument_id,
+                method,
+            },
+        ),
+        CommandArgumentResolveError::Incompatible { first, second } => {
+            ProfileStoreError::CommandArgumentValidation(
+                ValidationError::IncompatibleCommandArguments { first, second },
+            )
+        }
+        CommandArgumentResolveError::UnsupportedLaunchMethod(method) => {
+            ProfileStoreError::CommandArgumentValidation(
+                ValidationError::CommandArgumentsUnsupportedForMethod(method),
+            )
+        }
+    }
+}
+
+fn validate_resolved_command_argument_tokens(tokens: &[String]) -> Result<(), ValidationError> {
+    if tokens.len() > MAX_COMMAND_ARGUMENT_TOKENS {
+        return Err(ValidationError::CommandArgumentTokenCountExceeded {
+            max_count: MAX_COMMAND_ARGUMENT_TOKENS,
+        });
+    }
+
+    for token in tokens {
+        if token.len() > MAX_COMMAND_ARGUMENT_TOKEN_LEN {
+            return Err(ValidationError::CommandArgumentTokenTooLong {
+                max_len: MAX_COMMAND_ARGUMENT_TOKEN_LEN,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_profile_command_arguments(
+    method: &str,
+    enabled_argument_ids: &[String],
+    custom_args: &[String],
+) -> Result<(), ProfileStoreError> {
+    if enabled_argument_ids.is_empty() && custom_args.is_empty() {
+        return Ok(());
+    }
+
+    let resolved_method = resolved_launch_method(method);
+    if resolved_method == METHOD_NATIVE {
+        return Err(ProfileStoreError::CommandArgumentValidation(
+            ValidationError::CommandArgumentsUnsupportedForMethod(resolved_method.to_string()),
+        ));
+    }
+
+    for custom_arg in custom_args {
+        validate_custom_command_argument_token(custom_arg)
+            .map_err(ProfileStoreError::CommandArgumentValidation)?;
+    }
+
+    let resolved =
+        resolve_command_arguments_for_method(enabled_argument_ids, custom_args, resolved_method)
+            .map_err(command_argument_resolve_error)?;
+
+    validate_resolved_command_argument_tokens(&resolved.tokens)
+        .map_err(ProfileStoreError::CommandArgumentValidation)?;
+
+    Ok(())
 }

--- a/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/tests/command_arguments.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/tests/command_arguments.rs
@@ -1,0 +1,153 @@
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::launch::request::ValidationError;
+use crate::profile::toml_store::{ProfileStore, ProfileStoreError};
+
+use super::fixtures::sample_profile;
+
+#[test]
+fn save_command_arguments_merges_only_launch_section() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+    let profile = sample_profile();
+
+    store.save("elden-ring", &profile).unwrap();
+
+    let enabled_argument_ids = vec!["force_vulkan".to_string()];
+    let custom_args = vec!["-windowed".to_string()];
+    store
+        .save_command_arguments(
+            "elden-ring",
+            enabled_argument_ids.clone(),
+            custom_args.clone(),
+        )
+        .unwrap();
+
+    let loaded = store.load("elden-ring").unwrap();
+    assert_eq!(loaded.game, profile.game);
+    assert_eq!(loaded.trainer, profile.trainer);
+    assert_eq!(loaded.injection, profile.injection);
+    assert_eq!(loaded.steam, profile.steam);
+    assert_eq!(loaded.runtime, profile.runtime);
+    assert_eq!(loaded.launch.method, profile.launch.method);
+    assert_eq!(loaded.launch.optimizations, profile.launch.optimizations);
+    assert_eq!(
+        loaded.launch.command_arguments.enabled_argument_ids,
+        enabled_argument_ids
+    );
+    assert_eq!(loaded.launch.command_arguments.custom_args, custom_args);
+}
+
+#[test]
+fn save_command_arguments_trims_ids_and_custom_tokens() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+    store.save("elden-ring", &sample_profile()).unwrap();
+
+    store
+        .save_command_arguments(
+            "elden-ring",
+            vec!["  force_vulkan  ".to_string()],
+            vec!["  -windowed  ".to_string()],
+        )
+        .unwrap();
+
+    let loaded = store.load("elden-ring").unwrap();
+    assert_eq!(
+        loaded.launch.command_arguments.enabled_argument_ids,
+        vec!["force_vulkan".to_string()]
+    );
+    assert_eq!(
+        loaded.launch.command_arguments.custom_args,
+        vec!["-windowed".to_string()]
+    );
+}
+
+#[test]
+fn save_command_arguments_rejects_missing_profiles() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+
+    let result =
+        store.save_command_arguments("missing-profile", vec!["force_vulkan".to_string()], vec![]);
+
+    assert!(matches!(result, Err(ProfileStoreError::NotFound(_))));
+}
+
+#[test]
+fn save_command_arguments_rejects_unknown_argument_ids() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+    store.save("elden-ring", &sample_profile()).unwrap();
+
+    let result = store.save_command_arguments(
+        "elden-ring",
+        vec!["not_a_real_command_argument".to_string()],
+        vec![],
+    );
+
+    assert!(matches!(
+        result,
+        Err(ProfileStoreError::InvalidCommandArgumentId(id))
+            if id == "not_a_real_command_argument"
+    ));
+}
+
+#[test]
+fn save_command_arguments_rejects_blank_custom_tokens() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+    store.save("elden-ring", &sample_profile()).unwrap();
+
+    let result = store.save_command_arguments("elden-ring", vec![], vec!["   ".to_string()]);
+
+    assert!(matches!(
+        result,
+        Err(ProfileStoreError::CommandArgumentValidation(
+            ValidationError::CommandArgumentCustomTokenEmpty
+        ))
+    ));
+}
+
+#[test]
+fn save_command_arguments_rejects_invalid_custom_tokens() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+    store.save("elden-ring", &sample_profile()).unwrap();
+
+    let result = store.save_command_arguments("elden-ring", vec![], vec!["bad\x07arg".to_string()]);
+
+    assert!(matches!(
+        result,
+        Err(ProfileStoreError::CommandArgumentValidation(
+            ValidationError::CommandArgumentCustomTokenContainsControlCharacter
+        ))
+    ));
+}
+
+#[test]
+fn save_command_arguments_writes_only_command_arguments_subsection() {
+    let temp_dir = tempdir().unwrap();
+    let store = ProfileStore::with_base_path(temp_dir.path().join("profiles"));
+    let profile = sample_profile();
+    store.save("elden-ring", &profile).unwrap();
+
+    store
+        .save_command_arguments(
+            "elden-ring",
+            vec!["skip_launcher".to_string()],
+            vec!["+set sv_cheats 1".to_string()],
+        )
+        .unwrap();
+
+    let raw = fs::read_to_string(store.profile_path("elden-ring").unwrap()).unwrap();
+    assert!(raw.contains("[launch.command_arguments]"));
+    assert!(raw.contains("enabled_argument_ids = [\"skip_launcher\"]"));
+    assert!(raw.contains("custom_args = [\"+set sv_cheats 1\"]"));
+    assert!(!raw.contains("[launch.command_arguments.command_arguments]"));
+
+    let loaded = store.load("elden-ring").unwrap();
+    assert_eq!(loaded.launch.optimizations, profile.launch.optimizations);
+}

--- a/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/tests/mod.rs
+++ b/src/crosshook-native/crates/crosshook-core/src/profile/toml_store/tests/mod.rs
@@ -1,5 +1,6 @@
 mod fixtures;
 
+mod command_arguments;
 mod duplicate;
 mod import_legacy;
 mod load_save;

--- a/src/crosshook-native/src-tauri/src/commands/catalog.rs
+++ b/src/crosshook-native/src-tauri/src/commands/catalog.rs
@@ -1,4 +1,7 @@
 use crosshook_core::launch::catalog::{global_catalog, OptimizationEntry};
+use crosshook_core::launch::command_arguments::{
+    global_catalog as global_command_argument_catalog, CommandArgumentEntry,
+};
 use crosshook_core::launch::mangohud_presets::{global_mangohud_presets, MangoHudPreset};
 use serde::Serialize;
 
@@ -6,6 +9,22 @@ use serde::Serialize;
 pub struct OptimizationCatalogPayload {
     pub catalog_version: u32,
     pub entries: Vec<OptimizationEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandArgumentCatalogPayload {
+    pub catalog_version: u32,
+    pub entries: Vec<CommandArgumentEntry>,
+}
+
+/// Returns the active command-argument catalog (merged default + user overrides).
+#[tauri::command]
+pub fn get_command_argument_catalog() -> CommandArgumentCatalogPayload {
+    let catalog = global_command_argument_catalog();
+    CommandArgumentCatalogPayload {
+        catalog_version: catalog.catalog_version,
+        entries: catalog.entries.clone(),
+    }
 }
 
 /// Returns the active optimization catalog (merged default + user overrides).

--- a/src/crosshook-native/src-tauri/src/commands/launch/queries.rs
+++ b/src/crosshook-native/src-tauri/src/commands/launch/queries.rs
@@ -2,9 +2,10 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crosshook_core::launch::{
     build_launch_preview,
-    build_steam_launch_options_command as build_steam_launch_options_command_core, validate,
-    LaunchPlatformCapabilities, LaunchPreview, LaunchRequest, LaunchSessionRegistry,
-    LaunchValidationIssue, SessionKind,
+    build_steam_launch_options_command as build_steam_launch_options_command_core,
+    escape_steam_token, resolve_command_arguments_for_method, validate, LaunchPlatformCapabilities,
+    LaunchPreview, LaunchRequest, LaunchSessionRegistry, LaunchValidationIssue, SessionKind,
+    METHOD_STEAM_APPLAUNCH,
 };
 use crosshook_core::metadata::{LaunchHistoryEntry, MetadataStore, MAX_HISTORY_LIST_LIMIT};
 use crosshook_core::profile::GamescopeConfig;
@@ -42,19 +43,40 @@ pub async fn preview_launch(
 /// plus profile custom env vars (custom wins on duplicate keys in the prefix).
 ///
 /// When `gamescope` is provided and enabled, the gamescope compositor is inserted as a wrapper
-/// (e.g. `gamescope -w 2560 -h 1440 -f -- %command%`).
+/// (e.g. `gamescope -w 2560 -h 1440 -f -- %command%`). Resolved command-argument tokens are
+/// appended after `%command%` when `enabled_argument_ids` or `custom_command_args` are non-empty.
 #[tauri::command]
 pub fn build_steam_launch_options_command(
     enabled_option_ids: Vec<String>,
     custom_env_vars: BTreeMap<String, String>,
     gamescope: Option<GamescopeConfig>,
+    enabled_argument_ids: Vec<String>,
+    custom_command_args: Vec<String>,
 ) -> Result<String, String> {
-    build_steam_launch_options_command_core(
+    let mut command = build_steam_launch_options_command_core(
         &enabled_option_ids,
         &custom_env_vars,
         gamescope.as_ref(),
     )
-    .map_err(|error| error.to_string())
+    .map_err(|error| error.to_string())?;
+
+    if enabled_argument_ids.is_empty() && custom_command_args.is_empty() {
+        return Ok(command);
+    }
+
+    let resolved = resolve_command_arguments_for_method(
+        &enabled_argument_ids,
+        &custom_command_args,
+        METHOD_STEAM_APPLAUNCH,
+    )
+    .map_err(|error| format!("{error:?}"))?;
+
+    for token in resolved.tokens {
+        command.push(' ');
+        command.push_str(&escape_steam_token(&token));
+    }
+
+    Ok(command)
 }
 
 #[tauri::command]

--- a/src/crosshook-native/src-tauri/src/commands/profile/command_arguments.rs
+++ b/src/crosshook-native/src-tauri/src/commands/profile/command_arguments.rs
@@ -42,7 +42,7 @@ pub fn profile_save_command_arguments(
         capture_config_revision(
             profile_name,
             &updated,
-            ConfigRevisionSource::LaunchOptimizationSave,
+            ConfigRevisionSource::LaunchCommandArgumentsSave,
             None,
             &metadata_store,
         );

--- a/src/crosshook-native/src-tauri/src/commands/profile/command_arguments.rs
+++ b/src/crosshook-native/src-tauri/src/commands/profile/command_arguments.rs
@@ -1,0 +1,52 @@
+use crosshook_core::metadata::{ConfigRevisionSource, MetadataStore};
+use crosshook_core::profile::ProfileStore;
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use super::shared::{capture_config_revision, map_error, observe_profile_write_launch_change};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CommandArgumentsPayload {
+    #[serde(
+        rename = "enabled_argument_ids",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub enabled_argument_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_args: Vec<String>,
+}
+
+#[tauri::command]
+pub fn profile_save_command_arguments(
+    name: String,
+    command_arguments: CommandArgumentsPayload,
+    store: State<'_, ProfileStore>,
+    metadata_store: State<'_, MetadataStore>,
+) -> Result<(), String> {
+    let profile_name = name.trim();
+    if profile_name.is_empty() {
+        return Err("profile name is required".to_string());
+    }
+
+    store
+        .save_command_arguments(
+            profile_name,
+            command_arguments.enabled_argument_ids,
+            command_arguments.custom_args,
+        )
+        .map_err(map_error)?;
+
+    if let Ok(updated) = store.load(profile_name) {
+        observe_profile_write_launch_change(profile_name, &store, &metadata_store, &updated);
+        capture_config_revision(
+            profile_name,
+            &updated,
+            ConfigRevisionSource::LaunchOptimizationSave,
+            None,
+            &metadata_store,
+        );
+    }
+
+    Ok(())
+}

--- a/src/crosshook-native/src-tauri/src/commands/profile/mod.rs
+++ b/src/crosshook-native/src-tauri/src/commands/profile/mod.rs
@@ -6,6 +6,7 @@
 //! - `favorites`      — favorite profile commands
 //! - `config_history` — config revision history, diff, rollback, and mark-known-good
 
+mod command_arguments;
 mod config_history;
 mod favorites;
 mod lifecycle;
@@ -15,6 +16,7 @@ mod shared;
 #[cfg(test)]
 mod tests;
 
+pub use command_arguments::profile_save_command_arguments;
 pub use config_history::{
     profile_config_diff, profile_config_history, profile_config_rollback, profile_mark_known_good,
 };
@@ -31,6 +33,8 @@ pub use optimizations::{
 pub use shared::capture_config_revision;
 
 // Re-export Tauri command macros so `generate_handler!` can resolve `commands::profile::<name>`.
+pub use command_arguments::__cmd__profile_save_command_arguments;
+pub use command_arguments::__tauri_command_name_profile_save_command_arguments;
 pub use config_history::__cmd__profile_config_diff;
 pub use config_history::__cmd__profile_config_history;
 pub use config_history::__cmd__profile_config_rollback;

--- a/src/crosshook-native/src-tauri/src/lib.rs
+++ b/src/crosshook-native/src-tauri/src/lib.rs
@@ -10,7 +10,10 @@ pub use background_portal::{
 use crosshook_core::app_id_migration::migrate_legacy_tauri_app_id_xdg_directories;
 use crosshook_core::community::CommunityTapStore;
 use crosshook_core::flatpak_migration::{is_host_xdg_opt_in, MigrationOutcome};
-use crosshook_core::launch::{initialize_catalog, load_catalog};
+use crosshook_core::launch::{
+    initialize_catalog, initialize_command_argument_catalog, load_catalog,
+    load_command_argument_catalog,
+};
 use crosshook_core::logging;
 use crosshook_core::metadata::MetadataStore;
 use crosshook_core::offline::{initialize_trainer_type_catalog, load_trainer_type_catalog};
@@ -117,6 +120,11 @@ pub fn run() {
     // Merge order: embedded default → user override (~/.config/crosshook/optimization_catalog.toml).
     let catalog = load_catalog(Some(&settings_store.base_path), &[]);
     initialize_catalog(catalog);
+
+    // Command-argument catalog: embedded default → optional user override only (no SQLite).
+    let command_argument_catalog =
+        load_command_argument_catalog(Some(&settings_store.base_path), &[]);
+    initialize_command_argument_catalog(command_argument_catalog);
 
     let trainer_type_catalog = load_trainer_type_catalog(Some(&settings_store.base_path), &[]);
     initialize_trainer_type_catalog(trainer_type_catalog);
@@ -432,6 +440,7 @@ pub fn run() {
             commands::profile::profile_rename,
             commands::profile::profile_save,
             commands::profile::profile_save_launch_optimizations,
+            commands::profile::profile_save_command_arguments,
             commands::profile::profile_save_mangohud_config,
             commands::profile::profile_save_gamescope_config,
             commands::profile::profile_save_trainer_gamescope_config,
@@ -510,6 +519,7 @@ pub fn run() {
             commands::onboarding::dismiss_readiness_nag,
             commands::onboarding::get_trainer_guidance,
             commands::catalog::get_optimization_catalog,
+            commands::catalog::get_command_argument_catalog,
             commands::catalog::get_mangohud_presets,
             commands::offline::check_offline_readiness,
             commands::offline::batch_offline_readiness,

--- a/src/crosshook-native/src/components/CommandArgumentsPanel.tsx
+++ b/src/crosshook-native/src/components/CommandArgumentsPanel.tsx
@@ -1,0 +1,641 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import { type ChangeEvent, useEffect, useId, useMemo, useState } from 'react';
+import type { LaunchMethod } from '../types';
+import type {
+  CommandArgumentCatalogPayload,
+  CommandArgumentEntry,
+  LaunchCommandArguments,
+} from '../types/launch-command-arguments';
+import { buildArgumentsById, buildConflictMatrix } from '../utils/command-argument-catalog';
+import { formatCountLabel, joinClasses } from './launch-optimizations/utils';
+import '../styles/launch-pipeline.css';
+
+const MAX_COMMAND_ARGUMENT_TOKEN_LEN = 512;
+
+const COMMAND_ARGUMENT_CATEGORIES = ['graphics', 'compatibility'] as const;
+
+const COMMAND_ARGUMENT_CATEGORY_LABELS: Record<(typeof COMMAND_ARGUMENT_CATEGORIES)[number], string> = {
+  graphics: 'Graphics',
+  compatibility: 'Compatibility',
+};
+
+export interface CommandArgumentsPanelProps {
+  method: LaunchMethod;
+  commandArguments: LaunchCommandArguments;
+  catalog: CommandArgumentCatalogPayload | null;
+  onToggleArgument: (argumentId: string, nextEnabled: boolean) => void;
+  onUpdateCustomArgs: (customArgs: readonly string[]) => void;
+  className?: string;
+}
+
+interface CommandArgumentConflict {
+  argumentId: string;
+  conflictsWith: string;
+}
+
+interface GroupedArguments {
+  category: (typeof COMMAND_ARGUMENT_CATEGORIES)[number];
+  entries: CommandArgumentEntry[];
+}
+
+type CustomArgRow = { id: string; value: string };
+
+function groupArguments(entries: readonly CommandArgumentEntry[]): GroupedArguments[] {
+  return COMMAND_ARGUMENT_CATEGORIES.map((category) => ({
+    category,
+    entries: entries.filter((entry) => entry.category === category),
+  })).filter((group) => group.entries.length > 0);
+}
+
+function findCommandArgumentConflicts(
+  enabledIds: readonly string[],
+  conflictMatrix: Readonly<Record<string, readonly string[]>>
+): CommandArgumentConflict[] {
+  const conflicts: CommandArgumentConflict[] = [];
+  const seen = new Set<string>();
+
+  for (const argumentId of enabledIds) {
+    for (const conflictsWith of conflictMatrix[argumentId] ?? []) {
+      if (!enabledIds.includes(conflictsWith)) {
+        continue;
+      }
+      const key = [argumentId, conflictsWith].sort().join('|');
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      conflicts.push({ argumentId, conflictsWith });
+    }
+  }
+
+  return conflicts;
+}
+
+function getConflictingEnabledIds(
+  argumentId: string,
+  enabledIds: readonly string[],
+  conflictMatrix: Readonly<Record<string, readonly string[]>>
+): string[] {
+  return (conflictMatrix[argumentId] ?? []).filter((id) => enabledIds.includes(id));
+}
+
+function getConflictLabels(
+  entry: CommandArgumentEntry,
+  argumentsById: Record<string, CommandArgumentEntry>,
+  conflictMatrix: Readonly<Record<string, readonly string[]>>
+): string[] {
+  return (conflictMatrix[entry.id] ?? [])
+    .map((conflictId) => argumentsById[conflictId]?.label)
+    .filter((label): label is string => Boolean(label));
+}
+
+function formatConflictLabels(conflictLabels: readonly string[]): string {
+  if (conflictLabels.length <= 1) {
+    return conflictLabels[0] ?? '';
+  }
+  if (conflictLabels.length === 2) {
+    return `${conflictLabels[0]} or ${conflictLabels[1]}`;
+  }
+  return `${conflictLabels.slice(0, -1).join(', ')}, or ${conflictLabels[conflictLabels.length - 1]}`;
+}
+
+function formatConflictSummary(
+  conflict: CommandArgumentConflict,
+  argumentsById: Record<string, CommandArgumentEntry>
+): string {
+  return `${argumentsById[conflict.argumentId]?.label ?? conflict.argumentId} conflicts with ${argumentsById[conflict.conflictsWith]?.label ?? conflict.conflictsWith}.`;
+}
+
+function customArgRowError(value: string): string | null {
+  if (value.length === 0) {
+    return null;
+  }
+  if (value.trim().length === 0) {
+    return 'Custom argument tokens cannot be empty or whitespace-only.';
+  }
+  if ([...value].some((character) => character.charCodeAt(0) < 32 || character.charCodeAt(0) === 127)) {
+    return 'Custom argument tokens cannot contain control characters.';
+  }
+  if (value.length > MAX_COMMAND_ARGUMENT_TOKEN_LEN) {
+    return `Custom argument tokens must be ${MAX_COMMAND_ARGUMENT_TOKEN_LEN} characters or fewer.`;
+  }
+  return null;
+}
+
+function customArgsToRows(customArgs: readonly string[]): CustomArgRow[] {
+  return customArgs.map((value) => ({ id: crypto.randomUUID(), value }));
+}
+
+function rowsToCustomArgs(rows: readonly CustomArgRow[]): string[] {
+  return rows.map((row) => row.value);
+}
+
+function rowsSignature(rows: readonly CustomArgRow[]): string {
+  return JSON.stringify(rows.map((row) => row.value));
+}
+
+interface ArgumentGroupProps {
+  group: GroupedArguments;
+  enabledIds: Set<string>;
+  selectedConflicts: readonly CommandArgumentConflict[];
+  isMethodSupported: boolean;
+  method: LaunchMethod;
+  onToggleArgument: (argumentId: string, nextEnabled: boolean) => void;
+  tooltipIdPrefix: string;
+  tooltipId: string | null;
+  setTooltipId: (argumentId: string | null) => void;
+  sectionTone: 'default' | 'advanced';
+  argumentsById: Record<string, CommandArgumentEntry>;
+  conflictMatrix: Readonly<Record<string, readonly string[]>>;
+}
+
+function ArgumentGroup({
+  group,
+  enabledIds,
+  selectedConflicts,
+  isMethodSupported,
+  method,
+  onToggleArgument,
+  tooltipIdPrefix,
+  tooltipId,
+  setTooltipId,
+  sectionTone,
+  argumentsById,
+  conflictMatrix,
+}: ArgumentGroupProps) {
+  const groupArgumentIds = group.entries.map((entry) => entry.id);
+  const groupConflicts = selectedConflicts.filter(
+    (conflict) => groupArgumentIds.includes(conflict.argumentId) || groupArgumentIds.includes(conflict.conflictsWith)
+  );
+
+  return (
+    <fieldset
+      className={joinClasses(
+        'crosshook-launch-optimizations__group',
+        `crosshook-launch-optimizations__group--${sectionTone}`
+      )}
+    >
+      <legend className="crosshook-launch-optimizations__group-title">
+        {COMMAND_ARGUMENT_CATEGORY_LABELS[group.category]}
+      </legend>
+      {groupConflicts.length > 0 ? (
+        <div className="crosshook-warning-banner crosshook-launch-optimizations__group-warning">
+          {groupConflicts.map((conflict) => formatConflictSummary(conflict, argumentsById)).join(' ')}
+        </div>
+      ) : null}
+      <div className="crosshook-launch-optimizations__option-list">
+        {group.entries.map((entry) => {
+          const isEnabled = enabledIds.has(entry.id);
+          const isTooltipOpen = tooltipId === entry.id;
+          const conflictingIds = getConflictingEnabledIds(
+            entry.id,
+            [...enabledIds].filter((enabledId) => enabledId !== entry.id),
+            conflictMatrix
+          );
+          const blockedByLabels = conflictingIds.map(
+            (conflictingId) => argumentsById[conflictingId]?.label ?? conflictingId
+          );
+          const isBlockedByConflict = !isEnabled && blockedByLabels.length > 0;
+          const isApplicable = entry.applicable_methods.includes(method);
+          const isSupported = isMethodSupported && isApplicable && !isBlockedByConflict;
+          const checkboxId = `${tooltipIdPrefix}-${entry.id}`;
+          const tooltipIdValue = `${tooltipIdPrefix}-${entry.id}-tooltip`;
+          const conflictLabels = getConflictLabels(entry, argumentsById, conflictMatrix);
+          const rowDisabled = !isSupported;
+
+          return (
+            <div
+              key={entry.id}
+              className={joinClasses(
+                'crosshook-launch-optimizations__option',
+                isEnabled && 'crosshook-launch-optimizations__option--enabled',
+                isTooltipOpen && 'crosshook-launch-optimizations__option--tooltip-open',
+                rowDisabled && 'crosshook-launch-optimizations__option--disabled'
+              )}
+            >
+              <div className="crosshook-launch-optimizations__option-body">
+                <input
+                  id={checkboxId}
+                  className="crosshook-launch-optimizations__checkbox"
+                  type="checkbox"
+                  checked={isEnabled}
+                  disabled={rowDisabled}
+                  onChange={(event) => onToggleArgument(entry.id, event.target.checked)}
+                />
+
+                <div className="crosshook-launch-optimizations__option-copy">
+                  <label className="crosshook-launch-optimizations__option-label" htmlFor={checkboxId}>
+                    {entry.label}
+                  </label>
+                  <p className="crosshook-launch-optimizations__option-description">{entry.description}</p>
+                  <div className="crosshook-launch-optimizations__option-meta">
+                    <span
+                      className={joinClasses(
+                        'crosshook-launch-optimizations__option-pill',
+                        entry.advanced && 'crosshook-launch-optimizations__option-pill--advanced',
+                        !entry.advanced && 'crosshook-launch-optimizations__option-pill--recommended'
+                      )}
+                    >
+                      {entry.advanced ? 'Advanced' : 'Recommended'}
+                    </span>
+                    {entry.community ? (
+                      <span className="crosshook-launch-optimizations__option-pill crosshook-launch-optimizations__option-pill--community">
+                        Community
+                      </span>
+                    ) : null}
+                    {entry.tokens.length > 0 ? (
+                      <span className="crosshook-command-arguments__token-pill">{entry.tokens.join(' ')}</span>
+                    ) : null}
+                    {conflictLabels.length > 0 ? (
+                      <span className="crosshook-launch-optimizations__option-pill crosshook-launch-optimizations__option-pill--warning">
+                        Conflicts with {conflictLabels.join(', ')}
+                      </span>
+                    ) : null}
+                    {blockedByLabels.length > 0 ? (
+                      <span className="crosshook-launch-optimizations__option-pill crosshook-launch-optimizations__option-pill--warning">
+                        Blocked by {formatConflictLabels(blockedByLabels)}
+                      </span>
+                    ) : null}
+                    {rowDisabled ? (
+                      <span className="crosshook-launch-optimizations__option-pill crosshook-launch-optimizations__option-pill--disabled">
+                        {isBlockedByConflict
+                          ? 'Resolve conflict first'
+                          : isMethodSupported
+                            ? 'Unavailable'
+                            : 'Not for this method'}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: container-level hover only; interactive child button carries full a11y */}
+              <div
+                className="crosshook-launch-optimizations__info-anchor"
+                onMouseEnter={() => setTooltipId(entry.id)}
+                onMouseLeave={() => setTooltipId(null)}
+              >
+                <button
+                  type="button"
+                  className="crosshook-launch-optimizations__info-button"
+                  aria-label={`More information about ${entry.label}`}
+                  aria-expanded={isTooltipOpen}
+                  aria-describedby={isTooltipOpen ? tooltipIdValue : undefined}
+                  onFocus={() => setTooltipId(entry.id)}
+                  onBlur={() => setTooltipId(null)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      setTooltipId(null);
+                    }
+                  }}
+                >
+                  i
+                </button>
+
+                <div
+                  id={tooltipIdValue}
+                  role="tooltip"
+                  aria-hidden={!isTooltipOpen}
+                  className={joinClasses(
+                    'crosshook-launch-optimizations__tooltip',
+                    isTooltipOpen && 'crosshook-launch-optimizations__tooltip--open'
+                  )}
+                >
+                  <p className="crosshook-launch-optimizations__tooltip-title">{entry.label}</p>
+                  <p className="crosshook-launch-optimizations__tooltip-kicker">What it does</p>
+                  <p className="crosshook-launch-optimizations__tooltip-copy">{entry.description}</p>
+                  <p className="crosshook-launch-optimizations__tooltip-kicker">When it helps</p>
+                  <p className="crosshook-launch-optimizations__tooltip-copy">{entry.help_text}</p>
+                  <p className="crosshook-launch-optimizations__tooltip-kicker">Argv tokens</p>
+                  <p className="crosshook-launch-optimizations__tooltip-copy">
+                    {entry.tokens.length > 0 ? entry.tokens.join(' ') : 'No fixed tokens'}
+                  </p>
+                  {blockedByLabels.length > 0 ? (
+                    <p className="crosshook-launch-optimizations__tooltip-copy">
+                      Selection is currently blocked by {formatConflictLabels(blockedByLabels)}.
+                    </p>
+                  ) : null}
+                  {conflictLabels.length > 0 ? (
+                    <p className="crosshook-launch-optimizations__tooltip-copy">
+                      Conflict note: {conflictLabels.join(', ')} should not be enabled together with this argument.
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+export function CommandArgumentsPanel({
+  method,
+  commandArguments,
+  catalog,
+  onToggleArgument,
+  onUpdateCustomArgs,
+  className,
+}: CommandArgumentsPanelProps) {
+  const titleId = useId();
+  const customArgsHelpId = useId();
+  const tooltipIdPrefix = useId();
+  const [tooltipId, setTooltipId] = useState<string | null>(null);
+  const [argumentSection, setArgumentSection] = useState<'recommended' | 'advanced'>('recommended');
+  const [customRows, setCustomRows] = useState<CustomArgRow[]>(() => customArgsToRows(commandArguments.custom_args));
+
+  const customArgsSignature = useMemo(
+    () => JSON.stringify(commandArguments.custom_args),
+    [commandArguments.custom_args]
+  );
+
+  useEffect(() => {
+    setCustomRows((currentRows) => {
+      if (rowsSignature(currentRows) === customArgsSignature) {
+        return currentRows;
+      }
+      return customArgsToRows(commandArguments.custom_args);
+    });
+  }, [customArgsSignature, commandArguments.custom_args]);
+
+  const isMethodSupported = method === 'proton_run' || method === 'steam_applaunch';
+
+  const argumentsById = useMemo(() => (catalog ? buildArgumentsById(catalog.entries) : {}), [catalog]);
+  const conflictMatrix = useMemo(() => (catalog ? buildConflictMatrix(catalog.entries) : {}), [catalog]);
+
+  if (!catalog) {
+    return <div className="crosshook-command-arguments">Loading command arguments...</div>;
+  }
+
+  const seen = new Set<string>();
+  const selectedArgumentIds = commandArguments.enabled_argument_ids.filter((argumentId) => {
+    if (!argumentsById[argumentId] || seen.has(argumentId)) {
+      return false;
+    }
+    seen.add(argumentId);
+    return true;
+  });
+  const enabledIdSet = new Set(selectedArgumentIds);
+  const selectedEntries = selectedArgumentIds.map((argumentId) => argumentsById[argumentId]);
+  const selectedConflicts = findCommandArgumentConflicts(selectedArgumentIds, conflictMatrix);
+  const commonEntries = catalog.entries.filter((entry) => !entry.advanced);
+  const advancedEntries = catalog.entries.filter((entry) => entry.advanced);
+  const commonGroups = groupArguments(commonEntries);
+  const advancedGroups = groupArguments(advancedEntries);
+  const enabledAdvancedCount = selectedEntries.filter((entry) => entry.advanced).length;
+  const rootClassName = joinClasses('crosshook-command-arguments', className);
+
+  const applyCustomRows = (nextRows: CustomArgRow[]) => {
+    setCustomRows(nextRows);
+    const hasErrors = nextRows.some((row) => customArgRowError(row.value) !== null);
+    if (hasErrors) {
+      return;
+    }
+    onUpdateCustomArgs(rowsToCustomArgs(nextRows));
+  };
+
+  const moveCustomRow = (rowId: string, direction: -1 | 1) => {
+    const index = customRows.findIndex((row) => row.id === rowId);
+    if (index < 0) {
+      return;
+    }
+    const targetIndex = index + direction;
+    if (targetIndex < 0 || targetIndex >= customRows.length) {
+      return;
+    }
+    const nextRows = [...customRows];
+    const [row] = nextRows.splice(index, 1);
+    nextRows.splice(targetIndex, 0, row);
+    applyCustomRows(nextRows);
+  };
+
+  return (
+    <section className={rootClassName} aria-labelledby={titleId} data-method={method}>
+      <div className="crosshook-command-arguments__header">
+        <div className="crosshook-command-arguments__heading">
+          <h2 id={titleId} className="crosshook-command-arguments__title">
+            Command Arguments
+          </h2>
+          <p className="crosshook-help-text crosshook-command-arguments__intro">
+            Curated game argv switches and ordered custom tokens appended after the executable for Proton and Steam
+            launch options.
+          </p>
+        </div>
+
+        <div className="crosshook-command-arguments__summary-row">
+          <span className="crosshook-launch-optimizations__summary-chip">
+            {formatCountLabel(selectedEntries.length, 'enabled argument', 'enabled arguments')}
+          </span>
+          <span className="crosshook-launch-optimizations__summary-chip">
+            {formatCountLabel(
+              customRows.filter((row) => row.value.trim().length > 0).length,
+              'custom token',
+              'custom tokens'
+            )}
+          </span>
+        </div>
+      </div>
+
+      {!isMethodSupported ? (
+        <div className="crosshook-warning-banner crosshook-command-arguments__method-warning">
+          Command arguments are only editable when the profile method is <code>proton_run</code> or{' '}
+          <code>steam_applaunch</code>.
+        </div>
+      ) : null}
+
+      <div className="crosshook-command-arguments__sections">
+        <Tabs.Root
+          value={argumentSection}
+          onValueChange={(value) => setArgumentSection(value as 'recommended' | 'advanced')}
+          className="crosshook-launch-optimizations__section-tabs"
+        >
+          <Tabs.List
+            className="crosshook-launch-optimizations__section-tab-list"
+            aria-label="Command argument detail level"
+          >
+            <Tabs.Trigger value="recommended" className="crosshook-launch-optimizations__section-tab-trigger">
+              Recommended
+            </Tabs.Trigger>
+            <Tabs.Trigger value="advanced" className="crosshook-launch-optimizations__section-tab-trigger">
+              <span className="crosshook-launch-optimizations__section-tab-trigger-inner">
+                <span>Advanced</span>
+                <span className="crosshook-launch-optimizations__section-tab-meta">
+                  {formatCountLabel(advancedEntries.length, 'argument', 'arguments')}
+                  {enabledAdvancedCount > 0 ? (
+                    <span className="crosshook-launch-optimizations__section-tab-meta-badge">
+                      {enabledAdvancedCount} on
+                    </span>
+                  ) : null}
+                </span>
+              </span>
+            </Tabs.Trigger>
+          </Tabs.List>
+
+          <div className="crosshook-launch-optimizations__section-tab-panels">
+            <Tabs.Content value="recommended" className="crosshook-launch-optimizations__section-tab-panel">
+              <p className="crosshook-launch-optimizations__section-copy">
+                Common renderer and launcher switches with conservative defaults.
+              </p>
+              <div className="crosshook-launch-optimizations__group-list">
+                {commonGroups.map((group) => (
+                  <ArgumentGroup
+                    key={group.category}
+                    group={group}
+                    enabledIds={enabledIdSet}
+                    selectedConflicts={selectedConflicts}
+                    isMethodSupported={isMethodSupported}
+                    method={method}
+                    onToggleArgument={onToggleArgument}
+                    tooltipIdPrefix={tooltipIdPrefix}
+                    tooltipId={tooltipId}
+                    setTooltipId={setTooltipId}
+                    sectionTone="default"
+                    argumentsById={argumentsById}
+                    conflictMatrix={conflictMatrix}
+                  />
+                ))}
+              </div>
+            </Tabs.Content>
+
+            <Tabs.Content
+              value="advanced"
+              className={joinClasses(
+                'crosshook-launch-optimizations__section-tab-panel',
+                'crosshook-launch-optimizations__section-tab-panel--advanced'
+              )}
+            >
+              <p className="crosshook-help-text crosshook-launch-optimizations__advanced-copy">
+                Less common switches that may help specific titles but are not safe defaults for every game.
+              </p>
+              <div className="crosshook-launch-optimizations__group-list">
+                {advancedGroups.map((group) => (
+                  <ArgumentGroup
+                    key={group.category}
+                    group={group}
+                    enabledIds={enabledIdSet}
+                    selectedConflicts={selectedConflicts}
+                    isMethodSupported={isMethodSupported}
+                    method={method}
+                    onToggleArgument={onToggleArgument}
+                    tooltipIdPrefix={tooltipIdPrefix}
+                    tooltipId={tooltipId}
+                    setTooltipId={setTooltipId}
+                    sectionTone="advanced"
+                    argumentsById={argumentsById}
+                    conflictMatrix={conflictMatrix}
+                  />
+                ))}
+              </div>
+            </Tabs.Content>
+          </div>
+        </Tabs.Root>
+      </div>
+
+      <div className="crosshook-command-arguments__custom">
+        <div className="crosshook-command-arguments__custom-header">
+          <h3 className="crosshook-command-arguments__custom-title">Custom tokens</h3>
+          <p className="crosshook-help-text" id={customArgsHelpId}>
+            Ordered argv tokens appended after curated arguments. Use one token per row; paths with spaces stay in a
+            single row.
+          </p>
+        </div>
+
+        {customRows.length === 0 ? (
+          <p className="crosshook-help-text">No custom tokens configured for this profile.</p>
+        ) : null}
+
+        <div className="crosshook-command-arguments__custom-rows">
+          {customRows.map((row, index) => {
+            const rowErr = customArgRowError(row.value);
+            const rowErrorId = `${tooltipIdPrefix}-custom-arg-err-${row.id}`;
+            const inputId = `${tooltipIdPrefix}-custom-arg-${row.id}`;
+            const canMoveUp = index > 0;
+            const canMoveDown = index < customRows.length - 1;
+
+            return (
+              <div key={row.id} className="crosshook-command-arguments__custom-row">
+                <div className="crosshook-command-arguments__custom-row-main">
+                  <span className="crosshook-command-arguments__custom-row-index" aria-hidden="true">
+                    {index + 1}
+                  </span>
+                  <div className="crosshook-field crosshook-command-arguments__custom-field">
+                    <label className="crosshook-label" htmlFor={inputId}>
+                      Token
+                    </label>
+                    <input
+                      id={inputId}
+                      className="crosshook-input"
+                      value={row.value}
+                      placeholder="-nolauncher"
+                      disabled={!isMethodSupported}
+                      aria-invalid={Boolean(rowErr)}
+                      aria-describedby={
+                        [rowErr ? rowErrorId : null, customArgsHelpId].filter(Boolean).join(' ') || undefined
+                      }
+                      onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                        const nextValue = event.target.value;
+                        applyCustomRows(
+                          customRows.map((current) =>
+                            current.id === row.id ? { ...current, value: nextValue } : current
+                          )
+                        );
+                      }}
+                    />
+                  </div>
+                  <div className="crosshook-command-arguments__custom-row-actions">
+                    <button
+                      type="button"
+                      className="crosshook-button crosshook-button--secondary crosshook-button--small"
+                      aria-label={`Move custom token ${index + 1} up`}
+                      disabled={!isMethodSupported || !canMoveUp}
+                      onClick={() => moveCustomRow(row.id, -1)}
+                    >
+                      Up
+                    </button>
+                    <button
+                      type="button"
+                      className="crosshook-button crosshook-button--secondary crosshook-button--small"
+                      aria-label={`Move custom token ${index + 1} down`}
+                      disabled={!isMethodSupported || !canMoveDown}
+                      onClick={() => moveCustomRow(row.id, 1)}
+                    >
+                      Down
+                    </button>
+                    <button
+                      type="button"
+                      className="crosshook-button crosshook-button--secondary crosshook-button--small"
+                      aria-label={`Remove custom token ${index + 1}`}
+                      disabled={!isMethodSupported}
+                      onClick={() => {
+                        applyCustomRows(customRows.filter((current) => current.id !== row.id));
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+                {rowErr ? (
+                  <p id={rowErrorId} className="crosshook-danger" role="alert">
+                    {rowErr}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          className="crosshook-button crosshook-button--secondary crosshook-command-arguments__custom-add"
+          disabled={!isMethodSupported}
+          onClick={() => applyCustomRows([...customRows, { id: crypto.randomUUID(), value: '' }])}
+        >
+          Add token
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default CommandArgumentsPanel;

--- a/src/crosshook-native/src/components/LaunchSubTabs.tsx
+++ b/src/crosshook-native/src/components/LaunchSubTabs.tsx
@@ -3,6 +3,7 @@ import { type CSSProperties, useEffect, useRef, useState } from 'react';
 import { useLaunchStateContext } from '../context/LaunchStateContext';
 import { useGameCoverArt } from '../hooks/useGameCoverArt';
 import { useImageDominantColor } from '../hooks/useImageDominantColor';
+import { CommandArgumentsTabContent } from './launch-subtabs/CommandArgumentsTabContent';
 import { EnvironmentTabContent } from './launch-subtabs/EnvironmentTabContent';
 import { GamescopeTabContent } from './launch-subtabs/GamescopeTabContent';
 import { MangoHudTabContent } from './launch-subtabs/MangoHudTabContent';
@@ -39,6 +40,10 @@ export function LaunchSubTabs({
   optimizationPresetActionBusy,
   onSaveManualPreset,
   catalog,
+  commandArguments,
+  onToggleCommandArgument,
+  onUpdateCommandArgumentsCustomArgs,
+  commandArgumentCatalog,
   customEnvVars,
   profileName,
   onUpdateProfile,
@@ -57,9 +62,16 @@ export function LaunchSubTabs({
   onDismissSuggestion,
   gamescopeAutoSaveStatus,
   mangoHudAutoSaveStatus,
+  commandArgumentsAutoSaveStatus,
 }: LaunchSubTabsProps) {
-  const { tabs, showsGamescopeTab, showsMangoHudTab, showsOptimizationsTab, showsSteamOptionsTab } =
-    useTabVisibility(launchMethod);
+  const {
+    tabs,
+    showsGamescopeTab,
+    showsMangoHudTab,
+    showsOptimizationsTab,
+    showsCommandArgumentsTab,
+    showsSteamOptionsTab,
+  } = useTabVisibility(launchMethod);
 
   const [activeTab, setActiveTab] = useState(tabs[0] ?? 'environment');
   const autoSwitchedRef = useRef(false);
@@ -70,6 +82,7 @@ export function LaunchSubTabs({
     launchOptimizationsStatus,
     gamescopeAutoSaveStatus,
     mangoHudAutoSaveStatus,
+    commandArgumentsAutoSaveStatus,
   });
 
   useEffect(() => {
@@ -213,11 +226,24 @@ export function LaunchSubTabs({
             />
           ) : null}
 
+          {showsCommandArgumentsTab ? (
+            <CommandArgumentsTabContent
+              activeTab={activeTab}
+              launchMethod={launchMethod}
+              commandArguments={commandArguments}
+              onToggleCommandArgument={onToggleCommandArgument}
+              onUpdateCommandArgumentsCustomArgs={onUpdateCommandArgumentsCustomArgs}
+              commandArgumentCatalog={commandArgumentCatalog}
+              chipSlot={activeTab === 'command-arguments' ? autoSaveChipSlot : null}
+            />
+          ) : null}
+
           {showsSteamOptionsTab ? (
             <SteamOptionsTabContent
               activeTab={activeTab}
               enabledOptionIds={enabledOptionIds}
               customEnvVars={customEnvVars}
+              commandArguments={commandArguments}
               gamescopeConfig={gamescopeConfig}
               chipSlot={activeTab === 'steam-options' ? autoSaveChipSlot : null}
             />

--- a/src/crosshook-native/src/components/SteamLaunchOptionsPanel.tsx
+++ b/src/crosshook-native/src/components/SteamLaunchOptionsPanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useId, useMemo, useState } from 'react';
 import { callCommand } from '@/lib/ipc';
 import { useCapabilityGate } from '../hooks/useCapabilityGate';
+import type { LaunchCommandArguments } from '../types/launch-command-arguments';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '../types/launch-command-arguments';
 import type { LaunchOptimizationId } from '../types/launch-optimizations';
 import type { GamescopeConfig } from '../types/profile';
 import { copyToClipboard } from '../utils/clipboard';
@@ -9,6 +11,8 @@ export interface SteamLaunchOptionsPanelProps {
   enabledOptionIds: readonly LaunchOptimizationId[];
   /** Profile `launch.custom_env_vars` — merged into the Steam launch options prefix after optimizations. */
   customEnvVars?: Readonly<Record<string, string>>;
+  /** Profile `launch.command_arguments` — appended after `%command%` in the generated line. */
+  commandArguments?: LaunchCommandArguments;
   /** When provided and enabled, gamescope wrapping is included in the generated command. */
   gamescopeConfig?: GamescopeConfig;
   className?: string;
@@ -17,6 +21,7 @@ export interface SteamLaunchOptionsPanelProps {
 export function SteamLaunchOptionsPanel({
   enabledOptionIds,
   customEnvVars,
+  commandArguments = DEFAULT_LAUNCH_COMMAND_ARGUMENTS,
   gamescopeConfig,
   className,
 }: SteamLaunchOptionsPanelProps) {
@@ -45,6 +50,14 @@ export function SteamLaunchOptionsPanel({
     return { ...gamescopeConfig };
   }, [gamescopeConfig]);
 
+  const _serializedCommandArguments = JSON.stringify(commandArguments);
+  const stableCommandArguments = useMemo<LaunchCommandArguments>(() => {
+    return {
+      enabled_argument_ids: [...commandArguments.enabled_argument_ids],
+      custom_args: [...commandArguments.custom_args],
+    };
+  }, [commandArguments]);
+
   useEffect(() => {
     let cancelled = false;
     const ids = [...enabledOptionIds];
@@ -58,6 +71,8 @@ export function SteamLaunchOptionsPanel({
           enabledOptionIds: ids,
           customEnvVars: { ...stableCustomEnv },
           gamescope: stableGamescope,
+          enabledArgumentIds: [...stableCommandArguments.enabled_argument_ids],
+          customCommandArgs: [...stableCommandArguments.custom_args],
         });
         if (!cancelled) {
           setCommand(line);
@@ -78,7 +93,7 @@ export function SteamLaunchOptionsPanel({
     return () => {
       cancelled = true;
     };
-  }, [enabledOptionIds, stableCustomEnv, stableGamescope]);
+  }, [enabledOptionIds, stableCustomEnv, stableGamescope, stableCommandArguments]);
 
   async function handleCopy() {
     if (!command.trim()) {
@@ -117,7 +132,7 @@ export function SteamLaunchOptionsPanel({
         <p className="crosshook-help-text crosshook-steam-launch-options__intro">
           Paste this single line into the game&apos;s <strong>Properties → General → Launch Options</strong> in Steam.
           It matches the same Proton optimization env vars and wrappers as a direct <code>proton_run</code> launch, and
-          must end with <code>%command%</code>.
+          must end with <code>%command%</code>, followed by any configured game argv tokens.
         </p>
       </div>
 

--- a/src/crosshook-native/src/components/__tests__/CommandArgumentsPanel.test.tsx
+++ b/src/crosshook-native/src/components/__tests__/CommandArgumentsPanel.test.tsx
@@ -1,0 +1,222 @@
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommandArgumentsPanel } from '@/components/CommandArgumentsPanel';
+import SteamLaunchOptionsPanel from '@/components/SteamLaunchOptionsPanel';
+import { makeCommandArgumentCatalogPayload } from '@/test/fixtures';
+import { renderWithMocks } from '@/test/render';
+import type { LaunchCommandArguments } from '@/types/launch-command-arguments';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '@/types/launch-command-arguments';
+
+vi.mock('@/lib/ipc', async () => {
+  const { mockCallCommand } = await import('@/test/render');
+  return { callCommand: mockCallCommand };
+});
+
+vi.mock('@/hooks/useCapabilityGate', () => ({
+  useCapabilityGate: () => ({ state: 'available', rationale: '' }),
+}));
+
+const catalog = makeCommandArgumentCatalogPayload();
+
+function renderCommandArgumentsPanel(overrides: Partial<React.ComponentProps<typeof CommandArgumentsPanel>> = {}) {
+  const onToggleArgument = vi.fn();
+  const onUpdateCustomArgs = vi.fn();
+
+  const view = renderWithMocks(
+    <TooltipProvider>
+      <CommandArgumentsPanel
+        method="proton_run"
+        commandArguments={DEFAULT_LAUNCH_COMMAND_ARGUMENTS}
+        catalog={catalog}
+        onToggleArgument={onToggleArgument}
+        onUpdateCustomArgs={onUpdateCustomArgs}
+        {...overrides}
+      />
+    </TooltipProvider>
+  );
+
+  return { ...view, onToggleArgument, onUpdateCustomArgs };
+}
+
+describe('CommandArgumentsPanel', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let uuidCounter = 0;
+
+  beforeEach(() => {
+    uuidCounter = 0;
+    vi.stubGlobal('crypto', {
+      randomUUID: () => `test-uuid-${++uuidCounter}`,
+    });
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('shows loading state when catalog is null', () => {
+    renderCommandArgumentsPanel({ catalog: null });
+    expect(screen.getByText('Loading command arguments...')).toBeInTheDocument();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders curated argument toggles for supported methods', () => {
+    renderCommandArgumentsPanel();
+    expect(screen.getByRole('heading', { name: 'Command Arguments' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Force Vulkan renderer')).toBeInTheDocument();
+    expect(screen.getByLabelText('Skip in-game launcher')).toBeInTheDocument();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows method warning for native launch method', () => {
+    renderCommandArgumentsPanel({ method: 'native' });
+    expect(screen.getByText(/Command arguments are only editable when the profile method is/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Force Vulkan renderer')).toBeDisabled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls onToggleArgument when a curated argument is toggled', async () => {
+    const user = userEvent.setup();
+    const { onToggleArgument } = renderCommandArgumentsPanel();
+
+    await user.click(screen.getByLabelText('Force Vulkan renderer'));
+    expect(onToggleArgument).toHaveBeenCalledWith('force_vulkan', true);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('adds, edits, and removes custom tokens in order', async () => {
+    const user = userEvent.setup();
+    const { onUpdateCustomArgs } = renderCommandArgumentsPanel({
+      commandArguments: {
+        enabled_argument_ids: [],
+        custom_args: ['--first'],
+      },
+    });
+
+    const tokenInput = screen.getByLabelText('Token');
+    expect(tokenInput).toHaveValue('--first');
+
+    await user.click(screen.getByRole('button', { name: 'Add token' }));
+    expect(onUpdateCustomArgs).toHaveBeenLastCalledWith(['--first', '']);
+
+    await user.clear(tokenInput);
+    await user.type(tokenInput, '--updated');
+    expect(onUpdateCustomArgs).toHaveBeenLastCalledWith(['--updated', '']);
+
+    await user.click(screen.getByRole('button', { name: 'Remove custom token 1' }));
+    expect(onUpdateCustomArgs).toHaveBeenLastCalledWith(['']);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('moves custom tokens up and down', async () => {
+    const user = userEvent.setup();
+    const { onUpdateCustomArgs } = renderCommandArgumentsPanel({
+      commandArguments: {
+        enabled_argument_ids: [],
+        custom_args: ['--alpha', '--beta'],
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Move custom token 2 up' }));
+    expect(onUpdateCustomArgs).toHaveBeenLastCalledWith(['--beta', '--alpha']);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not autosave blank custom token rows with validation errors', async () => {
+    const user = userEvent.setup();
+    const { onUpdateCustomArgs } = renderCommandArgumentsPanel({
+      commandArguments: {
+        enabled_argument_ids: [],
+        custom_args: ['valid'],
+      },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Add token' }));
+    const callsBeforeBlankEdit = onUpdateCustomArgs.mock.calls.length;
+
+    const tokenInputs = screen.getAllByLabelText('Token');
+    await user.type(tokenInputs[1], '   ');
+    expect(onUpdateCustomArgs.mock.calls.length).toBe(callsBeforeBlankEdit);
+    expect(screen.getByRole('alert')).toHaveTextContent(/cannot be empty or whitespace-only/i);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('SteamLaunchOptionsPanel command arguments', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderSteamPanel(commandArguments: LaunchCommandArguments) {
+    return renderWithMocks(<SteamLaunchOptionsPanel enabledOptionIds={[]} commandArguments={commandArguments} />);
+  }
+
+  function getSteamPreview(): HTMLElement {
+    const preview = document.querySelector('.crosshook-steam-launch-options__preview');
+    if (!(preview instanceof HTMLElement)) {
+      throw new Error('Steam launch options preview element not found');
+    }
+    return preview;
+  }
+
+  it('appends resolved command arguments after %command% in the preview line', async () => {
+    renderSteamPanel({
+      enabled_argument_ids: ['force_vulkan'],
+      custom_args: ['--custom-flag'],
+    });
+
+    await waitFor(() => {
+      expect(getSteamPreview()).toHaveTextContent('%command% -force_vulkan --custom-flag');
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows only the prefix when no command arguments are configured', async () => {
+    renderSteamPanel(DEFAULT_LAUNCH_COMMAND_ARGUMENTS);
+
+    await waitFor(() => {
+      expect(getSteamPreview()).toHaveTextContent('%command%');
+    });
+    expect(getSteamPreview().textContent?.trim()).toBe('%command%');
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the preview when command arguments change', async () => {
+    const { rerender } = renderWithMocks(
+      <SteamLaunchOptionsPanel
+        enabledOptionIds={[]}
+        commandArguments={{ enabled_argument_ids: ['skip_launcher'], custom_args: [] }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getSteamPreview()).toHaveTextContent('-skip_launcher');
+    });
+
+    rerender(
+      <SteamLaunchOptionsPanel
+        enabledOptionIds={[]}
+        commandArguments={{ enabled_argument_ids: [], custom_args: ['+set', 'gfx'] }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(getSteamPreview()).toHaveTextContent('+set gfx');
+    });
+    expect(getSteamPreview()).not.toHaveTextContent('-skip_launcher');
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/crosshook-native/src/components/__tests__/LaunchSubTabs.test.tsx
+++ b/src/crosshook-native/src/components/__tests__/LaunchSubTabs.test.tsx
@@ -11,9 +11,10 @@ import { LaunchStateProvider, useLaunchStateContext } from '@/context/LaunchStat
 import { PreferencesProvider } from '@/context/PreferencesContext';
 import { ProfileProvider, useProfileContext } from '@/context/ProfileContext';
 import { ProfileHealthProvider } from '@/context/ProfileHealthContext';
-import { makeProfileDraft } from '@/test/fixtures';
+import { makeCommandArgumentCatalogPayload, makeProfileDraft } from '@/test/fixtures';
 import { renderWithMocks } from '@/test/render';
 import type { LaunchAutoSaveStatus, LaunchMethod } from '@/types';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '@/types/launch-command-arguments';
 import { DEFAULT_GAMESCOPE_CONFIG, DEFAULT_MANGOHUD_CONFIG } from '@/types/profile';
 
 vi.mock('@/lib/ipc', async () => {
@@ -36,6 +37,10 @@ function makeSubTabsProps(overrides: Partial<LaunchSubTabsProps> = {}): LaunchSu
     onToggleOption: vi.fn(),
     launchOptimizationsStatus: { tone: 'idle', label: '' },
     catalog: null,
+    commandArguments: DEFAULT_LAUNCH_COMMAND_ARGUMENTS,
+    onToggleCommandArgument: vi.fn(),
+    onUpdateCommandArgumentsCustomArgs: vi.fn(),
+    commandArgumentCatalog: makeCommandArgumentCatalogPayload(),
     profileName: 'test-profile',
     onUpdateProfile: vi.fn(),
     showProtonDbLookup: false,
@@ -68,6 +73,7 @@ const baseHandlerOverrides = {
   check_game_running: async () => false,
   check_gamescope_session: async () => false,
   get_optimization_catalog: async () => null,
+  get_command_argument_catalog: async () => makeCommandArgumentCatalogPayload(),
   get_trainer_type_catalog: async () => [],
   get_cached_health_snapshots: async () => [],
   get_cached_offline_readiness_snapshots: async () => [],
@@ -197,6 +203,7 @@ describe('LaunchSubTabs', () => {
     const gamescopeStatus: LaunchAutoSaveStatus = { tone: 'success', label: 'Gamescope saved' };
     const mangohudStatus: LaunchAutoSaveStatus = { tone: 'error', label: 'MangoHud error' };
     const optimizationsStatus = { tone: 'saving' as const, label: 'Saving...' };
+    const commandArgumentsStatus: LaunchAutoSaveStatus = { tone: 'success', label: 'Arguments saved' };
 
     const { container } = renderSubTabs(
       makeSubTabsProps({
@@ -204,6 +211,7 @@ describe('LaunchSubTabs', () => {
         gamescopeAutoSaveStatus: gamescopeStatus,
         mangoHudAutoSaveStatus: mangohudStatus,
         launchOptimizationsStatus: optimizationsStatus,
+        commandArgumentsAutoSaveStatus: commandArgumentsStatus,
       }),
       { handlerOverrides: baseHandlerOverrides }
     );
@@ -213,6 +221,70 @@ describe('LaunchSubTabs', () => {
     await waitFor(() => {
       const chip = container.querySelector('.crosshook-launch-autosave-chip--error');
       expect(chip).toBeInTheDocument();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows the Command Arguments tab for proton_run', async () => {
+    renderSubTabs(makeSubTabsProps({ launchMethod: 'proton_run' }), {
+      handlerOverrides: baseHandlerOverrides,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Command Arguments' })).toBeInTheDocument();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows Command Arguments panel content when the Command Arguments tab is active', async () => {
+    const user = userEvent.setup();
+
+    renderSubTabs(makeSubTabsProps({ launchMethod: 'proton_run' }), {
+      handlerOverrides: baseHandlerOverrides,
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Command Arguments' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Command Arguments' })).toBeInTheDocument();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows the Command Arguments tab for steam_applaunch', async () => {
+    renderSubTabs(makeSubTabsProps({ launchMethod: 'steam_applaunch' }), {
+      handlerOverrides: baseHandlerOverrides,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Command Arguments' })).toBeInTheDocument();
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('threads command arguments into the Steam launch options preview', async () => {
+    const user = userEvent.setup();
+
+    renderSubTabs(
+      makeSubTabsProps({
+        launchMethod: 'steam_applaunch',
+        commandArguments: {
+          enabled_argument_ids: ['force_vulkan'],
+          custom_args: ['--extra'],
+        },
+      }),
+      { handlerOverrides: baseHandlerOverrides }
+    );
+
+    await user.click(screen.getByRole('tab', { name: 'Steam Options' }));
+
+    await waitFor(() => {
+      const preview = document.querySelector('.crosshook-steam-launch-options__preview');
+      expect(preview).toHaveTextContent('%command% -force_vulkan --extra');
     });
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
@@ -230,10 +302,11 @@ describe('LaunchSubTabs', () => {
       expect(screen.getByRole('tab', { name: 'Offline' })).toBeInTheDocument();
     });
 
-    // native: no gamescope, mangohud, optimizations, steam-options
+    // native: no gamescope, mangohud, optimizations, command arguments, steam-options
     expect(screen.queryByRole('tab', { name: 'Gamescope' })).not.toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'MangoHud' })).not.toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Optimizations' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Command Arguments' })).not.toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Steam Options' })).not.toBeInTheDocument();
 
     // Suppress unused warning
@@ -242,7 +315,7 @@ describe('LaunchSubTabs', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  it('(b) tab visibility matrix — proton_run shows gamescope, mangohud, optimizations; not steam-options', async () => {
+  it('(b) tab visibility matrix — proton_run shows gamescope, mangohud, optimizations, command arguments; not steam-options', async () => {
     renderSubTabs(makeSubTabsProps({ launchMethod: 'proton_run' }), {
       handlerOverrides: baseHandlerOverrides,
     });
@@ -251,6 +324,7 @@ describe('LaunchSubTabs', () => {
       expect(screen.getByRole('tab', { name: 'Gamescope' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'MangoHud' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Optimizations' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Command Arguments' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Environment' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Offline' })).toBeInTheDocument();
     });
@@ -260,7 +334,7 @@ describe('LaunchSubTabs', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
-  it('(b) tab visibility matrix — steam_applaunch shows steam-options, gamescope, mangohud, optimizations', async () => {
+  it('(b) tab visibility matrix — steam_applaunch shows steam-options, gamescope, mangohud, optimizations, command arguments', async () => {
     renderSubTabs(makeSubTabsProps({ launchMethod: 'steam_applaunch' }), {
       handlerOverrides: baseHandlerOverrides,
     });
@@ -270,6 +344,7 @@ describe('LaunchSubTabs', () => {
       expect(screen.getByRole('tab', { name: 'Gamescope' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'MangoHud' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Optimizations' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Command Arguments' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Environment' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Offline' })).toBeInTheDocument();
     });
@@ -292,8 +367,10 @@ describe('LaunchSubTabs', () => {
     // Switch to Gamescope tab
     await user.click(screen.getByRole('tab', { name: 'Gamescope' }));
 
-    const allPanels = screen.getAllByRole('tabpanel', { hidden: true });
-    expect(allPanels).toHaveLength(5);
+    const launchTabPanels = screen
+      .getAllByRole('tabpanel', { hidden: true })
+      .filter((panel) => panel.classList.contains('crosshook-subtab-content'));
+    expect(launchTabPanels).toHaveLength(6);
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
@@ -360,7 +437,7 @@ describe('LaunchSubTabs', () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByRole('tablist')).toBeInTheDocument();
+        expect(screen.getByRole('tablist', { name: 'Launch configuration sections' })).toBeInTheDocument();
       });
 
       unmount();

--- a/src/crosshook-native/src/components/community-import/utils.ts
+++ b/src/crosshook-native/src/components/community-import/utils.ts
@@ -91,6 +91,10 @@ export function buildLaunchRequest(profile: GameProfile, steamClientInstallPath:
     optimizations: {
       enabled_option_ids: [...profile.launch.optimizations.enabled_option_ids],
     },
+    command_arguments: {
+      enabled_argument_ids: [...(profile.launch.command_arguments?.enabled_argument_ids ?? [])],
+      custom_args: [...(profile.launch.command_arguments?.custom_args ?? [])],
+    },
     launch_game_only: false,
     launch_trainer_only: false,
     custom_env_vars: { ...profile.launch.custom_env_vars },

--- a/src/crosshook-native/src/components/config-history/helpers.ts
+++ b/src/crosshook-native/src/components/config-history/helpers.ts
@@ -6,6 +6,7 @@ export const SOURCE_LABELS: Record<ConfigRevisionSource, string> = {
   rollback_apply: 'Restore',
   import: 'Import',
   launch_optimization_save: 'Optimization save',
+  launch_command_arguments_save: 'Command arguments save',
   preset_apply: 'Preset applied',
   migration: 'Migration',
 };

--- a/src/crosshook-native/src/components/launch-subtabs/CommandArgumentsTabContent.tsx
+++ b/src/crosshook-native/src/components/launch-subtabs/CommandArgumentsTabContent.tsx
@@ -1,0 +1,62 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import type { ReactNode } from 'react';
+import type { LaunchMethod } from '../../types';
+import type { CommandArgumentCatalogPayload, LaunchCommandArguments } from '../../types/launch-command-arguments';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '../../types/launch-command-arguments';
+import CommandArgumentsPanel from '../CommandArgumentsPanel';
+import { DashboardPanelSection } from '../layout/DashboardPanelSection';
+import type { LaunchSubTabId } from './types';
+
+interface CommandArgumentsTabContentProps {
+  activeTab: LaunchSubTabId;
+  launchMethod: LaunchMethod;
+  commandArguments?: LaunchCommandArguments;
+  onToggleCommandArgument?: (argumentId: string, nextEnabled: boolean) => void;
+  onUpdateCommandArgumentsCustomArgs?: (customArgs: readonly string[]) => void;
+  commandArgumentCatalog?: CommandArgumentCatalogPayload | null;
+  /** Autosave chip — rendered in panel header actions when this tab is active. */
+  chipSlot?: ReactNode;
+}
+
+export function CommandArgumentsTabContent({
+  activeTab,
+  launchMethod,
+  commandArguments = DEFAULT_LAUNCH_COMMAND_ARGUMENTS,
+  onToggleCommandArgument,
+  onUpdateCommandArgumentsCustomArgs,
+  commandArgumentCatalog = null,
+  chipSlot,
+}: CommandArgumentsTabContentProps) {
+  const showCommandArguments =
+    onToggleCommandArgument !== undefined && onUpdateCommandArgumentsCustomArgs !== undefined;
+
+  if (!showCommandArguments) {
+    return null;
+  }
+
+  return (
+    <Tabs.Content
+      value="command-arguments"
+      forceMount
+      className="crosshook-subtab-content"
+      style={{ display: activeTab === 'command-arguments' ? undefined : 'none' }}
+    >
+      <div className="crosshook-subtab-content__inner">
+        <DashboardPanelSection
+          eyebrow="Command Arguments"
+          title="Launch Command Arguments"
+          titleAs="h3"
+          actions={chipSlot}
+        >
+          <CommandArgumentsPanel
+            method={launchMethod}
+            commandArguments={commandArguments}
+            catalog={commandArgumentCatalog}
+            onToggleArgument={onToggleCommandArgument}
+            onUpdateCustomArgs={onUpdateCommandArgumentsCustomArgs}
+          />
+        </DashboardPanelSection>
+      </div>
+    </Tabs.Content>
+  );
+}

--- a/src/crosshook-native/src/components/launch-subtabs/SteamOptionsTabContent.tsx
+++ b/src/crosshook-native/src/components/launch-subtabs/SteamOptionsTabContent.tsx
@@ -1,5 +1,7 @@
 import * as Tabs from '@radix-ui/react-tabs';
 import type { ReactNode } from 'react';
+import type { LaunchCommandArguments } from '../../types/launch-command-arguments';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '../../types/launch-command-arguments';
 import type { LaunchOptimizationId } from '../../types/launch-optimizations';
 import type { GamescopeConfig } from '../../types/profile';
 import { DashboardPanelSection } from '../layout/DashboardPanelSection';
@@ -10,6 +12,7 @@ interface SteamOptionsTabContentProps {
   activeTab: LaunchSubTabId;
   enabledOptionIds: readonly LaunchOptimizationId[];
   customEnvVars?: Readonly<Record<string, string>>;
+  commandArguments?: LaunchCommandArguments;
   gamescopeConfig: GamescopeConfig;
   /** Autosave chip — rendered in panel header actions when this tab is active. */
   chipSlot?: ReactNode;
@@ -19,6 +22,7 @@ export function SteamOptionsTabContent({
   activeTab,
   enabledOptionIds,
   customEnvVars,
+  commandArguments = DEFAULT_LAUNCH_COMMAND_ARGUMENTS,
   gamescopeConfig,
   chipSlot,
 }: SteamOptionsTabContentProps) {
@@ -34,6 +38,7 @@ export function SteamOptionsTabContent({
           <SteamLaunchOptionsPanel
             enabledOptionIds={enabledOptionIds}
             customEnvVars={customEnvVars}
+            commandArguments={commandArguments}
             gamescopeConfig={gamescopeConfig}
           />
         </DashboardPanelSection>

--- a/src/crosshook-native/src/components/launch-subtabs/types.ts
+++ b/src/crosshook-native/src/components/launch-subtabs/types.ts
@@ -1,4 +1,5 @@
 import type { BundledOptimizationPreset, LaunchAutoSaveStatus, LaunchMethod } from '../../types';
+import type { CommandArgumentCatalogPayload, LaunchCommandArguments } from '../../types/launch-command-arguments';
 import type { LaunchOptimizationId } from '../../types/launch-optimizations';
 import type { GameProfile, GamescopeConfig, MangoHudConfig } from '../../types/profile';
 import type { AcceptSuggestionRequest, ProtonDbRecommendationGroup, ProtonDbSuggestionSet } from '../../types/protondb';
@@ -6,7 +7,14 @@ import type { OptimizationCatalogPayload } from '../../utils/optimization-catalo
 import type { PendingProtonDbOverwrite } from '../../utils/protondb';
 import type { LaunchOptimizationsPanelStatus } from '../LaunchOptimizationsPanel';
 
-export type LaunchSubTabId = 'offline' | 'environment' | 'gamescope' | 'mangohud' | 'optimizations' | 'steam-options';
+export type LaunchSubTabId =
+  | 'offline'
+  | 'environment'
+  | 'gamescope'
+  | 'mangohud'
+  | 'optimizations'
+  | 'command-arguments'
+  | 'steam-options';
 
 export const TAB_LABELS: Record<LaunchSubTabId, string> = {
   offline: 'Offline',
@@ -14,6 +22,7 @@ export const TAB_LABELS: Record<LaunchSubTabId, string> = {
   gamescope: 'Gamescope',
   mangohud: 'MangoHud',
   optimizations: 'Optimizations',
+  'command-arguments': 'Command Arguments',
   'steam-options': 'Steam Options',
 };
 
@@ -47,6 +56,13 @@ export interface LaunchSubTabsProps {
   optimizationPresetActionBusy?: boolean;
   onSaveManualPreset?: (presetName: string) => Promise<void>;
   catalog: OptimizationCatalogPayload | null;
+
+  // Command Arguments panel (Task 5.2 UI; state wired in Task 5.1)
+  commandArguments?: LaunchCommandArguments;
+  onToggleCommandArgument?: (argumentId: string, nextEnabled: boolean) => void;
+  onUpdateCommandArgumentsCustomArgs?: (customArgs: readonly string[]) => void;
+  commandArgumentCatalog?: CommandArgumentCatalogPayload | null;
+  commandArgumentsAutoSaveStatus?: LaunchAutoSaveStatus;
 
   // Steam Launch Options panel
   customEnvVars?: Readonly<Record<string, string>>;

--- a/src/crosshook-native/src/components/launch-subtabs/useAutoSaveChip.ts
+++ b/src/crosshook-native/src/components/launch-subtabs/useAutoSaveChip.ts
@@ -8,6 +8,7 @@ interface UseAutoSaveChipOptions {
   launchOptimizationsStatus?: LaunchOptimizationsPanelStatus;
   gamescopeAutoSaveStatus?: LaunchAutoSaveStatus;
   mangoHudAutoSaveStatus?: LaunchAutoSaveStatus;
+  commandArgumentsAutoSaveStatus?: LaunchAutoSaveStatus;
 }
 
 interface UseAutoSaveChipResult {
@@ -19,11 +20,13 @@ export function useAutoSaveChip({
   launchOptimizationsStatus,
   gamescopeAutoSaveStatus,
   mangoHudAutoSaveStatus,
+  commandArgumentsAutoSaveStatus,
 }: UseAutoSaveChipOptions): UseAutoSaveChipResult {
   const allStatuses: LaunchAutoSaveStatus[] = [
     launchOptimizationsStatus ?? { tone: 'idle', label: '' },
     gamescopeAutoSaveStatus ?? { tone: 'idle', label: '' },
     mangoHudAutoSaveStatus ?? { tone: 'idle', label: '' },
+    commandArgumentsAutoSaveStatus ?? { tone: 'idle', label: '' },
   ];
   const combinedAutoSaveStatus = allStatuses.reduce<LaunchAutoSaveStatus>(
     (best, s) => ((TONE_PRIORITY[s.tone] ?? 0) > (TONE_PRIORITY[best.tone] ?? 0) ? s : best),

--- a/src/crosshook-native/src/components/launch-subtabs/useTabVisibility.ts
+++ b/src/crosshook-native/src/components/launch-subtabs/useTabVisibility.ts
@@ -7,6 +7,7 @@ interface UseTabVisibilityResult {
   showsGamescopeTab: boolean;
   showsMangoHudTab: boolean;
   showsOptimizationsTab: boolean;
+  showsCommandArgumentsTab: boolean;
   showsSteamOptionsTab: boolean;
 }
 
@@ -22,12 +23,14 @@ export function useTabVisibility(launchMethod: LaunchMethod): UseTabVisibilityRe
   const showsGamescopeTab = launchMethod === 'proton_run' || launchMethod === 'steam_applaunch';
   const showsMangoHudTab = launchMethodSupportsOptimizations;
   const showsOptimizationsTab = launchMethodSupportsOptimizations;
+  const showsCommandArgumentsTab = launchMethod === 'proton_run' || launchMethod === 'steam_applaunch';
   const showsSteamOptionsTab = launchMethod === 'steam_applaunch';
 
   const tabs: LaunchSubTabId[] = isNative
     ? ['environment', 'offline']
     : [
         ...(showsOptimizationsTab ? ['optimizations' as const] : []),
+        ...(showsCommandArgumentsTab ? ['command-arguments' as const] : []),
         'environment',
         ...(showsMangoHudTab ? ['mangohud' as const] : []),
         ...(showsGamescopeTab ? ['gamescope' as const] : []),
@@ -35,5 +38,12 @@ export function useTabVisibility(launchMethod: LaunchMethod): UseTabVisibilityRe
         'offline',
       ];
 
-  return { tabs, showsGamescopeTab, showsMangoHudTab, showsOptimizationsTab, showsSteamOptionsTab };
+  return {
+    tabs,
+    showsGamescopeTab,
+    showsMangoHudTab,
+    showsOptimizationsTab,
+    showsCommandArgumentsTab,
+    showsSteamOptionsTab,
+  };
 }

--- a/src/crosshook-native/src/components/library/__tests__/HeroLaunchCommandSection.test.tsx
+++ b/src/crosshook-native/src/components/library/__tests__/HeroLaunchCommandSection.test.tsx
@@ -135,6 +135,19 @@ describe('HeroLaunchCommandSection', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
+  it('renders effective_command with appended game argv tokens when command arguments are present', () => {
+    renderCommandSection({
+      preview: makeLaunchPreview({
+        effective_command:
+          'gamescope -- /compat/proton run /games/synthetic-quest/game.exe -force_vulkan --custom-flag',
+      }),
+    });
+    expect(screen.getByTestId('command-block')).toHaveTextContent(
+      'gamescope -- /compat/proton run /games/synthetic-quest/game.exe -force_vulkan --custom-flag'
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
   it('shows "no preview" message when launchRequest is null', () => {
     renderCommandSection({ launchRequest: null, preview: null });
     expect(

--- a/src/crosshook-native/src/hooks/launch/useLaunchSubTabsProps.ts
+++ b/src/crosshook-native/src/hooks/launch/useLaunchSubTabsProps.ts
@@ -5,6 +5,7 @@ import { useProfileHealthContext } from '../../context/ProfileHealthContext';
 import { DEFAULT_GAMESCOPE_CONFIG, DEFAULT_MANGOHUD_CONFIG } from '../../types/profile';
 import { useLaunchEnvironmentAutosave } from '../profile/useLaunchEnvironmentAutosave';
 import { useProtonDbApply } from '../profile/useProtonDbApply';
+import { useCommandArgumentCatalog } from '../useCommandArgumentCatalog';
 import { useProtonDbSuggestions } from '../useProtonDbSuggestions';
 
 export interface UseLaunchSubTabsPropsInput {
@@ -65,6 +66,7 @@ export function useLaunchSubTabsProps({
   // ---------------------------------------------------------------------------
 
   const suggestions = useProtonDbSuggestions(resolvedSteamAppId, selectedProfile);
+  const { catalog: commandArgumentCatalog } = useCommandArgumentCatalog();
 
   const handleAcceptSuggestion = useCallback(
     async (request: Parameters<typeof suggestions.acceptSuggestion>[0]): Promise<void> => {
@@ -197,6 +199,12 @@ export function useLaunchSubTabsProps({
     optimizationPresetActionBusy: profileState.optimizationPresetActionBusy,
     onSaveManualPreset: profileState.saveManualOptimizationPreset,
     catalog: profileState.catalog,
+
+    commandArguments: profile.launch.command_arguments,
+    onToggleCommandArgument: profileState.toggleCommandArgument,
+    onUpdateCommandArgumentsCustomArgs: profileState.updateCommandArgumentsCustomArgs,
+    commandArgumentCatalog,
+    commandArgumentsAutoSaveStatus: profileState.commandArgumentsAutoSaveStatus,
 
     customEnvVars: profile.launch.custom_env_vars,
     profileName,

--- a/src/crosshook-native/src/hooks/profile/__tests__/profileNormalize.test.ts
+++ b/src/crosshook-native/src/hooks/profile/__tests__/profileNormalize.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { createDefaultProfile } from '@/types/profile';
+import { createDefaultProfile, normalizeSerializedGameProfile, type SerializedGameProfile } from '@/types/profile';
 import { createEmptyProfile } from '../createEmptyProfile';
-import { normalizeProfileForEdit } from '../profileNormalize';
+import { normalizeProfileForEdit, normalizeProfileForSave } from '../profileNormalize';
 
 describe('profile runtime umu hints', () => {
   it('initializes empty profile helpers with umu hint fields', () => {
@@ -35,5 +35,110 @@ describe('profile runtime umu hints', () => {
 
     expect(normalized.runtime.umu_store).toBe('');
     expect(normalized.runtime.umu_codename).toHaveLength(128);
+  });
+});
+
+describe('profile launch command arguments', () => {
+  it('initializes default profiles with empty command arguments', () => {
+    expect(createDefaultProfile().launch.command_arguments).toEqual({
+      enabled_argument_ids: [],
+      custom_args: [],
+    });
+    expect(normalizeProfileForEdit(createEmptyProfile(), {}, false).launch.command_arguments).toEqual({
+      enabled_argument_ids: [],
+      custom_args: [],
+    });
+  });
+
+  it('normalizes older serialized profiles missing command_arguments', () => {
+    const legacyProfile = {
+      game: { name: 'Legacy Game', executable_path: '/games/legacy/game.exe' },
+      trainer: { path: '', type: '', loading_mode: 'source_directory' as const },
+      injection: {
+        dll_paths: [],
+        inject_on_launch: [],
+        loaded_hooks: [],
+        method: 'disabled' as const,
+        stage: 'trainer_launch' as const,
+        timeout_ms: 0,
+        fallback: 'warn_and_continue' as const,
+      },
+      steam: {
+        enabled: false,
+        app_id: '',
+        compatdata_path: '',
+        proton_path: '',
+        launcher: { icon_path: '', display_name: '' },
+      },
+      launch: {
+        method: 'proton_run' as const,
+        optimizations: { enabled_option_ids: [] },
+        custom_env_vars: {},
+      },
+    } as SerializedGameProfile;
+
+    const normalized = normalizeSerializedGameProfile(legacyProfile);
+
+    expect(normalized.launch.command_arguments).toEqual({
+      enabled_argument_ids: [],
+      custom_args: [],
+    });
+  });
+
+  it('trims curated argument IDs and deduplicates for edit', () => {
+    const profile = createDefaultProfile();
+    profile.launch.command_arguments = {
+      enabled_argument_ids: ['  force_vulkan  ', 'force_vulkan', ''],
+      custom_args: ['  --dx11  '],
+    };
+
+    const normalized = normalizeProfileForEdit(profile, {}, false);
+
+    expect(normalized.launch.command_arguments.enabled_argument_ids).toEqual(['force_vulkan']);
+    expect(normalized.launch.command_arguments.custom_args).toEqual(['--dx11']);
+  });
+
+  it('preserves non-blank custom args with control characters during edit', () => {
+    const profile = createDefaultProfile();
+    profile.launch.command_arguments = {
+      enabled_argument_ids: [],
+      custom_args: ['--bad\x00arg', 'valid-token'],
+    };
+
+    const normalized = normalizeProfileForEdit(profile, {}, false);
+
+    expect(normalized.launch.command_arguments.custom_args).toEqual(['--bad\x00arg', 'valid-token']);
+  });
+
+  it('drops blank custom rows only when normalizing for save', () => {
+    const profile = createDefaultProfile();
+    profile.launch.command_arguments = {
+      enabled_argument_ids: ['  force_vulkan  '],
+      custom_args: ['   ', '--dx11', '\t', '--bad\x00arg'],
+    };
+
+    const forEdit = normalizeProfileForEdit(profile, {}, false);
+    expect(forEdit.launch.command_arguments.custom_args).toEqual(['', '--dx11', '', '--bad\x00arg']);
+
+    const forSave = normalizeProfileForSave(profile, {}, false);
+    expect(forSave.launch.command_arguments).toEqual({
+      enabled_argument_ids: ['force_vulkan'],
+      custom_args: ['--dx11', '--bad\x00arg'],
+    });
+  });
+
+  it('round-trips populated command arguments through edit normalization', () => {
+    const profile = createDefaultProfile();
+    profile.launch.command_arguments = {
+      enabled_argument_ids: ['force_vulkan', 'skip_launcher'],
+      custom_args: ['-- %command%', '+set sv_cheats 1'],
+    };
+
+    const normalized = normalizeProfileForEdit(profile, {}, false);
+
+    expect(normalized.launch.command_arguments).toEqual({
+      enabled_argument_ids: ['force_vulkan', 'skip_launcher'],
+      custom_args: ['-- %command%', '+set sv_cheats 1'],
+    });
   });
 });

--- a/src/crosshook-native/src/hooks/profile/createEmptyProfile.ts
+++ b/src/crosshook-native/src/hooks/profile/createEmptyProfile.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_INJECTION_SECTION, type GameProfile } from '../../types';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '../../types/launch-command-arguments';
 
 export function createEmptyProfile(): GameProfile {
   return {
@@ -41,6 +42,7 @@ export function createEmptyProfile(): GameProfile {
       optimizations: {
         enabled_option_ids: [],
       },
+      command_arguments: { ...DEFAULT_LAUNCH_COMMAND_ARGUMENTS },
       presets: {},
       active_preset: '',
       custom_env_vars: {},

--- a/src/crosshook-native/src/hooks/profile/profileNormalize.ts
+++ b/src/crosshook-native/src/hooks/profile/profileNormalize.ts
@@ -1,4 +1,5 @@
 import type { GameProfile, SerializedGameProfile } from '../../types';
+import type { LaunchCommandArguments } from '../../types/launch-command-arguments';
 import type { LaunchOptimizations } from '../../types/launch-optimizations';
 import { normalizeInjectionSection, normalizeSerializedGameProfile } from '../../types/profile';
 import { resolveLaunchMethod } from '../../utils/launch';
@@ -7,6 +8,49 @@ import { normalizeLaunchOptimizationIds } from './launchOptimizationIds';
 import { deriveGameName, deriveLauncherDisplayName, stripAutomaticLauncherSuffix } from './profileDisplayNames';
 
 const UMU_RUNTIME_HINT_MAX_LENGTH = 128;
+
+function normalizeCommandArgumentIds(ids: readonly string[] | undefined): string[] {
+  const normalized: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (const argumentId of ids ?? []) {
+    const trimmedId = argumentId.trim();
+    if (!trimmedId || seenIds.has(trimmedId)) {
+      continue;
+    }
+    seenIds.add(trimmedId);
+    normalized.push(trimmedId);
+  }
+
+  return normalized;
+}
+
+function normalizeCommandArgumentCustomArgsForEdit(args: readonly string[] | undefined): string[] {
+  return (args ?? []).map((arg) => arg.trim());
+}
+
+function dropBlankCommandArgumentCustomArgs(args: readonly string[]): string[] {
+  return args.filter((arg) => arg.trim().length > 0);
+}
+
+function normalizeCommandArgumentsForEdit(
+  commandArguments: LaunchCommandArguments | undefined
+): LaunchCommandArguments {
+  return {
+    enabled_argument_ids: normalizeCommandArgumentIds(commandArguments?.enabled_argument_ids),
+    custom_args: normalizeCommandArgumentCustomArgsForEdit(commandArguments?.custom_args),
+  };
+}
+
+function normalizeCommandArgumentsForSave(
+  commandArguments: LaunchCommandArguments | undefined
+): LaunchCommandArguments {
+  const forEdit = normalizeCommandArgumentsForEdit(commandArguments);
+  return {
+    enabled_argument_ids: forEdit.enabled_argument_ids,
+    custom_args: dropBlankCommandArgumentCustomArgs(forEdit.custom_args),
+  };
+}
 
 function normalizeUmuRuntimeHint(value: string | undefined, options: { lowercase: boolean }): string {
   const trimmed = (value ?? '').trim();
@@ -92,6 +136,7 @@ export function normalizeProfileForEdit(
       optimizations: {
         enabled_option_ids: enabledOptionIds,
       },
+      command_arguments: normalizeCommandArgumentsForEdit(normalizedProfile.launch.command_arguments),
       custom_env_vars: { ...(normalizedProfile.launch.custom_env_vars ?? {}) },
     },
   };
@@ -119,6 +164,10 @@ export function normalizeProfileForSave(
         ...normalized.steam.launcher,
         display_name: deriveLauncherDisplayName(normalized),
       },
+    },
+    launch: {
+      ...normalized.launch,
+      command_arguments: normalizeCommandArgumentsForSave(normalized.launch.command_arguments),
     },
   };
 }

--- a/src/crosshook-native/src/hooks/profile/useProfileLaunchAutosave.ts
+++ b/src/crosshook-native/src/hooks/profile/useProfileLaunchAutosave.ts
@@ -1,9 +1,12 @@
-import { type Dispatch, type SetStateAction, useCallback, useRef, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useMemo, useRef, useState } from 'react';
 import { callCommand } from '@/lib/ipc';
 import type { BundledOptimizationPreset, GameProfile, LaunchAutoSaveStatus, SerializedGameProfile } from '../../types';
+import type { CommandArgumentEntry } from '../../types/launch-command-arguments';
 import type { LaunchOptimizationId } from '../../types/launch-optimizations';
+import { buildArgumentsById, buildConflictMatrix } from '../../utils/command-argument-catalog';
 import { resolveLaunchMethod } from '../../utils/launch';
 import type { OptimizationEntry } from '../../utils/optimization-catalog';
+import { useCommandArgumentCatalog } from '../useCommandArgumentCatalog';
 import { formatInvokeError } from './formatInvokeError';
 import { areLaunchOptimizationIdsEqual, normalizeLaunchOptimizationIds } from './launchOptimizationIds';
 import { buildLaunchOptimizationsStatus, type LaunchOptimizationsStatus } from './launchOptimizationStatus';
@@ -11,11 +14,44 @@ import { applyLaunchOptimizationToggle } from './launchOptimizationToggle';
 import { normalizeProfileForEdit } from './profileNormalize';
 import {
   useBundledOptimizationPresetsEffect,
+  useCommandArgumentsAutosaveEffect,
   useGamescopeAutosaveEffect,
   useLaunchOptimizationsAutosaveEffect,
   useMangoHudAutosaveEffect,
   useTrainerGamescopeAutosaveEffect,
 } from './useProfileLaunchAutosaveEffects';
+
+function normalizeCommandArgumentIds(
+  ids: readonly string[] | undefined,
+  argumentsById: Record<string, CommandArgumentEntry>,
+  catalogLoaded: boolean
+): string[] {
+  const normalized: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (const argumentId of ids ?? []) {
+    if (catalogLoaded && !(argumentId in argumentsById)) {
+      continue;
+    }
+
+    if (seenIds.has(argumentId)) {
+      continue;
+    }
+
+    seenIds.add(argumentId);
+    normalized.push(argumentId);
+  }
+
+  return normalized;
+}
+
+function getConflictingCommandArgumentIds(
+  argumentId: string,
+  currentIds: readonly string[],
+  conflictMatrix: Readonly<Record<string, readonly string[]>>
+): string[] {
+  return (conflictMatrix[argumentId] ?? []).filter((id) => currentIds.includes(id));
+}
 
 interface UseProfileLaunchAutosaveOptions {
   profile: GameProfile;
@@ -58,14 +94,22 @@ export function useProfileLaunchAutosave({
     tone: 'idle',
     label: 'Ready',
   });
+  const [commandArgumentsAutoSaveStatus, setCommandArgumentsAutoSaveStatus] = useState<LaunchAutoSaveStatus>({
+    tone: 'idle',
+    label: 'Ready',
+  });
   const launchOptimizationsAutosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const gamescopeAutosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const trainerGamescopeAutosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mangoHudAutosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const commandArgumentsAutosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSavedLaunchOptimizationIdsRef = useRef<LaunchOptimizationId[]>([]);
   const lastSavedGamescopeJsonRef = useRef<string>('null');
   const lastSavedTrainerGamescopeJsonRef = useRef<string>('null');
   const lastSavedMangoHudJsonRef = useRef<string>('null');
+  const lastSavedCommandArgumentsJsonRef = useRef<string>(
+    JSON.stringify({ enabled_argument_ids: [], custom_args: [] })
+  );
   const pendingLaunchPresetRef = useRef<string | null>(null);
   const profileRef = useRef(profile);
   profileRef.current = profile;
@@ -73,6 +117,16 @@ export function useProfileLaunchAutosave({
   selectedProfileRef.current = selectedProfile;
   const hasExistingSavedProfileRef = useRef(hasExistingSavedProfile);
   hasExistingSavedProfileRef.current = hasExistingSavedProfile;
+  const { catalog: commandArgumentCatalog } = useCommandArgumentCatalog();
+  const commandArgumentCatalogLoaded = commandArgumentCatalog !== null;
+  const argumentsById = useMemo(
+    () => (commandArgumentCatalog ? buildArgumentsById(commandArgumentCatalog.entries) : {}),
+    [commandArgumentCatalog]
+  );
+  const commandArgumentConflictMatrix = useMemo(
+    () => (commandArgumentCatalog ? buildConflictMatrix(commandArgumentCatalog.entries) : {}),
+    [commandArgumentCatalog]
+  );
   /** Serializes launch-section writes so concurrent autosaves cannot clobber each other. */
   const launchProfileWriteChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const enqueueLaunchProfileWrite = useCallback(<T>(fn: () => Promise<T>): Promise<T> => {
@@ -88,6 +142,7 @@ export function useProfileLaunchAutosave({
     lastSavedGamescopeJsonRef.current = JSON.stringify(nextProfile.launch.gamescope ?? null);
     lastSavedTrainerGamescopeJsonRef.current = JSON.stringify(nextProfile.launch.trainer_gamescope ?? null);
     lastSavedMangoHudJsonRef.current = JSON.stringify(nextProfile.launch.mangohud ?? null);
+    lastSavedCommandArgumentsJsonRef.current = JSON.stringify(nextProfile.launch.command_arguments);
   }, []);
   const clearAutosaveTimers = useCallback(() => {
     if (launchOptimizationsAutosaveTimerRef.current !== null) {
@@ -105,6 +160,10 @@ export function useProfileLaunchAutosave({
     if (mangoHudAutosaveTimerRef.current !== null) {
       clearTimeout(mangoHudAutosaveTimerRef.current);
       mangoHudAutosaveTimerRef.current = null;
+    }
+    if (commandArgumentsAutosaveTimerRef.current !== null) {
+      clearTimeout(commandArgumentsAutosaveTimerRef.current);
+      commandArgumentsAutosaveTimerRef.current = null;
     }
   }, []);
   /** Clears pending timer and persists launch.optimizations immediately. */
@@ -164,6 +223,60 @@ export function useProfileLaunchAutosave({
       setDirty((currentDirty: boolean) => currentDirty || !hasExistingSavedProfileRef.current);
     },
     [catalogLoaded, conflictMatrix, optionsById, setDirty, setProfile]
+  );
+  const toggleCommandArgument = useCallback(
+    (argumentId: string, nextEnabled: boolean) => {
+      const current = profileRef.current;
+      const currentIds = current.launch.command_arguments.enabled_argument_ids;
+      const conflictingIds = nextEnabled
+        ? getConflictingCommandArgumentIds(argumentId, currentIds, commandArgumentConflictMatrix)
+        : [];
+
+      if (conflictingIds.length > 0) {
+        const conflictLabels = conflictingIds.map(
+          (conflictingId) => argumentsById[conflictingId]?.label ?? conflictingId
+        );
+        setCommandArgumentsAutoSaveStatus({
+          tone: 'warning',
+          label: 'Conflicting argument blocked',
+          detail: `Disable ${conflictLabels.join(' or ')} before enabling ${argumentsById[argumentId]?.label ?? argumentId}.`,
+        });
+        return;
+      }
+
+      const nextIds = nextEnabled
+        ? normalizeCommandArgumentIds([...currentIds, argumentId], argumentsById, commandArgumentCatalogLoaded)
+        : currentIds.filter((currentArgumentId) => currentArgumentId !== argumentId);
+
+      setProfile({
+        ...current,
+        launch: {
+          ...current.launch,
+          command_arguments: {
+            ...current.launch.command_arguments,
+            enabled_argument_ids: nextIds,
+          },
+        },
+      });
+      setDirty((currentDirty: boolean) => currentDirty || !hasExistingSavedProfileRef.current);
+    },
+    [argumentsById, commandArgumentCatalogLoaded, commandArgumentConflictMatrix, setDirty, setProfile]
+  );
+  const updateCommandArgumentsCustomArgs = useCallback(
+    (customArgs: readonly string[]) => {
+      setProfile((current) => ({
+        ...current,
+        launch: {
+          ...current.launch,
+          command_arguments: {
+            ...current.launch.command_arguments,
+            custom_args: [...customArgs],
+          },
+        },
+      }));
+      setDirty((currentDirty: boolean) => currentDirty || !hasExistingSavedProfileRef.current);
+    },
+    [setDirty, setProfile]
   );
   const switchLaunchOptimizationPreset = useCallback(
     async (presetName: string): Promise<void> => {
@@ -477,14 +590,27 @@ export function useProfileLaunchAutosave({
     lastSavedMangoHudJsonRef,
     setMangoHudAutoSaveStatus,
   });
+  useCommandArgumentsAutosaveEffect({
+    enqueueLaunchProfileWrite,
+    hasExistingSavedProfile,
+    profile,
+    profileName,
+    setDirty,
+    commandArgumentsAutosaveTimerRef,
+    lastSavedCommandArgumentsJsonRef,
+    setCommandArgumentsAutoSaveStatus,
+  });
   return {
     launchOptimizationsStatus,
     gamescopeAutoSaveStatus,
     trainerGamescopeAutoSaveStatus,
     mangoHudAutoSaveStatus,
+    commandArgumentsAutoSaveStatus,
     bundledOptimizationPresets,
     optimizationPresetActionBusy,
     toggleLaunchOptimization,
+    toggleCommandArgument,
+    updateCommandArgumentsCustomArgs,
     switchLaunchOptimizationPreset,
     applyBundledOptimizationPreset,
     saveManualOptimizationPreset,

--- a/src/crosshook-native/src/hooks/profile/useProfileLaunchAutosaveEffects.ts
+++ b/src/crosshook-native/src/hooks/profile/useProfileLaunchAutosaveEffects.ts
@@ -1,12 +1,36 @@
 import { type Dispatch, type MutableRefObject, type SetStateAction, useEffect } from 'react';
 import { callCommand } from '@/lib/ipc';
 import type { BundledOptimizationPreset, GameProfile, LaunchAutoSaveStatus } from '../../types';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from '../../types/launch-command-arguments';
 import { DEFAULT_GAMESCOPE_CONFIG, DEFAULT_MANGOHUD_CONFIG } from '../../types/profile';
-import { resolveLaunchMethod } from '../../utils/launch';
+import { type ResolvedLaunchMethod, resolveLaunchMethod } from '../../utils/launch';
 import { launchOptimizationsAutosaveDelayMs } from './constants';
 import { formatInvokeError } from './formatInvokeError';
 import { areLaunchOptimizationIdsEqual } from './launchOptimizationIds';
 import { buildLaunchOptimizationsStatus, type LaunchOptimizationsStatus } from './launchOptimizationStatus';
+
+export function buildCommandArgumentsStatus(
+  method: ResolvedLaunchMethod,
+  hasExistingSavedProfile: boolean
+): LaunchAutoSaveStatus {
+  if (method !== 'proton_run' && method !== 'steam_applaunch') {
+    return {
+      tone: 'warning',
+      label: 'Unavailable for current method',
+      detail: 'Command arguments are only editable when the profile method is proton_run or steam_applaunch.',
+    };
+  }
+
+  if (!hasExistingSavedProfile) {
+    return {
+      tone: 'warning',
+      label: 'Save profile first',
+      detail: 'Command argument changes stay local until the profile has been saved once.',
+    };
+  }
+
+  return { tone: 'idle', label: 'Ready' };
+}
 
 interface LaunchOptimizationAutosaveEffectOptions {
   enqueueLaunchProfileWrite: <T>(fn: () => Promise<T>) => Promise<T>;
@@ -43,6 +67,12 @@ interface MangoHudEffectOptions extends LaunchConfigAutosaveEffectOptions {
   mangoHudAutosaveTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
   lastSavedMangoHudJsonRef: MutableRefObject<string>;
   setMangoHudAutoSaveStatus: Dispatch<SetStateAction<LaunchAutoSaveStatus>>;
+}
+
+interface CommandArgumentsEffectOptions extends LaunchConfigAutosaveEffectOptions {
+  commandArgumentsAutosaveTimerRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
+  lastSavedCommandArgumentsJsonRef: MutableRefObject<string>;
+  setCommandArgumentsAutoSaveStatus: Dispatch<SetStateAction<LaunchAutoSaveStatus>>;
 }
 
 export function useBundledOptimizationPresetsEffect(
@@ -376,5 +406,103 @@ export function useMangoHudAutosaveEffect({
     mangoHudAutosaveTimerRef,
     lastSavedMangoHudJsonRef,
     setMangoHudAutoSaveStatus,
+  ]);
+}
+
+export function useCommandArgumentsAutosaveEffect({
+  enqueueLaunchProfileWrite,
+  hasExistingSavedProfile,
+  profile,
+  profileName,
+  setDirty,
+  commandArgumentsAutosaveTimerRef,
+  lastSavedCommandArgumentsJsonRef,
+  setCommandArgumentsAutoSaveStatus,
+}: CommandArgumentsEffectOptions) {
+  useEffect(() => {
+    const method = resolveLaunchMethod(profile);
+    const commandArguments = profile.launch.command_arguments ?? DEFAULT_LAUNCH_COMMAND_ARGUMENTS;
+    const currentJson = JSON.stringify(commandArguments);
+
+    if (commandArgumentsAutosaveTimerRef.current !== null) {
+      clearTimeout(commandArgumentsAutosaveTimerRef.current);
+      commandArgumentsAutosaveTimerRef.current = null;
+    }
+
+    if (method !== 'proton_run' && method !== 'steam_applaunch') {
+      setCommandArgumentsAutoSaveStatus(buildCommandArgumentsStatus(method, hasExistingSavedProfile));
+      return;
+    }
+
+    if (!hasExistingSavedProfile) {
+      if (currentJson !== lastSavedCommandArgumentsJsonRef.current) {
+        setCommandArgumentsAutoSaveStatus({ tone: 'warning', label: 'Save profile first' });
+      } else {
+        setCommandArgumentsAutoSaveStatus(buildCommandArgumentsStatus(method, false));
+      }
+      return;
+    }
+
+    if (currentJson === lastSavedCommandArgumentsJsonRef.current) {
+      setCommandArgumentsAutoSaveStatus({ tone: 'idle', label: 'Ready' });
+      return;
+    }
+
+    setCommandArgumentsAutoSaveStatus({ tone: 'saving', label: 'Saving...' });
+    const trimmedName = profileName.trim();
+    const payload = {
+      enabled_argument_ids: [...commandArguments.enabled_argument_ids],
+      custom_args: [...commandArguments.custom_args],
+    };
+    let cancelled = false;
+
+    commandArgumentsAutosaveTimerRef.current = setTimeout(() => {
+      void (async () => {
+        try {
+          await enqueueLaunchProfileWrite(async () => {
+            await callCommand('profile_save_command_arguments', {
+              name: trimmedName,
+              command_arguments: payload,
+            });
+          });
+          if (cancelled) {
+            return;
+          }
+          lastSavedCommandArgumentsJsonRef.current = currentJson;
+          setCommandArgumentsAutoSaveStatus({
+            tone: 'success',
+            label: 'Saved automatically',
+            detail: 'Only launch.command_arguments was written to disk.',
+          });
+        } catch (err) {
+          if (cancelled) {
+            return;
+          }
+          setDirty(true);
+          setCommandArgumentsAutoSaveStatus({
+            tone: 'error',
+            label: 'Failed to save',
+            detail: formatInvokeError(err),
+          });
+        }
+      })();
+    }, launchOptimizationsAutosaveDelayMs);
+
+    return () => {
+      cancelled = true;
+      if (commandArgumentsAutosaveTimerRef.current !== null) {
+        clearTimeout(commandArgumentsAutosaveTimerRef.current);
+        commandArgumentsAutosaveTimerRef.current = null;
+      }
+    };
+  }, [
+    enqueueLaunchProfileWrite,
+    hasExistingSavedProfile,
+    profile,
+    profileName,
+    setDirty,
+    commandArgumentsAutosaveTimerRef,
+    lastSavedCommandArgumentsJsonRef,
+    setCommandArgumentsAutoSaveStatus,
   ]);
 }

--- a/src/crosshook-native/src/hooks/useCommandArgumentCatalog.ts
+++ b/src/crosshook-native/src/hooks/useCommandArgumentCatalog.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import type { CommandArgumentCatalogPayload } from '@/types/launch-command-arguments';
+import { fetchCommandArgumentCatalog } from '@/utils/command-argument-catalog';
+
+export interface UseCommandArgumentCatalogResult {
+  catalog: CommandArgumentCatalogPayload | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/** React hook that fetches and caches the command-argument catalog from the backend. */
+export function useCommandArgumentCatalog(): UseCommandArgumentCatalogResult {
+  const [catalog, setCatalog] = useState<CommandArgumentCatalogPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchCommandArgumentCatalog()
+      .then((c) => {
+        if (!cancelled) {
+          setCatalog(c);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(String(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { catalog, loading, error };
+}

--- a/src/crosshook-native/src/hooks/useProfile.ts
+++ b/src/crosshook-native/src/hooks/useProfile.ts
@@ -55,6 +55,7 @@ export interface UseProfileResult {
   gamescopeAutoSaveStatus: LaunchAutoSaveStatus;
   trainerGamescopeAutoSaveStatus: LaunchAutoSaveStatus;
   mangoHudAutoSaveStatus: LaunchAutoSaveStatus;
+  commandArgumentsAutoSaveStatus: LaunchAutoSaveStatus;
   /** True while any config-history IPC call is in flight. */
   historyLoading: boolean;
   /** Error message from the most recent config-history operation; null when none. */
@@ -80,6 +81,8 @@ export interface UseProfileResult {
   updateProfile: (updater: (current: GameProfile) => GameProfile) => void;
   updateLaunchSetting: (updater: (current: GameProfile) => GameProfile) => void;
   toggleLaunchOptimization: (optionId: LaunchOptimizationId, nextEnabled: boolean) => void;
+  toggleCommandArgument: (argumentId: string, nextEnabled: boolean) => void;
+  updateCommandArgumentsCustomArgs: (customArgs: readonly string[]) => void;
   /** Persists switching the active named optimization preset (requires presets in profile TOML). */
   switchLaunchOptimizationPreset: (presetName: string) => Promise<void>;
   /** GPU vendor presets from the app catalog (metadata DB); empty when metadata is off. */
@@ -243,6 +246,7 @@ export function useProfile(options: UseProfileOptions = {}): UseProfileResult {
     gamescopeAutoSaveStatus: launchAutosave.gamescopeAutoSaveStatus,
     trainerGamescopeAutoSaveStatus: launchAutosave.trainerGamescopeAutoSaveStatus,
     mangoHudAutoSaveStatus: launchAutosave.mangoHudAutoSaveStatus,
+    commandArgumentsAutoSaveStatus: launchAutosave.commandArgumentsAutoSaveStatus,
     historyLoading: history.historyLoading,
     historyError: history.historyError,
     setProfileName: crud.setProfileName,
@@ -251,6 +255,8 @@ export function useProfile(options: UseProfileOptions = {}): UseProfileResult {
     updateProfile: crud.updateProfile,
     updateLaunchSetting: crud.updateLaunchSetting,
     toggleLaunchOptimization: launchAutosave.toggleLaunchOptimization,
+    toggleCommandArgument: launchAutosave.toggleCommandArgument,
+    updateCommandArgumentsCustomArgs: launchAutosave.updateCommandArgumentsCustomArgs,
     switchLaunchOptimizationPreset: launchAutosave.switchLaunchOptimizationPreset,
     bundledOptimizationPresets: launchAutosave.bundledOptimizationPresets,
     applyBundledOptimizationPreset: launchAutosave.applyBundledOptimizationPreset,

--- a/src/crosshook-native/src/lib/mocks/handlers/launch.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/launch.ts
@@ -5,6 +5,7 @@ import type { LaunchHistoryEntry } from '../../../types/library';
 import { getActiveFixture } from '../../fixture';
 import { emitMockEvent } from '../eventBus';
 import { getStore } from '../store';
+import { mockCommandArgumentCatalogEntries } from './system';
 import type { Handler } from './types';
 
 // ---------------------------------------------------------------------------
@@ -50,6 +51,123 @@ function neverResolving<T>(): Promise<T> {
  */
 function forcedError(commandName: string): Error {
   return new Error(`[dev-mock] forced error for ${commandName}`);
+}
+
+function escapeSteamToken(value: string): string {
+  const needsQuotes =
+    value.length === 0 ||
+    [...value].some((ch) => {
+      if (/\s/.test(ch)) return true;
+      return (
+        ch === '$' ||
+        ch === ';' ||
+        ch === '"' ||
+        ch === "'" ||
+        ch === '\\' ||
+        ch === '`' ||
+        ch === '\n' ||
+        ch === '\r' ||
+        ch === '|' ||
+        ch === '&' ||
+        ch === '<' ||
+        ch === '>'
+      );
+    });
+
+  if (!needsQuotes) {
+    return value;
+  }
+
+  let out = '"';
+  for (const ch of value) {
+    switch (ch) {
+      case '\\':
+        out += '\\\\';
+        break;
+      case '"':
+        out += '\\"';
+        break;
+      case '$':
+        out += '\\$';
+        break;
+      case '`':
+        out += '\\`';
+        break;
+      case '\n':
+        out += '\\n';
+        break;
+      case '\r':
+        out += '\\r';
+        break;
+      default:
+        out += ch;
+    }
+  }
+  out += '"';
+  return out;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+function resolveMockCommandArgumentTokens(
+  enabledArgumentIds: readonly string[],
+  customArgs: readonly string[],
+  resolvedMethod: 'proton_run' | 'steam_applaunch'
+): string[] {
+  if (enabledArgumentIds.length === 0 && customArgs.length === 0) {
+    return [];
+  }
+
+  const selectedIds = new Set(enabledArgumentIds);
+  const tokens: string[] = [];
+
+  for (const entry of mockCommandArgumentCatalogEntries) {
+    if (!selectedIds.has(entry.id)) {
+      continue;
+    }
+    if (!entry.applicable_methods.includes(resolvedMethod)) {
+      continue;
+    }
+    tokens.push(...entry.tokens);
+  }
+
+  tokens.push(...customArgs);
+  return tokens;
+}
+
+function appendSteamCommandArguments(command: string, tokens: readonly string[]): string {
+  if (tokens.length === 0) {
+    return command;
+  }
+  let out = command;
+  for (const token of tokens) {
+    out += ` ${escapeSteamToken(token)}`;
+  }
+  return out;
+}
+
+function buildMockSteamLaunchOptionsPrefix(
+  enabledOptionIds: readonly string[],
+  customEnvVars: Readonly<Record<string, string>>
+): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(customEnvVars)) {
+    const trimmedKey = key.trim();
+    if (trimmedKey.length === 0) {
+      continue;
+    }
+    parts.push(`${trimmedKey}=${escapeSteamToken(value)}`);
+  }
+  if (enabledOptionIds.includes('esync')) parts.push('WINEESYNC=1');
+  if (enabledOptionIds.includes('fsync')) parts.push('WINEFSYNC=1');
+  if (enabledOptionIds.includes('proton_log')) parts.push('PROTON_LOG=1');
+  parts.push('%command%');
+  return parts.join(' ');
 }
 
 // ---------------------------------------------------------------------------
@@ -383,6 +501,30 @@ export function registerLaunch(map: Map<string, Handler>): void {
     const mockUmuRun = '/usr/bin/umu-run';
     const mockUsesUmu = method === 'proton_run';
 
+    const commandArgumentTokens = request.launch_trainer_only
+      ? []
+      : resolveMockCommandArgumentTokens(
+          request.command_arguments?.enabled_argument_ids ?? [],
+          request.command_arguments?.custom_args ?? [],
+          method === 'steam_applaunch' ? 'steam_applaunch' : 'proton_run'
+        );
+
+    const protonEffectiveCommand = mockUsesUmu
+      ? `gamescope mangohud -- ${mockUmuRun} ${mockGameExe}${commandArgumentTokens.length > 0 ? ` ${commandArgumentTokens.join(' ')}` : ''}`
+      : `${mockProtonExe} run ${mockGameExe}${commandArgumentTokens.length > 0 ? ` ${commandArgumentTokens.join(' ')}` : ''}`;
+
+    const steamLaunchOptionsBase =
+      method === 'steam_applaunch'
+        ? buildMockSteamLaunchOptionsPrefix(
+            request.optimizations?.enabled_option_ids ?? [],
+            request.custom_env_vars ?? {}
+          )
+        : null;
+    const steamLaunchOptions =
+      steamLaunchOptionsBase === null
+        ? null
+        : appendSteamCommandArguments(steamLaunchOptionsBase, commandArgumentTokens);
+
     // Build populated preview (shared base for both populated and warning paths)
     const preview: LaunchPreview = {
       resolved_method: method,
@@ -390,11 +532,10 @@ export function registerLaunch(map: Map<string, Handler>): void {
       environment: makePreviewEnvVars(),
       cleared_variables: ['LD_PRELOAD'],
       wrappers: ['gamescope', 'mangohud'],
-      effective_command: mockUsesUmu
-        ? `gamescope mangohud -- ${mockUmuRun} ${mockGameExe}`
-        : `${mockProtonExe} run ${mockGameExe}`,
+      effective_command:
+        method === 'steam_applaunch' ? steamLaunchOptions : method === 'native' ? mockGameExe : protonEffectiveCommand,
       directives_error: null,
-      steam_launch_options: method === 'steam_applaunch' ? 'PROTON_LOG=1 %command%' : null,
+      steam_launch_options: steamLaunchOptions,
       proton_setup:
         method !== 'native'
           ? {
@@ -541,17 +682,20 @@ export function registerLaunch(map: Map<string, Handler>): void {
     if (fixture === 'error') throw forcedError('build_steam_launch_options_command');
     if (fixture === 'loading') return neverResolving<string>();
     if (fixture === 'empty') return '%command%';
-    const { enabled_option_ids } = args as {
-      enabled_option_ids: string[];
-      custom_env_vars: Record<string, string>;
-      gamescope: unknown;
-    };
-    const parts: string[] = [];
-    if (enabled_option_ids.includes('esync')) parts.push('WINEESYNC=1');
-    if (enabled_option_ids.includes('fsync')) parts.push('WINEFSYNC=1');
-    if (enabled_option_ids.includes('proton_log')) parts.push('PROTON_LOG=1');
-    parts.push('%command%');
-    return parts.join(' ');
+
+    const raw = args as Record<string, unknown>;
+    const enabled_option_ids = readStringArray(raw.enabled_option_ids ?? raw.enabledOptionIds);
+    const custom_env_vars = (raw.custom_env_vars ?? raw.customEnvVars ?? {}) as Record<string, string>;
+    const enabled_argument_ids = readStringArray(raw.enabled_argument_ids ?? raw.enabledArgumentIds);
+    const custom_command_args = readStringArray(raw.custom_command_args ?? raw.customCommandArgs);
+
+    const base = buildMockSteamLaunchOptionsPrefix(enabled_option_ids, custom_env_vars);
+    const argumentTokens = resolveMockCommandArgumentTokens(
+      enabled_argument_ids,
+      custom_command_args,
+      'steam_applaunch'
+    );
+    return appendSteamCommandArguments(base, argumentTokens);
   });
 
   // -------------------------------------------------------------------------

--- a/src/crosshook-native/src/lib/mocks/handlers/profile-mutations.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/profile-mutations.ts
@@ -4,6 +4,7 @@
 // `.github/workflows/release.yml` "Verify no mock code in production bundle"
 // sentinel.
 
+import type { LaunchCommandArguments } from '../../../types/launch-command-arguments';
 import type { DuplicateProfileResult, GameProfile, GamescopeConfig, MangoHudConfig } from '../../../types/profile';
 import { createDefaultProfile } from '../../../types/profile';
 import { emitMockEvent } from '../eventBus';
@@ -26,6 +27,36 @@ export function registerProfileMutations(map: Map<string, Handler>): void {
       store.profiles.set(trimmed, structuredClone(data));
       appendRevision(trimmed, 'manual_save');
       emitMockEvent('profiles-changed', { name: trimmed, action: 'save' });
+      return null;
+    })
+  );
+
+  map.set(
+    'profile_save_command_arguments',
+    withProfileFixtureGate('profile_save_command_arguments', async (args) => {
+      const { name, command_arguments } = args as {
+        name: string;
+        command_arguments: LaunchCommandArguments;
+      };
+      const trimmed = name.trim();
+      const store = getStore();
+      const existing = store.profiles.get(trimmed);
+      if (!existing) {
+        throw new Error(`[dev-mock] profile_save_command_arguments: profile not found: ${trimmed}`);
+      }
+      const updated: GameProfile = {
+        ...existing,
+        launch: {
+          ...existing.launch,
+          command_arguments: {
+            enabled_argument_ids: [...command_arguments.enabled_argument_ids],
+            custom_args: [...command_arguments.custom_args],
+          },
+        },
+      };
+      store.profiles.set(trimmed, updated);
+      appendRevision(trimmed, 'launch_optimization_save');
+      emitMockEvent('profiles-changed', { name: trimmed, action: 'save-command-arguments' });
       return null;
     })
   );

--- a/src/crosshook-native/src/lib/mocks/handlers/profile-mutations.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/profile-mutations.ts
@@ -55,7 +55,7 @@ export function registerProfileMutations(map: Map<string, Handler>): void {
         },
       };
       store.profiles.set(trimmed, updated);
-      appendRevision(trimmed, 'launch_optimization_save');
+      appendRevision(trimmed, 'launch_command_arguments_save');
       emitMockEvent('profiles-changed', { name: trimmed, action: 'save-command-arguments' });
       return null;
     })

--- a/src/crosshook-native/src/lib/mocks/handlers/system.ts
+++ b/src/crosshook-native/src/lib/mocks/handlers/system.ts
@@ -6,6 +6,7 @@ import type {
   TrainerSearchResponse,
   VersionMatchResult,
 } from '../../../types/discovery';
+import type { CommandArgumentCatalogPayload, CommandArgumentEntry } from '../../../types/launch-command-arguments';
 import type { HashVerifyResult, OfflineReadinessReport, TrainerTypeEntry } from '../../../types/offline';
 import type { BinaryDetectionResult, PrefixDependencyStatus } from '../../../types/prefix-deps';
 import type {
@@ -16,6 +17,8 @@ import type {
 } from '../../../types/prefix-storage';
 import type { RunExecutableResult } from '../../../types/run-executable';
 import type { OptimizationCatalogPayload, OptimizationEntry } from '../../../utils/optimization-catalog';
+import { getActiveFixture } from '../../fixture';
+import { forcedError, neverResolving } from './profile-utils';
 import type { Handler } from './types';
 
 // --- Module-scope state ---
@@ -174,6 +177,84 @@ const MOCK_CATALOG: OptimizationCatalogPayload = {
   catalog_version: 1,
   entries: MOCK_CATALOG_ENTRIES,
 };
+
+// --- command argument catalog (mirrors default_command_argument_catalog.toml) ---
+
+const MOCK_COMMAND_ARGUMENT_ENTRIES: CommandArgumentEntry[] = [
+  {
+    id: 'force_vulkan',
+    tokens: ['-force_vulkan'],
+    label: 'Force Vulkan renderer',
+    description: 'Pass a Vulkan-forcing switch when the game supports it.',
+    help_text:
+      'Some Unity and native builds accept -force_vulkan. Many titles ignore it or crash — verify per game before relying on it.',
+    category: 'graphics',
+    advanced: false,
+    community: false,
+    applicable_methods: ['proton_run', 'steam_applaunch'],
+    conflicts_with: ['force_dx11', 'force_dx12', 'force_opengl'],
+  },
+  {
+    id: 'force_dx11',
+    tokens: ['-dx11'],
+    label: 'Force DirectX 11',
+    description: 'Request a DirectX 11 code path when the game reads launch switches.',
+    help_text:
+      'Common on Source and some Unreal titles, but not universal. Wrong switches can prevent startup or leave you on an unintended renderer.',
+    category: 'graphics',
+    advanced: false,
+    community: false,
+    applicable_methods: ['proton_run', 'steam_applaunch'],
+    conflicts_with: ['force_vulkan', 'force_dx12', 'force_opengl'],
+  },
+  {
+    id: 'force_dx12',
+    tokens: ['-dx12'],
+    label: 'Force DirectX 12',
+    description: 'Request a DirectX 12 code path when the game reads launch switches.',
+    help_text:
+      'Only helps when the game actually exposes a DX12 switch. On Proton/Wine paths DX12 support varies by title and driver stack.',
+    category: 'graphics',
+    advanced: false,
+    community: false,
+    applicable_methods: ['proton_run', 'steam_applaunch'],
+    conflicts_with: ['force_vulkan', 'force_dx11', 'force_opengl'],
+  },
+  {
+    id: 'skip_launcher',
+    tokens: ['-skip_launcher'],
+    label: 'Skip in-game launcher',
+    description: 'Skip a publisher launcher when the game honors the switch.',
+    help_text:
+      'Works on some Unity and older PC builds. Useless or harmful on titles without a separate launcher step.',
+    category: 'compatibility',
+    advanced: false,
+    community: false,
+    applicable_methods: ['proton_run', 'steam_applaunch'],
+    conflicts_with: [],
+  },
+  {
+    id: 'force_opengl',
+    tokens: ['-force_opengl'],
+    label: 'Force OpenGL renderer',
+    description: 'Pass an OpenGL-forcing switch when supported.',
+    help_text:
+      'Occasionally stabilizes older Unity builds on Linux/Proton. Most modern Windows-first titles ignore or mishandle it.',
+    category: 'graphics',
+    advanced: true,
+    community: false,
+    applicable_methods: ['proton_run', 'steam_applaunch'],
+    conflicts_with: ['force_vulkan', 'force_dx11', 'force_dx12'],
+  },
+];
+
+const MOCK_COMMAND_ARGUMENT_CATALOG: CommandArgumentCatalogPayload = {
+  catalog_version: 1,
+  entries: MOCK_COMMAND_ARGUMENT_ENTRIES,
+};
+
+/** Shared mock catalog entries for launch preview / Steam options handlers. */
+export const mockCommandArgumentCatalogEntries: readonly CommandArgumentEntry[] = MOCK_COMMAND_ARGUMENT_ENTRIES;
 
 // --- offline ---
 
@@ -345,6 +426,16 @@ export function registerSystem(map: Map<string, Handler>): void {
 
   map.set('get_optimization_catalog', async (): Promise<OptimizationCatalogPayload> => {
     return structuredClone(MOCK_CATALOG);
+  });
+
+  map.set('get_command_argument_catalog', async (): Promise<CommandArgumentCatalogPayload> => {
+    const fixture = getActiveFixture();
+    if (fixture === 'error') throw forcedError('get_command_argument_catalog');
+    if (fixture === 'loading') return neverResolving<CommandArgumentCatalogPayload>();
+    if (fixture === 'empty') {
+      return { catalog_version: MOCK_COMMAND_ARGUMENT_CATALOG.catalog_version, entries: [] };
+    }
+    return structuredClone(MOCK_COMMAND_ARGUMENT_CATALOG);
   });
 
   map.set('get_mangohud_presets', async () => {

--- a/src/crosshook-native/src/styles/launch-pipeline.css
+++ b/src/crosshook-native/src/styles/launch-pipeline.css
@@ -343,3 +343,156 @@
     justify-content: flex-start;
   }
 }
+
+/* --- Launch optimizations tab: command arguments panel (Task 5.2) --- */
+
+.crosshook-optimizations-tab-stack {
+  display: grid;
+  gap: 18px;
+}
+
+.crosshook-command-arguments {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow: visible;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(circle at top right, rgba(107, 163, 217, 0.08), transparent 28%),
+    linear-gradient(180deg, rgba(17, 22, 40, 0.92), rgba(11, 16, 31, 0.92));
+}
+
+.crosshook-command-arguments__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.crosshook-command-arguments__heading {
+  display: grid;
+  gap: 6px;
+  min-width: min(100%, 44ch);
+}
+
+.crosshook-command-arguments__title {
+  margin: 0;
+  color: var(--crosshook-color-text);
+  font-size: clamp(1.25rem, 1.6vw, 1.65rem);
+  line-height: 1.1;
+}
+
+.crosshook-command-arguments__intro {
+  max-width: 62ch;
+}
+
+.crosshook-command-arguments__summary-row {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.crosshook-command-arguments__method-warning {
+  margin: 0;
+}
+
+.crosshook-command-arguments__sections {
+  min-height: 0;
+}
+
+.crosshook-command-arguments__token-pill {
+  min-height: 24px;
+  padding: 0 10px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--crosshook-color-text-muted);
+  font-family: var(--crosshook-font-mono, ui-monospace, monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.01em;
+}
+
+.crosshook-command-arguments__custom {
+  display: grid;
+  gap: 12px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.crosshook-command-arguments__custom-header {
+  display: grid;
+  gap: 6px;
+}
+
+.crosshook-command-arguments__custom-title {
+  margin: 0;
+  color: var(--crosshook-color-text);
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.crosshook-command-arguments__custom-rows {
+  display: grid;
+  gap: var(--crosshook-custom-env-rows-gap, 12px);
+}
+
+.crosshook-command-arguments__custom-row {
+  display: grid;
+  gap: var(--crosshook-custom-env-row-gap, 8px);
+}
+
+.crosshook-command-arguments__custom-row-main {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--crosshook-custom-env-fields-gap, 10px);
+  align-items: end;
+}
+
+.crosshook-command-arguments__custom-row-index {
+  min-width: 1.75rem;
+  min-height: var(--crosshook-touch-target-min, 40px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--crosshook-color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.crosshook-command-arguments__custom-field {
+  min-width: 0;
+}
+
+.crosshook-command-arguments__custom-row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.crosshook-command-arguments__custom-add {
+  justify-self: start;
+  margin-top: var(--crosshook-custom-env-add-margin-top, 12px);
+}
+
+@media (max-width: 768px) {
+  .crosshook-command-arguments__custom-row-main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .crosshook-command-arguments__custom-row-index {
+    min-height: auto;
+    justify-content: flex-start;
+  }
+
+  .crosshook-command-arguments__custom-row-actions {
+    justify-content: flex-start;
+  }
+}

--- a/src/crosshook-native/src/test/fixtures.ts
+++ b/src/crosshook-native/src/test/fixtures.ts
@@ -1,5 +1,10 @@
 import type { ProfileHealthReport } from '@/types/health';
 import type { LaunchPreview, LaunchRequest } from '@/types/launch';
+import {
+  type CommandArgumentCatalogPayload,
+  type CommandArgumentEntry,
+  DEFAULT_LAUNCH_COMMAND_ARGUMENTS,
+} from '@/types/launch-command-arguments';
 import type { LibraryCardData } from '@/types/library';
 import type { Capability, HostToolCheckResult, HostToolInstallCommand, ReadinessCheckResult } from '@/types/onboarding';
 import { createDefaultProfile, type GameProfile, normalizeInjectionSection } from '@/types/profile';
@@ -94,6 +99,58 @@ export function makeProfileHealthReport(overrides: Partial<ProfileHealthReport> 
 }
 
 /**
+ * Factory for a single command-argument catalog entry (aligned with default_command_argument_catalog.toml).
+ */
+export function makeCommandArgumentEntry(overrides: Partial<CommandArgumentEntry> = {}): CommandArgumentEntry {
+  return {
+    id: 'force_vulkan',
+    tokens: ['-force_vulkan'],
+    label: 'Force Vulkan renderer',
+    description: 'Pass a Vulkan-forcing switch when the game supports it.',
+    help_text:
+      'Some Unity and native builds accept -force_vulkan. Many titles ignore it or crash — verify per game before relying on it.',
+    category: 'graphics',
+    advanced: false,
+    community: false,
+    applicable_methods: ['proton_run', 'steam_applaunch'],
+    conflicts_with: ['force_dx11', 'force_dx12'],
+    ...overrides,
+  };
+}
+
+/** Factory for command-argument catalog payloads used in UI and mock parity tests. */
+export function makeCommandArgumentCatalogPayload(
+  overrides: Partial<CommandArgumentCatalogPayload> = {}
+): CommandArgumentCatalogPayload {
+  return {
+    catalog_version: 1,
+    entries: [
+      makeCommandArgumentEntry(),
+      makeCommandArgumentEntry({
+        id: 'force_dx11',
+        tokens: ['-dx11'],
+        label: 'Force DirectX 11',
+        description: 'Request a DirectX 11 code path when the game reads launch switches.',
+        help_text:
+          'Common on Source and some Unreal titles, but not universal. Wrong switches can prevent startup or leave you on an unintended renderer.',
+        conflicts_with: ['force_vulkan', 'force_dx12'],
+      }),
+      makeCommandArgumentEntry({
+        id: 'skip_launcher',
+        tokens: ['-skip_launcher'],
+        label: 'Skip in-game launcher',
+        description: 'Skip a publisher launcher when the game honors the switch.',
+        help_text:
+          'Works on some Unity and older PC builds. Useless or harmful on titles without a separate launcher step.',
+        category: 'compatibility',
+        conflicts_with: [],
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+/**
  * Factory for `LaunchRequest` used in launch-tab and gate tests.
  * Commonly overridden fields: `method`, `game_path`, `optimizations`.
  */
@@ -117,6 +174,7 @@ export function makeLaunchRequest(overrides: Partial<LaunchRequest> = {}): Launc
       steam_app_id: '9999001',
     },
     optimizations: { enabled_option_ids: [] },
+    command_arguments: { ...DEFAULT_LAUNCH_COMMAND_ARGUMENTS },
     launch_trainer_only: false,
     launch_game_only: false,
     profile_name: 'Synthetic Quest',
@@ -237,6 +295,17 @@ export function makeProfileDraft(overrides: Partial<GameProfile> = {}): GameProf
     launch: {
       ...base.launch,
       ...(overrides.launch ?? {}),
+      command_arguments: {
+        ...base.launch.command_arguments,
+        ...(overrides.launch?.command_arguments ?? {}),
+        enabled_argument_ids: [
+          ...(overrides.launch?.command_arguments?.enabled_argument_ids ??
+            base.launch.command_arguments.enabled_argument_ids),
+        ],
+        custom_args: [
+          ...(overrides.launch?.command_arguments?.custom_args ?? base.launch.command_arguments.custom_args),
+        ],
+      },
     },
   };
 

--- a/src/crosshook-native/src/types/launch-command-arguments.ts
+++ b/src/crosshook-native/src/types/launch-command-arguments.ts
@@ -1,0 +1,34 @@
+/** Profile-scoped curated command-argument IDs and custom argv tokens. */
+export interface LaunchCommandArguments {
+  enabled_argument_ids: string[];
+  custom_args: string[];
+}
+
+/** A single command-argument catalog entry from the Rust backend. */
+export interface CommandArgumentEntry {
+  id: string;
+  tokens: string[];
+  label: string;
+  description: string;
+  help_text: string;
+  category: string;
+  advanced: boolean;
+  community: boolean;
+  applicable_methods: string[];
+  conflicts_with: string[];
+}
+
+/** Full command-argument catalog payload returned by the Tauri IPC command. */
+export interface CommandArgumentCatalogPayload {
+  catalog_version: number;
+  entries: CommandArgumentEntry[];
+}
+
+export const DEFAULT_LAUNCH_COMMAND_ARGUMENTS: LaunchCommandArguments = {
+  enabled_argument_ids: [],
+  custom_args: [],
+};
+
+export function isLaunchCommandArgumentsEmpty(args: LaunchCommandArguments): boolean {
+  return args.enabled_argument_ids.length === 0 && args.custom_args.length === 0;
+}

--- a/src/crosshook-native/src/types/launch.ts
+++ b/src/crosshook-native/src/types/launch.ts
@@ -1,5 +1,6 @@
 import type { ResolvedLaunchMethod } from '../utils/launch';
 import type { DiagnosticReport } from './diagnostics';
+import type { LaunchCommandArguments } from './launch-command-arguments';
 import type { LaunchOptimizations } from './launch-optimizations';
 import type { GamescopeConfig, LaunchHook, LaunchMethod, MangoHudConfig, TrainerLoadingMode } from './profile';
 import type { UmuPreference } from './settings';
@@ -48,6 +49,7 @@ export interface LaunchRequest {
     umu_codename?: string;
   };
   optimizations: LaunchOptimizations;
+  command_arguments: LaunchCommandArguments;
   launch_trainer_only: boolean;
   launch_game_only: boolean;
   /**

--- a/src/crosshook-native/src/types/profile-history.ts
+++ b/src/crosshook-native/src/types/profile-history.ts
@@ -6,6 +6,7 @@ export type ConfigRevisionSource =
   | 'rollback_apply'
   | 'import'
   | 'launch_optimization_save'
+  | 'launch_command_arguments_save'
   | 'preset_apply'
   | 'migration';
 

--- a/src/crosshook-native/src/types/profile.ts
+++ b/src/crosshook-native/src/types/profile.ts
@@ -1,4 +1,6 @@
 import type { LaunchHook } from './generated/launch_hooks';
+import type { LaunchCommandArguments } from './launch-command-arguments';
+import { DEFAULT_LAUNCH_COMMAND_ARGUMENTS } from './launch-command-arguments';
 import type { LaunchOptimizations } from './launch-optimizations';
 import type { UmuPreference } from './settings';
 
@@ -173,6 +175,8 @@ export interface GameProfile {
   launch: {
     method: LaunchMethod;
     optimizations: LaunchOptimizations;
+    /** Curated command-argument IDs and custom argv tokens for supported launch methods. */
+    command_arguments: LaunchCommandArguments;
     /** Named optimization bundles (`[launch.presets.<name>]` in profile TOML). */
     presets?: Record<string, LaunchOptimizations>;
     /** When set and present in `presets`, optimizations are kept in sync with that entry. */
@@ -263,6 +267,7 @@ const DEFAULT_LAUNCH_SECTION: GameProfile['launch'] = {
   optimizations: {
     enabled_option_ids: [],
   },
+  command_arguments: { ...DEFAULT_LAUNCH_COMMAND_ARGUMENTS },
   presets: {},
   active_preset: '',
   custom_env_vars: {},
@@ -350,6 +355,10 @@ export function normalizeSerializedGameProfile(profile: SerializedGameProfile): 
       optimizations: {
         enabled_option_ids: [...(profile.launch.optimizations?.enabled_option_ids ?? [])],
       },
+      command_arguments: {
+        enabled_argument_ids: [...(profile.launch.command_arguments?.enabled_argument_ids ?? [])],
+        custom_args: [...(profile.launch.command_arguments?.custom_args ?? [])],
+      },
       presets: { ...(profile.launch.presets ?? {}) },
       custom_env_vars: { ...(profile.launch.custom_env_vars ?? {}) },
     },
@@ -397,6 +406,7 @@ export function createDefaultProfile(): GameProfile {
     launch: {
       method: 'proton_run',
       optimizations: { enabled_option_ids: [] },
+      command_arguments: { enabled_argument_ids: [], custom_args: [] },
       custom_env_vars: {},
     },
   });

--- a/src/crosshook-native/src/utils/command-argument-catalog.ts
+++ b/src/crosshook-native/src/utils/command-argument-catalog.ts
@@ -1,0 +1,59 @@
+import { callCommand } from '@/lib/ipc';
+import type { CommandArgumentCatalogPayload, CommandArgumentEntry } from '@/types/launch-command-arguments';
+
+let _cached: CommandArgumentCatalogPayload | null = null;
+
+/** Fetches the command-argument catalog from the Rust backend.
+ *  Caches the result in memory — subsequent calls return instantly. */
+export async function fetchCommandArgumentCatalog(): Promise<CommandArgumentCatalogPayload> {
+  if (_cached) return _cached;
+  _cached = await callCommand<CommandArgumentCatalogPayload>('get_command_argument_catalog');
+  return _cached;
+}
+
+/** Returns the cached catalog, or null if not yet fetched. */
+export function getCachedCommandArgumentCatalog(): CommandArgumentCatalogPayload | null {
+  return _cached;
+}
+
+/** Build a lookup map from entry id to entry. */
+export function buildArgumentsById(entries: readonly CommandArgumentEntry[]): Record<string, CommandArgumentEntry> {
+  const map: Record<string, CommandArgumentEntry> = {};
+  for (const entry of entries) {
+    map[entry.id] = entry;
+  }
+  return map;
+}
+
+/** Build a conflict matrix: for each entry id, the list of ids it conflicts with.
+ *
+ * Declared `conflicts_with` edges are normalized to be bidirectional so the UI
+ * and toggle logic stay consistent when the catalog lists a conflict on only one side.
+ */
+export function buildConflictMatrix(entries: readonly CommandArgumentEntry[]): Record<string, readonly string[]> {
+  const knownIds = new Set(entries.map((e) => e.id));
+  const mutable: Record<string, Set<string>> = {};
+  for (const id of knownIds) {
+    mutable[id] = new Set();
+  }
+
+  for (const entry of entries) {
+    const from = entry.id;
+    for (const to of entry.conflicts_with ?? []) {
+      if (to === from) {
+        continue;
+      }
+      mutable[from]?.add(to);
+      if (knownIds.has(to)) {
+        mutable[to]?.add(from);
+      }
+    }
+  }
+
+  const matrix: Record<string, readonly string[]> = {};
+  for (const id of knownIds) {
+    const list = Array.from(mutable[id] ?? []).sort();
+    matrix[id] = Object.freeze(list);
+  }
+  return matrix;
+}

--- a/src/crosshook-native/src/utils/launch.ts
+++ b/src/crosshook-native/src/utils/launch.ts
@@ -47,6 +47,10 @@ export function buildProfileLaunchRequest(
     optimizations: {
       enabled_option_ids: [...profile.launch.optimizations.enabled_option_ids],
     },
+    command_arguments: {
+      enabled_argument_ids: [...(profile.launch.command_arguments?.enabled_argument_ids ?? [])],
+      custom_args: [...(profile.launch.command_arguments?.custom_args ?? [])],
+    },
     launch_trainer_only: false,
     launch_game_only: false,
     profile_name: profileName || undefined,


### PR DESCRIPTION
## Summary

Adds profile-scoped **command arguments** — curated launch flags (e.g. `-dx11`, `-force_vulkan`) plus custom argv tokens — with a dedicated Launch sub-tab, bundled catalog, resolver, preview/execution integration, and Tauri persistence.

Command arguments are stored in profile TOML under `launch.command_arguments`, resolved in `crosshook-core`, and appended after `%command%` (Steam) or the game executable (Proton/umu). Trainers do not inherit game command arguments.

## Changes

- **Core**: `command_arguments` module (catalog, resolver, validation), launch preview/script-runner wiring, profile TOML save/load
- **IPC**: `get_command_argument_catalog`, profile command-argument mutations
- **UI**: `CommandArgumentsPanel`, Launch sub-tab, autosave, browser-dev mocks
- **Catalog**: `default_command_argument_catalog.toml` with conflict matrix (including `force_opengl` ↔ force_vulkan/dx11/dx12)
- **Docs**: quickstart and steam-proton-trainer launch feature doc updates

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation
- [ ] Build / CI
- [ ] Compatibility (new game/trainer/platform support)

## Testing

### Environment

- **Platform**: Linux (CachyOS)
- **Proton Version** (if applicable): n/a (unit/integration tests only)
- **Game / Trainer** (if applicable): n/a

### Checklist

- [ ] `./scripts/lint.sh` passes (or run `./scripts/format.sh` / `./scripts/lint.sh --fix`; same-repo PRs may get a formatting bot commit from `lint-autofix.yml`)
- [ ] `./scripts/build-release-binary.sh` builds without errors
- [x] `cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core` passes
- [ ] `npm run typecheck` passes from `src/crosshook-native/` (if touching frontend TypeScript)
- [ ] `./scripts/build-flatpak.sh --rebuild --strict` passes (if touching build/packaging)
- [ ] Tested on target platform (Linux desktop or Steam Deck)
- [x] **If touching crates/crosshook-core/src/launch/**: Verified game and trainer launch works (unit tests for preview + proton_game + trainer isolation)
- [ ] **If touching crates/crosshook-core/src/steam/**: Verified Steam auto-populate and Proton discovery
- [x] **If touching crates/crosshook-core/src/profile/**: Verified profile save/load/import (toml_store command_arguments tests)
- [x] **If touching src/components/ or src/hooks/**: Verified UI renders correctly (Vitest: CommandArgumentsPanel, LaunchSubTabs, profileNormalize)
- [ ] **If touching runtime-helpers/**: Verified shell scripts work under Proton

**Local verification run:**

```bash
cargo test --manifest-path src/crosshook-native/Cargo.toml -p crosshook-core command_arguments
cd src/crosshook-native && npm test -- --run CommandArgumentsPanel LaunchSubTabs profileNormalize
```

## Reviewer Notes

- Command arguments moved out of Optimizations into their own Launch sub-tab; Steam launch options panel no longer hosts this UI.
- Custom tokens are validated at save time (unknown curated IDs, duplicates, method gating, conflicts).
- Browser dev mode mocks updated for catalog + profile mutations.

## Related Issues

No linked issue — feature developed from internal plan (`docs/plans/command-arguments/`).

## Breaking Changes

- No breaking changes